### PR TITLE
[AMORO-6789]Memory leaks when using mix -hive format to write parquet files.

### DIFF
--- a/amoro-mixed-format/amoro-mixed-format-hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetWriter.java
+++ b/amoro-mixed-format/amoro-mixed-format-hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetWriter.java
@@ -228,7 +228,12 @@ class AdaptHiveParquetWriter<T> implements FileAppender<T>, Closeable {
       this.closed = true;
       flushRowGroup(true);
       writeStore.close();
-      writer.end(metadata);
+      if (writer != null) {
+        writer.end(metadata);
+      }
+      if (compressor != null) {
+        compressor.release();
+      }
     }
   }
 }


### PR DESCRIPTION
Fix bug that memory leaks when using mix -hive format to write parquet files.

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
To avoid writing tasks causing memory leak when write a mix-formatted table. Details refers to issue pls.
Close #2789 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- add logic of release a compressor to pool after finishing writing a file.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
