### PR TITLE
[AMORO-2714]Delete resource when optimizer instance expired

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/DefaultOptimizingService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/DefaultOptimizingService.java
@@ -548,6 +548,7 @@ public class DefaultOptimizingService extends StatedPersistentBase
                           .forEach(task -> retryTask(task, queue)));
           if (isExpired) {
             LOG.info("Optimizer {} has been expired, unregister it", keepingTask.getOptimizer());
+            deleteResource(keepingTask.getOptimizer().getResourceId());
             unregisterOptimizer(token);
           } else {
             LOG.debug("Optimizer {} is being touched, keep it", keepingTask.getOptimizer());


### PR DESCRIPTION
## Why are the changes needed?

Close #2714

## Brief change log
Delete resource when optimizer instance expired which will cause dirty data in db. and this data will never be used again.


## How was this patch tested?

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes )
- If yes, how is the feature documented? (not applicable )
