### PR TITLE
[AMORO-2553] Parallelize reading of EQ delete files and cache them on optimizers

### DIFF
--- a/ams/api/src/main/java/com/netease/arctic/api/OptimizerProperties.java
+++ b/ams/api/src/main/java/com/netease/arctic/api/OptimizerProperties.java
@@ -39,4 +39,16 @@ public class OptimizerProperties {
   public static final String OPTIMIZER_MEMORY_STORAGE_SIZE = "memory-storage-size";
   public static final String MAX_INPUT_FILE_SIZE_PER_THREAD = "max-input-file-size-per-thread";
   public static final Long MAX_INPUT_FILE_SIZE_PER_THREAD_DEFAULT = 512 * 1024 * 1024L; // 512MB
+
+  public static final String OPTIMIZER_CACHE_ENABLED = "cache-enabled";
+  public static final boolean OPTIMIZER_CACHE_ENABLED_DEFAULT = true;
+
+  public static final String OPTIMIZER_CACHE_TIMEOUT = "cache-timeout";
+  public static final long OPTIMIZER_CACHE_TIMEOUT_DEFAULT = 10;
+
+  public static final String OPTIMIZER_CACHE_MAX_ENTRY_SIZE = "cache-max-entry-size";
+  public static final long OPTIMIZER_CACHE_MAX_ENTRY_SIZE_DEFAULT = 64; // 64 MB
+
+  public static final String OPTIMIZER_CACHE_MAX_TOTAL_SIZE = "cache-max-total-size";
+  public static final long OPTIMIZER_CACHE_MAX_TOTAL_SIZE_DEFAULT = 128; // 128 MB
 }

--- a/ams/optimizer/common/src/main/java/com/netease/arctic/optimizer/common/OptimizerConfig.java
+++ b/ams/optimizer/common/src/main/java/com/netease/arctic/optimizer/common/OptimizerConfig.java
@@ -18,6 +18,11 @@
 
 package com.netease.arctic.optimizer.common;
 
+import static com.netease.arctic.api.OptimizerProperties.OPTIMIZER_CACHE_ENABLED_DEFAULT;
+import static com.netease.arctic.api.OptimizerProperties.OPTIMIZER_CACHE_MAX_ENTRY_SIZE_DEFAULT;
+import static com.netease.arctic.api.OptimizerProperties.OPTIMIZER_CACHE_MAX_TOTAL_SIZE_DEFAULT;
+import static com.netease.arctic.api.OptimizerProperties.OPTIMIZER_CACHE_TIMEOUT_DEFAULT;
+
 import com.netease.arctic.api.OptimizerProperties;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.kohsuke.args4j.CmdLineException;
@@ -84,6 +89,30 @@ public class OptimizerConfig implements Serializable {
 
   @Option(name = "-id", aliases = "--" + OptimizerProperties.RESOURCE_ID, usage = "Resource id")
   private String resourceId;
+
+  @Option(
+      name = "-ce",
+      aliases = "--" + OptimizerProperties.OPTIMIZER_CACHE_ENABLED,
+      usage = "Whether cache position delete files, default true")
+  private boolean cacheEnabled = OPTIMIZER_CACHE_ENABLED_DEFAULT;
+
+  @Option(
+      name = "-ct",
+      aliases = "--" + OptimizerProperties.OPTIMIZER_CACHE_TIMEOUT,
+      usage = "Memory storage size limit when extending disk storage(MB), default 512MB")
+  private long cacheTimeout = OPTIMIZER_CACHE_TIMEOUT_DEFAULT; // 10 Min
+
+  @Option(
+      name = "-cmes",
+      aliases = "--" + OptimizerProperties.OPTIMIZER_CACHE_MAX_ENTRY_SIZE,
+      usage = "Memory storage size limit when extending disk storage(MB), default 512MB")
+  private long cacheMaxEntrySize = OPTIMIZER_CACHE_MAX_ENTRY_SIZE_DEFAULT;
+
+  @Option(
+      name = "-cmts",
+      aliases = "--" + OptimizerProperties.OPTIMIZER_CACHE_MAX_TOTAL_SIZE,
+      usage = "Memory storage size limit when extending disk storage(MB), default 512MB")
+  private long cacheMaxTotalSize = OPTIMIZER_CACHE_MAX_TOTAL_SIZE_DEFAULT;
 
   public OptimizerConfig() {}
 
@@ -164,6 +193,38 @@ public class OptimizerConfig implements Serializable {
     this.resourceId = resourceId;
   }
 
+  public boolean isCacheEnabled() {
+    return cacheEnabled;
+  }
+
+  public void setCacheEnabled(boolean cacheEnabled) {
+    this.cacheEnabled = cacheEnabled;
+  }
+
+  public long getCacheTimeout() {
+    return cacheTimeout;
+  }
+
+  public void setCacheTimeout(long cacheTimeout) {
+    this.cacheTimeout = cacheTimeout;
+  }
+
+  public long getCacheMaxEntrySize() {
+    return cacheMaxEntrySize;
+  }
+
+  public void setCacheMaxEntrySize(long cacheMaxEntrySize) {
+    this.cacheMaxEntrySize = cacheMaxEntrySize;
+  }
+
+  public long getCacheMaxTotalSize() {
+    return cacheMaxTotalSize;
+  }
+
+  public void setCacheMaxTotalSize(long cacheMaxTotalSize) {
+    this.cacheMaxTotalSize = cacheMaxTotalSize;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -176,6 +237,10 @@ public class OptimizerConfig implements Serializable {
         .add("rocksDBBasePath", diskStoragePath)
         .add("memoryStorageSize", memoryStorageSize)
         .add("resourceId", resourceId)
+        .add("cacheEnabled", cacheEnabled)
+        .add("cacheTimeout", cacheTimeout)
+        .add("cacheMaxEntrySize", cacheMaxEntrySize)
+        .add("cacheMaxTotalSize", cacheMaxTotalSize)
         .toString();
   }
 }

--- a/ams/optimizer/common/src/main/java/com/netease/arctic/optimizer/common/OptimizerConfig.java
+++ b/ams/optimizer/common/src/main/java/com/netease/arctic/optimizer/common/OptimizerConfig.java
@@ -99,19 +99,19 @@ public class OptimizerConfig implements Serializable {
   @Option(
       name = "-ct",
       aliases = "--" + OptimizerProperties.OPTIMIZER_CACHE_TIMEOUT,
-      usage = "Memory storage size limit when extending disk storage(MB), default 512MB")
+      usage = "Cache timeout")
   private long cacheTimeout = OPTIMIZER_CACHE_TIMEOUT_DEFAULT; // 10 Min
 
   @Option(
       name = "-cmes",
       aliases = "--" + OptimizerProperties.OPTIMIZER_CACHE_MAX_ENTRY_SIZE,
-      usage = "Memory storage size limit when extending disk storage(MB), default 512MB")
+      usage = "Cache max entry size, default 64MB")
   private long cacheMaxEntrySize = OPTIMIZER_CACHE_MAX_ENTRY_SIZE_DEFAULT;
 
   @Option(
       name = "-cmts",
       aliases = "--" + OptimizerProperties.OPTIMIZER_CACHE_MAX_TOTAL_SIZE,
-      usage = "Memory storage size limit when extending disk storage(MB), default 512MB")
+      usage = "Cache max total size, default 128MB")
   private long cacheMaxTotalSize = OPTIMIZER_CACHE_MAX_TOTAL_SIZE_DEFAULT;
 
   public OptimizerConfig() {}

--- a/ams/optimizer/common/src/test/java/com/netease/arctic/optimizer/common/TestOptimizerConfig.java
+++ b/ams/optimizer/common/src/test/java/com/netease/arctic/optimizer/common/TestOptimizerConfig.java
@@ -18,6 +18,9 @@
 
 package com.netease.arctic.optimizer.common;
 
+import static com.netease.arctic.api.OptimizerProperties.OPTIMIZER_CACHE_MAX_ENTRY_SIZE_DEFAULT;
+import static com.netease.arctic.api.OptimizerProperties.OPTIMIZER_CACHE_MAX_TOTAL_SIZE_DEFAULT;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.kohsuke.args4j.CmdLineException;
@@ -28,7 +31,8 @@ public class TestOptimizerConfig {
 
   @Test
   public void testParseArguments() throws CmdLineException {
-    String cmd = "-a thrift://127.0.0.1:1260 -p 11 -g g1 -hb 2000 -eds -dsp /tmp/arctic -msz 512";
+    String cmd =
+        "-a thrift://127.0.0.1:1260 -p 11 -g g1 -hb 2000 -eds -dsp /tmp/arctic -msz 512 -ce -ct 10 -cmes 64 -cmts 128";
     String[] args = cmd.split(" ");
     OptimizerConfig optimizerConfig = new OptimizerConfig(args);
     Assert.assertEquals("thrift://127.0.0.1:1260", optimizerConfig.getAmsUrl());
@@ -38,6 +42,10 @@ public class TestOptimizerConfig {
     Assert.assertTrue(optimizerConfig.isExtendDiskStorage());
     Assert.assertEquals("/tmp/arctic", optimizerConfig.getDiskStoragePath());
     Assert.assertEquals(512, optimizerConfig.getMemoryStorageSize());
+    Assert.assertTrue(optimizerConfig.isCacheEnabled());
+    Assert.assertEquals(10, optimizerConfig.getCacheTimeout());
+    Assert.assertEquals(64, optimizerConfig.getCacheMaxEntrySize());
+    Assert.assertEquals(128, optimizerConfig.getCacheMaxTotalSize());
   }
 
   @Test
@@ -50,6 +58,7 @@ public class TestOptimizerConfig {
     String diskStoragePath = "/tmp";
     long memoryStorageSize = 1024;
     String resourceId = UUID.randomUUID().toString();
+    long cacheTimeout = 10;
 
     config.setAmsUrl(amsUrl);
     config.setExecutionParallel(executionParallel);
@@ -59,6 +68,10 @@ public class TestOptimizerConfig {
     config.setDiskStoragePath(diskStoragePath);
     config.setMemoryStorageSize(memoryStorageSize);
     config.setResourceId(resourceId);
+    config.setCacheEnabled(true);
+    config.setCacheTimeout(cacheTimeout);
+    config.setCacheMaxEntrySize(OPTIMIZER_CACHE_MAX_ENTRY_SIZE_DEFAULT);
+    config.setCacheMaxTotalSize(OPTIMIZER_CACHE_MAX_TOTAL_SIZE_DEFAULT);
 
     Assert.assertEquals(amsUrl, config.getAmsUrl());
     Assert.assertEquals(executionParallel, config.getExecutionParallel());
@@ -68,6 +81,10 @@ public class TestOptimizerConfig {
     Assert.assertEquals(diskStoragePath, config.getDiskStoragePath());
     Assert.assertEquals(memoryStorageSize, config.getMemoryStorageSize());
     Assert.assertEquals(resourceId, config.getResourceId());
+    Assert.assertTrue(config.isCacheEnabled());
+    Assert.assertEquals(cacheTimeout, config.getCacheTimeout());
+    Assert.assertEquals(OPTIMIZER_CACHE_MAX_ENTRY_SIZE_DEFAULT, config.getCacheMaxEntrySize());
+    Assert.assertEquals(OPTIMIZER_CACHE_MAX_TOTAL_SIZE_DEFAULT, config.getCacheMaxTotalSize());
   }
 
   @Test(expected = CmdLineException.class)

--- a/ams/optimizer/common/src/test/java/com/netease/arctic/optimizer/common/TestOptimizerExecutor.java
+++ b/ams/optimizer/common/src/test/java/com/netease/arctic/optimizer/common/TestOptimizerExecutor.java
@@ -143,7 +143,7 @@ public class TestOptimizerExecutor extends OptimizerTestBase {
     public void initialize(Map<String, String> properties) {}
 
     @Override
-    public OptimizingExecutor createExecutor(TestOptimizingInput input) {
+    public OptimizingExecutor<?> createExecutor(TestOptimizingInput input) {
       return new TestOptimizingExecutor(input);
     }
   }

--- a/ams/optimizer/flink-optimizer/src/main/java/com/netease/arctic/optimizer/flink/FlinkOptimizer.java
+++ b/ams/optimizer/flink-optimizer/src/main/java/com/netease/arctic/optimizer/flink/FlinkOptimizer.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.optimizer.flink;
 
+import com.netease.arctic.io.reader.OptimizerExecutorCache;
 import com.netease.arctic.optimizer.common.Optimizer;
 import com.netease.arctic.optimizer.common.OptimizerConfig;
 import com.netease.arctic.optimizer.common.OptimizerToucher;
@@ -32,6 +33,8 @@ import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.kohsuke.args4j.CmdLineException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
 
 public class FlinkOptimizer extends Optimizer {
   private static final Logger LOG = LoggerFactory.getLogger(FlinkOptimizer.class);
@@ -49,6 +52,13 @@ public class FlinkOptimizer extends Optimizer {
 
     // calculate optimizer memory allocation
     calcOptimizerMemory(optimizerConfig, env);
+
+    if (optimizerConfig.isCacheEnabled()) {
+      OptimizerExecutorCache.create(
+          Duration.ofMinutes(optimizerConfig.getCacheTimeout()),
+          optimizerConfig.getCacheMaxEntrySize() * 1024 * 1024,
+          optimizerConfig.getCacheMaxTotalSize() * 1024 * 1024);
+    }
 
     Optimizer optimizer = new FlinkOptimizer(optimizerConfig);
     env.addSource(new FlinkToucher(optimizer.getToucher()))

--- a/core/src/main/java/com/netease/arctic/io/reader/CombinedBaseDeleteLoader.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/CombinedBaseDeleteLoader.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.io.reader;
+
+import com.netease.arctic.utils.AmoroTypeUtil;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.DataReader;
+import org.apache.iceberg.data.orc.GenericOrcReader;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.orc.OrcRowReader;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.parquet.ParquetValueReader;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.math.LongMath;
+import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.ThreadPools;
+import org.apache.orc.TypeDescription;
+import org.apache.parquet.schema.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/** Copy from {@link org.apache.iceberg.data.BaseDeleteLoader}. */
+public class CombinedBaseDeleteLoader implements CombinedDeleteLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CombinedBaseDeleteLoader.class);
+
+  private final Function<DeleteFile, InputFile> loadInputFile;
+  private final ExecutorService workerPool;
+
+  public CombinedBaseDeleteLoader(Function<DeleteFile, InputFile> loadInputFile) {
+    // when iceberg version upgrade 1.5.0, modify to `ThreadPools.getDeleteWorkerPool()`
+    this(loadInputFile, ThreadPools.getWorkerPool());
+  }
+
+  /**
+   * Checks if the given number of bytes can be cached.
+   *
+   * <p>Implementations should override this method if they support caching. It is also recommended
+   * to use the provided size as a guideline to decide whether the value is eligible for caching.
+   * For instance, it may be beneficial to discard values that are too large to optimize the cache
+   * performance and utilization.
+   */
+  protected boolean canCache(long size) {
+    return false;
+  }
+
+  /**
+   * Gets the cached value for the key or populates the cache with a new mapping.
+   *
+   * <p>If the value for the specified key is in the cache, it should be returned. If the value is
+   * not in the cache, implementations should compute the value using the provided supplier, cache
+   * it, and then return it.
+   *
+   * <p>This method will be called only if {@link #canCache(long)} returned true.
+   */
+  protected <V> V getOrLoad(String key, Supplier<V> valueSupplier, long valueSize) {
+    throw new UnsupportedOperationException(getClass().getName() + " does not support caching");
+  }
+
+  public CombinedBaseDeleteLoader(
+      Function<DeleteFile, InputFile> loadInputFile, ExecutorService workerPool) {
+    this.loadInputFile = loadInputFile;
+    this.workerPool = workerPool;
+  }
+
+  @Override
+  public Iterable<RecordWithLsn> loadEqualityDeletes(
+      Iterable<DeleteFile> deleteFiles, Schema projection) {
+    Iterable<Iterable<RecordWithLsn>> deletes =
+        execute(deleteFiles, deleteFile -> getOrReadEqDeletes(deleteFile, projection));
+    return Iterables.concat(deletes);
+  }
+
+  private Iterable<RecordWithLsn> getOrReadEqDeletes(DeleteFile deleteFile, Schema projection) {
+    long estimatedSize = estimateEqDeletesSize(deleteFile, projection);
+    if (canCache(estimatedSize)) {
+      String cacheKey = deleteFile.path().toString();
+      return getOrLoad(cacheKey, () -> readEqDeletes(deleteFile, projection), estimatedSize);
+    } else {
+      return readEqDeletes(deleteFile, projection);
+    }
+  }
+
+  private Iterable<RecordWithLsn> readEqDeletes(DeleteFile deleteFile, Schema projection) {
+    CloseableIterable<RecordWithLsn> recordWithLsns =
+        CloseableIterable.transform(
+            openDeletes(deleteFile, projection),
+            r -> new RecordWithLsn(deleteFile.dataSequenceNumber(), r));
+    CloseableIterable<RecordWithLsn> copiedDeletes =
+        CloseableIterable.transform(recordWithLsns, RecordWithLsn::recordCopy);
+    return materialize(copiedDeletes);
+  }
+
+  // materializes the iterable and releases resources so that the result can be cached
+  private <T> Iterable<T> materialize(CloseableIterable<T> iterable) {
+    try (CloseableIterable<T> closeableIterable = iterable) {
+      return ImmutableList.copyOf(closeableIterable);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close iterable", e);
+    }
+  }
+
+  private CloseableIterable<Record> openDeletes(DeleteFile deleteFile, Schema projection) {
+    return openDeletes(deleteFile, projection, null /* no filter */);
+  }
+
+  private CloseableIterable<Record> openDeletes(
+      DeleteFile deleteFile, Schema projection, Expression filter) {
+
+    FileFormat format = deleteFile.format();
+    LOG.trace("Opening delete file {}", deleteFile.path());
+    InputFile inputFile = loadInputFile.apply(deleteFile);
+
+    switch (format) {
+      case AVRO:
+        return Avro.read(inputFile)
+            .project(projection)
+            .reuseContainers()
+            .createReaderFunc(DataReader::create)
+            .build();
+
+      case PARQUET:
+        return Parquet.read(inputFile)
+            .project(projection)
+            .filter(filter)
+            .reuseContainers()
+            .createReaderFunc(newParquetReaderFunc(projection))
+            .build();
+
+      case ORC:
+        // reusing containers is automatic for ORC, no need to call 'reuseContainers'
+        return ORC.read(inputFile)
+            .project(projection)
+            .filter(filter)
+            .createReaderFunc(newOrcReaderFunc(projection))
+            .build();
+
+      default:
+        throw new UnsupportedOperationException(
+            String.format(
+                "Cannot read deletes, %s is not a supported file format: %s",
+                format.name(), inputFile.location()));
+    }
+  }
+
+  private Function<MessageType, ParquetValueReader<?>> newParquetReaderFunc(Schema projection) {
+    return fileSchema -> GenericParquetReaders.buildReader(projection, fileSchema);
+  }
+
+  private Function<TypeDescription, OrcRowReader<?>> newOrcReaderFunc(Schema projection) {
+    return fileSchema -> GenericOrcReader.buildReader(projection, fileSchema);
+  }
+
+  private <I, O> Iterable<O> execute(Iterable<I> objects, Function<I, O> func) {
+    Queue<O> output = new ConcurrentLinkedQueue<>();
+
+    Tasks.foreach(objects)
+        .executeWith(workerPool)
+        .stopOnFailure()
+        .onFailure((object, exc) -> LOG.error("Failed to process {}", object, exc))
+        .run(object -> output.add(func.apply(object)));
+
+    return output;
+  }
+
+  // estimates the memory required to cache equality deletes (in bytes)
+  private long estimateEqDeletesSize(DeleteFile deleteFile, Schema projection) {
+    try {
+      long recordCount = deleteFile.recordCount();
+      int recordSize = estimateRecordSize(projection);
+      return LongMath.checkedMultiply(recordCount, recordSize);
+    } catch (ArithmeticException e) {
+      return Long.MAX_VALUE;
+    }
+  }
+
+  private int estimateRecordSize(Schema schema) {
+    return schema.columns().stream().mapToInt(AmoroTypeUtil::estimateSize).sum();
+  }
+}

--- a/core/src/main/java/com/netease/arctic/io/reader/CombinedDeleteLoader.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/CombinedDeleteLoader.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.io.reader;
+
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.Record;
+
+/** Copy from {@link org.apache.iceberg.data.DeleteLoader} to adapt return {@link RecordWithLsn}. */
+public interface CombinedDeleteLoader {
+
+  /**
+   * Loads the content of equality delete files into a set.
+   *
+   * @param deleteFiles equality delete file
+   * @param projection a projection of columns to load
+   * @return a set of equality deletes
+   */
+  Iterable<RecordWithLsn> loadEqualityDeletes(Iterable<DeleteFile> deleteFiles, Schema projection);
+
+  class RecordWithLsn {
+    private final Long lsn;
+    private Record record;
+
+    public RecordWithLsn(Long lsn, Record record) {
+      this.lsn = lsn;
+      this.record = record;
+    }
+
+    public Long getLsn() {
+      return lsn;
+    }
+
+    public Record getRecord() {
+      return record;
+    }
+
+    public RecordWithLsn recordCopy() {
+      record = record.copy();
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/com/netease/arctic/io/reader/OptimizerExecutorCache.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/OptimizerExecutorCache.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.io.reader;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/** Copy from {@link org.apache.iceberg.spark.SparkExecutorCache}. */
+public class OptimizerExecutorCache {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OptimizerExecutorCache.class);
+
+  private static volatile OptimizerExecutorCache instance = null;
+
+  private final Duration timeout;
+  private final long maxEntrySize;
+  private final long maxTotalSize;
+  private volatile Cache<String, CacheValue> state;
+
+  private OptimizerExecutorCache(Duration timeout, long maxEntrySize, long maxTotalSize) {
+    this.timeout = timeout;
+    this.maxEntrySize = maxEntrySize;
+    this.maxTotalSize = maxTotalSize;
+  }
+
+  public static OptimizerExecutorCache create(
+      Duration timeout, long maxEntrySize, long maxTotalSize) {
+    if (instance == null) {
+      synchronized (OptimizerExecutorCache.class) {
+        if (instance == null) {
+          OptimizerExecutorCache.instance =
+              new OptimizerExecutorCache(timeout, maxEntrySize, maxTotalSize);
+        }
+      }
+    }
+
+    return instance;
+  }
+
+  /**
+   * Returns the cache if created.
+   *
+   * <p>Note this method returns null if caching is disabled.
+   */
+  public static OptimizerExecutorCache getInstance() {
+    return instance;
+  }
+
+  /** Returns the cache if already created or null otherwise. */
+  public static OptimizerExecutorCache get() {
+    return instance;
+  }
+
+  /** Returns the max entry size in bytes that will be considered for caching. */
+  public long maxEntrySize() {
+    return maxEntrySize;
+  }
+
+  /**
+   * Gets the cached value for the key or populates the cache with a new mapping.
+   *
+   * @param group a group ID
+   * @param key a cache key
+   * @param valueSupplier a supplier to compute the value
+   * @param valueSize an estimated memory size of the value in bytes
+   * @return the cached or computed value
+   */
+  public <V> V getOrLoad(String group, String key, Supplier<V> valueSupplier, long valueSize) {
+    if (valueSize > maxEntrySize) {
+      LOG.debug("{} exceeds max entry size: {} > {}", key, valueSize, maxEntrySize);
+      return valueSupplier.get();
+    }
+
+    String internalKey = group + "_" + key;
+    CacheValue value = state().get(internalKey, loadFunc(valueSupplier, valueSize));
+    Preconditions.checkNotNull(value, "Loaded value must not be null");
+    return value.get();
+  }
+
+  private <V> Function<String, CacheValue> loadFunc(Supplier<V> valueSupplier, long valueSize) {
+    return key -> {
+      long start = System.currentTimeMillis();
+      V value = valueSupplier.get();
+      long end = System.currentTimeMillis();
+      LOG.debug("Loaded {} with size {} in {} ms", key, valueSize, (end - start));
+      return new CacheValue(value, valueSize);
+    };
+  }
+
+  /**
+   * Invalidates all keys associated with the given group ID.
+   *
+   * @param group a group ID
+   */
+  public void invalidate(String group) {
+    if (state != null) {
+      List<String> internalKeys = findInternalKeys(group);
+      LOG.info("Invalidating {} keys associated with {}", internalKeys.size(), group);
+      internalKeys.forEach(internalKey -> state.invalidate(internalKey));
+      LOG.info("Current cache stats {}", state.stats());
+    }
+  }
+
+  private List<String> findInternalKeys(String group) {
+    return state.asMap().keySet().stream()
+        .filter(internalKey -> internalKey.startsWith(group))
+        .collect(Collectors.toList());
+  }
+
+  private Cache<String, CacheValue> state() {
+    if (state == null) {
+      synchronized (this) {
+        if (state == null) {
+          LOG.info("Initializing cache state");
+          this.state = initState();
+        }
+      }
+    }
+
+    return state;
+  }
+
+  private Cache<String, CacheValue> initState() {
+    return Caffeine.newBuilder()
+        .expireAfterAccess(timeout)
+        .maximumWeight(maxTotalSize)
+        .weigher((key, value) -> ((CacheValue) value).weight())
+        .recordStats()
+        .removalListener((key, value, cause) -> LOG.debug("Evicted {} ({})", key, cause))
+        .build();
+  }
+
+  @org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting
+  static class CacheValue {
+    private final Object value;
+    private final long size;
+
+    CacheValue(Object value, long size) {
+      this.value = value;
+      this.size = size;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> V get() {
+      return (V) value;
+    }
+
+    public int weight() {
+      return (int) Math.min(size, Integer.MAX_VALUE);
+    }
+  }
+}

--- a/core/src/main/java/com/netease/arctic/optimizing/IcebergRewriteExecutor.java
+++ b/core/src/main/java/com/netease/arctic/optimizing/IcebergRewriteExecutor.java
@@ -61,6 +61,7 @@ public class IcebergRewriteExecutor extends AbstractRewriteFilesExecutor {
   @Override
   protected OptimizingDataReader dataReader() {
     return new GenericCombinedIcebergDataReader(
+        table,
         io,
         table.schema(),
         table.spec(),

--- a/core/src/main/java/com/netease/arctic/optimizing/IcebergRewriteExecutorFactory.java
+++ b/core/src/main/java/com/netease/arctic/optimizing/IcebergRewriteExecutorFactory.java
@@ -32,7 +32,7 @@ public class IcebergRewriteExecutorFactory implements OptimizingExecutorFactory<
   }
 
   @Override
-  public OptimizingExecutor createExecutor(RewriteFilesInput input) {
+  public OptimizingExecutor<?> createExecutor(RewriteFilesInput input) {
     OptimizingInputProperties optimizingConfig = OptimizingInputProperties.parse(properties);
     return new IcebergRewriteExecutor(
         input, input.getTable(), optimizingConfig.getStructLikeCollections());

--- a/core/src/main/java/com/netease/arctic/optimizing/OptimizingExecutorFactory.java
+++ b/core/src/main/java/com/netease/arctic/optimizing/OptimizingExecutorFactory.java
@@ -32,5 +32,5 @@ public interface OptimizingExecutorFactory<I extends TableOptimizing.OptimizingI
   void initialize(Map<String, String> properties);
 
   /** Create factory by input */
-  OptimizingExecutor createExecutor(I input);
+  OptimizingExecutor<?> createExecutor(I input);
 }

--- a/core/src/main/java/com/netease/arctic/utils/AmoroTypeUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/AmoroTypeUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.utils;
+
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/**
+ * copy from {@link org.apache.iceberg.types.TypeUtil} and remove this class after upgrading Iceberg
+ * version to 1.5+.
+ */
+public class AmoroTypeUtil {
+
+  private static final int HEADER_SIZE = 12;
+
+  /**
+   * Estimates the number of bytes a value for a given field may occupy in memory.
+   *
+   * <p>This method approximates the memory size based on heuristics and the internal Java
+   * representation defined by {@link Type.TypeID}. It is important to note that the actual size
+   * might differ from this estimation. The method is designed to handle a variety of data types,
+   * including primitive types, strings, and nested types such as structs, maps, and lists.
+   *
+   * @param field a field for which to estimate the size
+   * @return the estimated size in bytes of the field's value in memory
+   */
+  public static int estimateSize(Types.NestedField field) {
+    return estimateSize(field.type());
+  }
+
+  private static int estimateSize(Type type) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        // the size of a boolean variable is virtual machine dependent
+        // it is common to believe booleans occupy 1 byte in most JVMs
+        return 1;
+      case INTEGER:
+      case FLOAT:
+      case DATE:
+        // ints and floats occupy 4 bytes
+        // dates are internally represented as ints
+        return 4;
+      case LONG:
+      case DOUBLE:
+      case TIME:
+      case TIMESTAMP:
+        // longs and doubles occupy 8 bytes
+        // times and timestamps are internally represented as longs
+        return 8;
+      case STRING:
+        // 12 (header) + 6 (fields) + 16 (array overhead) + 20 (10 chars, 2 bytes each) = 54 bytes
+        return 54;
+      case UUID:
+        // 12 (header) + 16 (two long variables) = 28 bytes
+        return 28;
+      case FIXED:
+        return ((Types.FixedType) type).length();
+      case BINARY:
+        return 80;
+      case DECIMAL:
+        // 12 (header) + (12 + 12 + 4) (BigInteger) + 4 (scale) = 44 bytes
+        return 44;
+      case STRUCT:
+        Types.StructType struct = (Types.StructType) type;
+        return HEADER_SIZE + struct.fields().stream().mapToInt(AmoroTypeUtil::estimateSize).sum();
+      case LIST:
+        Types.ListType list = (Types.ListType) type;
+        return HEADER_SIZE + 5 * estimateSize(list.elementType());
+      case MAP:
+        Types.MapType map = (Types.MapType) type;
+        int entrySize = HEADER_SIZE + estimateSize(map.keyType()) + estimateSize(map.valueType());
+        return HEADER_SIZE + 5 * entrySize;
+      default:
+        return 16;
+    }
+  }
+}

--- a/core/src/test/java/com/netease/arctic/io/TestIcebergCombinedReader.java
+++ b/core/src/test/java/com/netease/arctic/io/TestIcebergCombinedReader.java
@@ -188,6 +188,7 @@ public class TestIcebergCombinedReader extends TableTestBase {
   public void readAllData() throws IOException {
     GenericCombinedIcebergDataReader dataReader =
         new GenericCombinedIcebergDataReader(
+            getArcticTable(),
             getArcticTable().io(),
             getArcticTable().schema(),
             getArcticTable().spec(),
@@ -210,6 +211,7 @@ public class TestIcebergCombinedReader extends TableTestBase {
   public void readAllDataNegate() throws IOException {
     GenericCombinedIcebergDataReader dataReader =
         new GenericCombinedIcebergDataReader(
+            getArcticTable(),
             getArcticTable().io(),
             getArcticTable().schema(),
             getArcticTable().spec(),
@@ -234,6 +236,7 @@ public class TestIcebergCombinedReader extends TableTestBase {
   public void readOnlyData() throws IOException {
     GenericCombinedIcebergDataReader dataReader =
         new GenericCombinedIcebergDataReader(
+            getArcticTable(),
             getArcticTable().io(),
             getArcticTable().schema(),
             getArcticTable().spec(),
@@ -254,6 +257,7 @@ public class TestIcebergCombinedReader extends TableTestBase {
   public void readOnlyDataNegate() throws IOException {
     GenericCombinedIcebergDataReader dataReader =
         new GenericCombinedIcebergDataReader(
+            getArcticTable(),
             getArcticTable().io(),
             getArcticTable().schema(),
             getArcticTable().spec(),
@@ -275,6 +279,7 @@ public class TestIcebergCombinedReader extends TableTestBase {
     CombinedDeleteFilter.FILTER_EQ_DELETE_TRIGGER_RECORD_COUNT = 100L;
     GenericCombinedIcebergDataReader dataReader =
         new GenericCombinedIcebergDataReader(
+            getArcticTable(),
             getArcticTable().io(),
             getArcticTable().schema(),
             getArcticTable().spec(),

--- a/core/src/test/java/com/netease/arctic/io/TestIcebergCombinedReaderVariousTypes.java
+++ b/core/src/test/java/com/netease/arctic/io/TestIcebergCombinedReaderVariousTypes.java
@@ -136,6 +136,7 @@ public class TestIcebergCombinedReaderVariousTypes extends TableTestBase {
 
     CloseableIterable<Record> readData =
         new GenericCombinedIcebergDataReader(
+                table,
                 table.io(),
                 table.schema(),
                 table.spec(),
@@ -187,6 +188,7 @@ public class TestIcebergCombinedReaderVariousTypes extends TableTestBase {
     CombinedDeleteFilter.FILTER_EQ_DELETE_TRIGGER_RECORD_COUNT = 100L;
     GenericCombinedIcebergDataReader reader =
         new GenericCombinedIcebergDataReader(
+            table,
             table.io(),
             table.schema(),
             table.spec(),

--- a/docs/admin-guides/managing-optimizers.md
+++ b/docs/admin-guides/managing-optimizers.md
@@ -251,15 +251,19 @@ You can submit optimizer in your own Flink task development platform or local Fl
 ```
 The description of the relevant parameters is shown in the following table:
 
-| Property | Required | Description                                                                                                                                                                                                                               |
-|----------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| -a       | Yes      | The address of the AMS thrift service, for example: thrift://127.0.0.1:1261, can be obtained from the config.yaml configuration.                                                                                                          |
-| -g       | Yes      | Group name created in advance under external container.                                                                                                                                                                                   |
-| -p       | Yes      | Optimizer parallelism usage.                                                                                                                                                                                                              |
-| -hb      | No       | Heart beat interval with ams, should be smaller than configuration ams.optimizer.heart-beat-timeout in AMS configuration conf/config.yaml which is 60000 milliseconds by default, default 10000(ms).                                      |
-| -eds     | No       | Whether extend storage to disk, default false.                                                                                                                                                                                            |
-| -dsp     | No       | Defines the directory where the storage files are saved, the default temporary-file directory is specified by the system property `java.io.tmpdir`. On UNIX systems the default value of this property is typically "/tmp" or "/var/tmp". |
-| -msz     | No       | Memory storage size limit when extending disk storage(MB), default 512(MB).                                                                                                                                                               |
+| Property | Required | Default                          | Description                                                                                                                                                                                                                               |
+|----------|----------|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -a       | Yes      | -                                | The address of the AMS thrift service, for example: thrift://127.0.0.1:1261, can be obtained from the config.yaml configuration.                                                                                                          |
+| -g       | Yes      | -                                | Group name created in advance under external container.                                                                                                                                                                                   |
+| -p       | Yes      | -                                | Optimizer parallelism usage.                                                                                                                                                                                                              |
+| -hb      | No       | 10000                            | Heart beat interval with ams, should be smaller than configuration ams.optimizer.heart-beat-timeout in AMS configuration conf/config.yaml which is 60000 milliseconds by default, default 10000(ms).                                      |
+| -eds     | No       | false                            | Whether extend storage to disk.                                                                                                                                                                                                           |
+| -dsp     | No       | System property `java.io.tmpdir` | Defines the directory where the storage files are saved, the default temporary-file directory is specified by the system property `java.io.tmpdir`. On UNIX systems the default value of this property is typically "/tmp" or "/var/tmp". |
+| -msz     | No       | 512 (M)                          | Memory storage size limit when extending disk storage(MB), default 512(MB).                                                                                                                                                               |
+| -ce      | No       | true                             | Whether cache EQ delete files.                                                                                                                                                                                                            |
+| -ct      | No       | 10 (min)                         | Cache timeout.                                                                                                                                                                                                                            |
+| -cmes    | No       | 64 (M)                           | Cache max entry size.                                                                                                                                                                                                                     |
+| -cmts    | No       | 128 (M)                          | Cache max total size.                                                                                                                                                                                                                     |
 
 
 Or you can submit optimizer in your own Spark task development platform or local Spark environment with the following configuration. The main parameters include:
@@ -277,8 +281,13 @@ Or you can submit optimizer in your own Spark task development platform or local
  -p 1 \
  -eds \
  -dsp /tmp \
- -msz 512
+ -msz 512 \
+ -ce \
+ -ct 10 \
+ -cmes 64 \
+ -cmts 128
 ```
+
 The description of the relevant parameters is shown in the following table:
 
 | Property | Required | Description                                                                                                                                                                                                                               |

--- a/mixed-format/hive/src/main/java/com/netease/arctic/hive/optimizing/MixFormatRewriteExecutorFactory.java
+++ b/mixed-format/hive/src/main/java/com/netease/arctic/hive/optimizing/MixFormatRewriteExecutorFactory.java
@@ -38,7 +38,7 @@ public class MixFormatRewriteExecutorFactory
   }
 
   @Override
-  public OptimizingExecutor createExecutor(RewriteFilesInput input) {
+  public OptimizingExecutor<?> createExecutor(RewriteFilesInput input) {
     OptimizingInputProperties optimizingConfig = OptimizingInputProperties.parse(properties);
     return new MixFormatRewriteExecutor(
         input,


### PR DESCRIPTION
## Why are the changes needed?

Close #2553.

## Brief change log

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
