### PR TITLE
[AMORO-2746] The artifactId of the sub modules of ams should use the same prefix

### DIFF
--- a/ams/metric-reporter/pom.xml
+++ b/ams/metric-reporter/pom.xml
@@ -27,7 +27,7 @@
         <version>0.7.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>amoro-metric-reporter</artifactId>
+    <artifactId>amoro-ams-metric-reporter</artifactId>
     <packaging>pom</packaging>
     <name>Amoro Project AMS Metric Reporter Parent</name>
     <url>https://amoro.apache.org</url>

--- a/ams/metric-reporter/prometheus-reporter/pom.xml
+++ b/ams/metric-reporter/prometheus-reporter/pom.xml
@@ -20,7 +20,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>amoro-metric-reporter</artifactId>
+        <artifactId>amoro-ams-metric-reporter</artifactId>
         <groupId>org.apache.amoro</groupId>
         <version>0.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/ams/optimizer/common/pom.xml
+++ b/ams/optimizer/common/pom.xml
@@ -21,7 +21,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>amoro-optimizer</artifactId>
+        <artifactId>amoro-ams-optimizer</artifactId>
         <groupId>org.apache.amoro</groupId>
         <version>0.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/ams/optimizer/flink-optimizer/pom.xml
+++ b/ams/optimizer/flink-optimizer/pom.xml
@@ -21,7 +21,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>amoro-optimizer</artifactId>
+        <artifactId>amoro-ams-optimizer</artifactId>
         <groupId>org.apache.amoro</groupId>
         <version>0.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/ams/optimizer/pom.xml
+++ b/ams/optimizer/pom.xml
@@ -27,7 +27,7 @@
         <version>0.7.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>amoro-optimizer</artifactId>
+    <artifactId>amoro-ams-optimizer</artifactId>
     <packaging>pom</packaging>
     <name>Amoro Project AMS Optimizer Parent</name>
     <url>https://amoro.apache.org</url>

--- a/ams/optimizer/spark-optimizer/pom.xml
+++ b/ams/optimizer/spark-optimizer/pom.xml
@@ -21,7 +21,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>amoro-optimizer</artifactId>
+        <artifactId>amoro-ams-optimizer</artifactId>
         <groupId>org.apache.amoro</groupId>
         <version>0.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/ams/optimizer/standalone-optimizer/pom.xml
+++ b/ams/optimizer/standalone-optimizer/pom.xml
@@ -21,7 +21,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>amoro-optimizer</artifactId>
+        <artifactId>amoro-ams-optimizer</artifactId>
         <groupId>org.apache.amoro</groupId>
         <version>0.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2746 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

The artifactId of the sub modules of ams should use the same prefix
- change `amoro-optimizer` to `amoro-ams-optimizer`
- change `amoro-metric-reporter` to `amoro-ams-metric-reporter`

![image](https://github.com/apache/amoro/assets/95013770/fffb66f1-9308-4d36-9357-b62be9a4f394)



## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
