### PR TITLE
[AMORO-2391] For Mixed-Hive tables, default refresh time for Hive partitions should be configured

### DIFF
--- a/mixed/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
+++ b/mixed/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
@@ -49,6 +49,7 @@ public class HiveTableProperties {
   public static final String AUTO_SYNC_HIVE_DATA_WRITE = "base.hive.auto-sync-data-write";
   public static final boolean AUTO_SYNC_HIVE_DATA_WRITE_DEFAULT = false;
 
+  // Unit milliseconds
   public static final String REFRESH_HIVE_INTERVAL = "base.hive.refresh-interval";
   public static final long REFRESH_HIVE_INTERVAL_DEFAULT = 1800000L;
 

--- a/mixed/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
+++ b/mixed/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
@@ -50,7 +50,7 @@ public class HiveTableProperties {
   public static final boolean AUTO_SYNC_HIVE_DATA_WRITE_DEFAULT = false;
 
   public static final String REFRESH_HIVE_INTERVAL = "base.hive.refresh-interval";
-  public static final long REFRESH_HIVE_INTERVAL_DEFAULT = -1L;
+  public static final long REFRESH_HIVE_INTERVAL_DEFAULT = 1800000L;
 
   public static final String HIVE_CONSISTENT_WRITE_ENABLED = "base.hive.consistent-write.enabled";
   public static final boolean HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT = true;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2391 

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-Set the default value of REFRESH_HIVE_INTERVAL to half an hour
## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
