### PR TITLE
[AMORO-1619] 0.4.x support copy large files when executing full optimizing of Unkeyed Mixed Hive Table

### DIFF
--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/OptimizeTaskProperties.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/OptimizeTaskProperties.java
@@ -4,7 +4,7 @@ public class OptimizeTaskProperties {
   // optimize task properties
   public static final String ALL_FILE_COUNT = "all-file-cnt";
   public static final String CUSTOM_HIVE_SUB_DIRECTORY = "custom-hive-sub-directory";
-  public static final String ENABLE_COPY_FILES= "copy-files-enabled";
+  public static final String COPY_FILES_TO_NEW_LOCATION = "copy-files-to-new-location";
   public static final String MAX_EXECUTE_TIME = "max-execute-time";
   public static final String MOVE_FILES_TO_HIVE_LOCATION = "move-files-to-hive-location";
 }

--- a/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/OptimizeTaskProperties.java
+++ b/ams/ams-api/src/main/java/com/netease/arctic/ams/api/properties/OptimizeTaskProperties.java
@@ -4,6 +4,7 @@ public class OptimizeTaskProperties {
   // optimize task properties
   public static final String ALL_FILE_COUNT = "all-file-cnt";
   public static final String CUSTOM_HIVE_SUB_DIRECTORY = "custom-hive-sub-directory";
+  public static final String ENABLE_COPY_FILES= "copy-files-enabled";
   public static final String MAX_EXECUTE_TIME = "max-execute-time";
   public static final String MOVE_FILES_TO_HIVE_LOCATION = "move-files-to-hive-location";
 }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractArcticOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractArcticOptimizePlan.java
@@ -184,7 +184,7 @@ public abstract class AbstractArcticOptimizePlan extends AbstractOptimizePlan {
       properties.put(OptimizeTaskProperties.CUSTOM_HIVE_SUB_DIRECTORY, customHiveSubdirectory);
       if (insertFiles.isEmpty() && deleteFiles.isEmpty() && posDeleteFiles.isEmpty() &&
           allLargeFiles(baseFiles)) {
-        properties.put(OptimizeTaskProperties.ENABLE_COPY_FILES, true + "");
+        properties.put(OptimizeTaskProperties.COPY_FILES_TO_NEW_LOCATION, true + "");
       }
     }
     if (taskConfig.isMoveFilesToHiveLocation()) {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/FullOptimizePlan.java
@@ -203,8 +203,7 @@ public class FullOptimizePlan extends AbstractArcticOptimizePlan {
           false, constructCustomHiveSubdirectory(baseFiles)
       );
 
-      List<List<DataFile>> packed = new BinPacking.ListPacker<DataFile>(taskSize, Integer.MAX_VALUE, true)
-          .pack(baseFiles, DataFile::fileSizeInBytes);
+      List<List<DataFile>> packed = binPackFiles(taskSize, baseFiles, !posDeleteFiles.isEmpty());
       for (List<DataFile> files : packed) {
         if (CollectionUtils.isNotEmpty(files)) {
           collector.add(buildOptimizeTask(null,
@@ -214,6 +213,11 @@ public class FullOptimizePlan extends AbstractArcticOptimizePlan {
     }
 
     return collector;
+  }
+
+  protected List<List<DataFile>> binPackFiles(long taskSize, List<DataFile> baseFiles, boolean deleteExist) {
+    return new BinPacking.ListPacker<DataFile>(taskSize, Integer.MAX_VALUE, true)
+        .pack(baseFiles, DataFile::fileSizeInBytes);
   }
 
   private long getOptimizingTargetSize() {

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/OptimizingIntegrationTest.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/OptimizingIntegrationTest.java
@@ -13,6 +13,7 @@ import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableBuilder;
 import com.netease.arctic.table.TableIdentifier;
 import com.netease.arctic.table.TableProperties;
+import com.netease.arctic.table.UnkeyedTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -59,6 +60,7 @@ public class OptimizingIntegrationTest {
   private static final TableIdentifier TB_12 = TableIdentifier.of(ICEBERG_CATALOG, DATABASE, "iceberg_table12");
   private static final TableIdentifier TB_13 = TableIdentifier.of(CATALOG, DATABASE, "test_table13");
   private static final TableIdentifier TB_14 = TableIdentifier.of(CATALOG, DATABASE, "test_table14");
+  private static final TableIdentifier TB_15 = TableIdentifier.of(HIVE_CATALOG, DATABASE, "hive_table15");
 
   private static final ConcurrentHashMap<String, ArcticCatalog> catalogsCache = new ConcurrentHashMap<>();
 
@@ -217,6 +219,16 @@ public class OptimizingIntegrationTest {
     MixedHiveOptimizingTest testCase =
         new MixedHiveOptimizingTest(table, TEST_HMS.getHiveClient(), getOptimizeHistoryStartId());
     testCase.testHiveKeyedTableMajorOptimizeAndMove();
+  }
+
+  @Test
+  public void testHiveUnKeyedTableFullOptimizeCopyingFiles() throws TException, IOException {
+    createHiveArcticTable(TB_15, PrimaryKeySpec.noPrimaryKey(), PartitionSpec.unpartitioned());
+    assertTableExist(TB_15);
+    UnkeyedTable table = catalog(HIVE_CATALOG).loadTable(TB_15).asUnkeyedTable();
+    MixedHiveOptimizingTest testCase =
+        new MixedHiveOptimizingTest(table, TEST_HMS.getHiveClient(), getOptimizeHistoryStartId());
+    testCase.testHiveUnKeyedTableFullOptimizeCopyingFiles();
   }
 
   private static long getOptimizeHistoryStartId() {

--- a/core/src/main/java/com/netease/arctic/io/ArcticFileIO.java
+++ b/core/src/main/java/com/netease/arctic/io/ArcticFileIO.java
@@ -62,6 +62,13 @@ public interface ArcticFileIO extends FileIO, Configurable {
    */
   void rename(String oldPath, String newPath);
 
+  /**
+   * Copy file from old path to new path
+   * @param oldPath - source path
+   * @param newPath - target path
+   */
+  void copy(String oldPath, String newPath);
+
   /** Delete a directory recursively
    *
    * @param path the path to delete.

--- a/core/src/main/java/com/netease/arctic/io/ArcticHadoopFileIO.java
+++ b/core/src/main/java/com/netease/arctic/io/ArcticHadoopFileIO.java
@@ -192,7 +192,7 @@ public class ArcticHadoopFileIO extends HadoopFileIO implements ArcticFileIO {
       try {
         FileUtil.copy(fs, srcPath, fs, dtsPath, false, true, conf());
       } catch (IOException e) {
-        throw new UncheckedIOException("Fail to rename: from " + src + " to " + dts, e);
+        throw new UncheckedIOException("Fail to copy: from " + src + " to " + dts, e);
       }
       return null;
     });

--- a/core/src/main/java/com/netease/arctic/io/RecoverableArcticFileIO.java
+++ b/core/src/main/java/com/netease/arctic/io/RecoverableArcticFileIO.java
@@ -56,6 +56,11 @@ public class RecoverableArcticFileIO implements ArcticFileIO {
   }
 
   @Override
+  public void copy(String oldPath, String newPath) {
+    fileIO.copy(oldPath, newPath);
+  }
+
+  @Override
   public void deleteDirectoryRecursively(String path) {
     //Do not move trash when deleting directory as it is used for dropping table only
     fileIO.deleteDirectoryRecursively(path);

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/BaseTaskExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/BaseTaskExecutor.java
@@ -233,6 +233,8 @@ public class BaseTaskExecutor implements Serializable {
 
       String customHiveSubdirectory = properties.get(OptimizeTaskProperties.CUSTOM_HIVE_SUB_DIRECTORY);
       nodeTask.setCustomHiveSubdirectory(customHiveSubdirectory);
+      nodeTask.setCopyFiles(
+          PropertyUtil.propertyAsBoolean(properties, OptimizeTaskProperties.ENABLE_COPY_FILES, false));
 
       Long maxExecuteTime = PropertyUtil.propertyAsLong(properties,
           OptimizeTaskProperties.MAX_EXECUTE_TIME, TableProperties.SELF_OPTIMIZING_EXECUTE_TIMEOUT_DEFAULT);

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/BaseTaskExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/BaseTaskExecutor.java
@@ -234,7 +234,7 @@ public class BaseTaskExecutor implements Serializable {
       String customHiveSubdirectory = properties.get(OptimizeTaskProperties.CUSTOM_HIVE_SUB_DIRECTORY);
       nodeTask.setCustomHiveSubdirectory(customHiveSubdirectory);
       nodeTask.setCopyFiles(
-          PropertyUtil.propertyAsBoolean(properties, OptimizeTaskProperties.ENABLE_COPY_FILES, false));
+          PropertyUtil.propertyAsBoolean(properties, OptimizeTaskProperties.COPY_FILES_TO_NEW_LOCATION, false));
 
       Long maxExecuteTime = PropertyUtil.propertyAsLong(properties,
           OptimizeTaskProperties.MAX_EXECUTE_TIME, TableProperties.SELF_OPTIMIZING_EXECUTE_TIMEOUT_DEFAULT);

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MajorExecutor.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/MajorExecutor.java
@@ -107,7 +107,12 @@ public class MajorExecutor extends AbstractExecutor {
           table.spec(), dataFile.partition(), customHiveSubdirectory);
 
       String sourcePath = dataFile.path().toString();
-      String targetPath = TableFileUtils.getNewFilePath(hiveLocation, sourcePath);
+      String targetPath;
+      if (sourcePath.startsWith(".")) {
+        targetPath = TableFileUtils.getNewFilePath(hiveLocation, sourcePath);
+      } else {
+        targetPath = TableFileUtils.getNewFilePath(hiveLocation, "." + sourcePath);
+      }
       LOG.info("Start copy file from {} to {}", sourcePath, targetPath);
       long startTime = System.currentTimeMillis();
       table.io().copy(sourcePath, targetPath);

--- a/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/NodeTask.java
+++ b/optimizer/src/main/java/com/netease/arctic/optimizer/operator/executor/NodeTask.java
@@ -58,6 +58,7 @@ public class NodeTask {
   private TableIdentifier tableIdentifier;
   private int attemptId;
   private String customHiveSubdirectory;
+  private boolean copyFiles;
   private Long maxExecuteTime;
 
   public NodeTask(List<ContentFileWithSequence<?>> baseFiles,
@@ -258,6 +259,14 @@ public class NodeTask {
     this.customHiveSubdirectory = customHiveSubdirectory;
   }
 
+  public boolean isCopyFiles() {
+    return copyFiles;
+  }
+
+  public void setCopyFiles(boolean copyFiles) {
+    this.copyFiles = copyFiles;
+  }
+
   public Long getMaxExecuteTime() {
     return maxExecuteTime;
   }
@@ -277,6 +286,7 @@ public class NodeTask {
         .add("taskId", taskId)
         .add("attemptId", attemptId)
         .add("tableIdentifier", tableIdentifier)
+        .add("copyFiles", copyFiles)
         .add("baseFiles", baseFiles.size())
         .add("insertFiles", insertFiles.size())
         .add("deleteFiles", deleteFiles.size())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #1619 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- optimizers support copy files to new hive locations if all files in this task are large files
- full optimizing plan of Unkeyed Mixed Hive Table supports split large files and small files into different tasks

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
