### PR TITLE
[AMORO-2787] Remove deprecated code for `OptimizerConfig`

### DIFF
--- a/amoro-ams/amoro-ams-api/src/main/java/org/apache/amoro/api/OptimizerProperties.java
+++ b/amoro-ams/amoro-ams-api/src/main/java/org/apache/amoro/api/OptimizerProperties.java
@@ -30,7 +30,6 @@ public class OptimizerProperties {
 
   // Resource group properties
   public static final String OPTIMIZER_EXECUTION_PARALLEL = "execution-parallel";
-  public static final String OPTIMIZER_MEMORY_SIZE = "memory-size";
   public static final String OPTIMIZER_GROUP_NAME = "group-name";
   public static final String OPTIMIZER_HEART_BEAT_INTERVAL = "heart-beat-interval";
   public static final String OPTIMIZER_EXTEND_DISK_STORAGE = "extend-disk-storage";

--- a/amoro-ams/amoro-ams-optimizer/amoro-optimizer-common/src/main/java/org/apache/amoro/optimizer/common/OptimizerConfig.java
+++ b/amoro-ams/amoro-ams-optimizer/amoro-optimizer-common/src/main/java/org/apache/amoro/optimizer/common/OptimizerConfig.java
@@ -43,14 +43,6 @@ public class OptimizerConfig implements Serializable {
       required = true)
   private int executionParallel;
 
-  /** @deprecated This parameter is deprecated and will be removed in version 0.7.0. */
-  @Deprecated
-  @Option(
-      name = "-m",
-      aliases = "--" + OptimizerProperties.OPTIMIZER_MEMORY_SIZE,
-      usage = "Optimizer memory size(MB)")
-  private int memorySize;
-
   @Option(
       name = "-g",
       aliases = "--" + OptimizerProperties.OPTIMIZER_GROUP_NAME,
@@ -116,14 +108,6 @@ public class OptimizerConfig implements Serializable {
     this.executionParallel = executionParallel;
   }
 
-  public int getMemorySize() {
-    return memorySize;
-  }
-
-  public void setMemorySize(int memorySize) {
-    this.memorySize = memorySize;
-  }
-
   public String getGroupName() {
     return groupName;
   }
@@ -169,7 +153,6 @@ public class OptimizerConfig implements Serializable {
     return MoreObjects.toStringHelper(this)
         .add("amsUrl", amsUrl)
         .add("executionParallel", executionParallel)
-        .add("memorySize", memorySize)
         .add("groupName", groupName)
         .add("heartBeat", heartBeat)
         .add("extendDiskStorage", extendDiskStorage)

--- a/amoro-ams/amoro-ams-optimizer/amoro-optimizer-common/src/main/java/org/apache/amoro/optimizer/common/OptimizerToucher.java
+++ b/amoro-ams/amoro-ams-optimizer/amoro-optimizer-common/src/main/java/org/apache/amoro/optimizer/common/OptimizerToucher.java
@@ -78,7 +78,6 @@ public class OptimizerToucher extends AbstractOptimizerOperator {
                       String.valueOf(getConfig().getHeartBeat()));
                   OptimizerRegisterInfo registerInfo = new OptimizerRegisterInfo();
                   registerInfo.setThreadCount(getConfig().getExecutionParallel());
-                  registerInfo.setMemoryMb(getConfig().getMemorySize());
                   registerInfo.setGroupName(getConfig().getGroupName());
                   registerInfo.setProperties(registerProperties);
                   registerInfo.setResourceId(getConfig().getResourceId());

--- a/amoro-ams/amoro-ams-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerToucher.java
+++ b/amoro-ams/amoro-ams-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerToucher.java
@@ -71,7 +71,6 @@ public class TestOptimizerToucher extends OptimizerTestBase {
     OptimizerRegisterInfo registerInfo = registeredOptimizerMap.get(token);
     Assert.assertEquals(registerConfig.getResourceId(), registerInfo.getResourceId());
     Assert.assertEquals(registerConfig.getGroupName(), registerInfo.getGroupName());
-    Assert.assertEquals(registerConfig.getMemorySize(), registerInfo.getMemoryMb());
     Assert.assertEquals(registerConfig.getExecutionParallel(), registerInfo.getThreadCount());
     Assert.assertEquals(optimizerProperties, registerInfo.getProperties());
   }

--- a/amoro-ams/amoro-ams-optimizer/amoro-optimizer-flink/src/main/java/org/apache/amoro/optimizer/flink/FlinkOptimizer.java
+++ b/amoro-ams/amoro-ams-optimizer/amoro-optimizer-flink/src/main/java/org/apache/amoro/optimizer/flink/FlinkOptimizer.java
@@ -86,12 +86,5 @@ public class FlinkOptimizer extends Optimizer {
     if (parallelism % numberOfTaskSlots != 0) {
       memorySize += taskMemorySize.getMebiBytes();
     }
-    if (memorySize != config.getMemorySize()) {
-      LOG.info(
-          "Reset the memory allocation of the optimizer to {}, before set is {}",
-          memorySize,
-          config.getMemorySize());
-      config.setMemorySize(memorySize);
-    }
   }
 }

--- a/amoro-ams/amoro-ams-optimizer/amoro-optimizer-spark/src/main/java/org/apache/amoro/optimizer/spark/SparkOptimizer.java
+++ b/amoro-ams/amoro-ams-optimizer/amoro-optimizer-spark/src/main/java/org/apache/amoro/optimizer/spark/SparkOptimizer.java
@@ -56,7 +56,6 @@ public class SparkOptimizer extends Optimizer {
     // calculate optimizer memory allocation
     int driverMemory = Utils.memoryStringToMb(jsc.getConf().get("spark.driver.memory", "1g"));
     int executorMemory = Utils.memoryStringToMb(jsc.getConf().get("spark.executor.memory", "1g"));
-    config.setMemorySize(driverMemory + config.getExecutionParallel() * executorMemory);
 
     SparkOptimizer optimizer = new SparkOptimizer(config, jsc);
     OptimizerToucher toucher = optimizer.getToucher();

--- a/amoro-ams/amoro-ams-optimizer/amoro-optimizer-standalone/src/main/java/org/apache/amoro/optimizer/standalone/StandaloneOptimizer.java
+++ b/amoro-ams/amoro-ams-optimizer/amoro-optimizer-standalone/src/main/java/org/apache/amoro/optimizer/standalone/StandaloneOptimizer.java
@@ -31,10 +31,6 @@ public class StandaloneOptimizer {
     OptimizerConfig optimizerConfig = new OptimizerConfig(args);
     Optimizer optimizer = new Optimizer(optimizerConfig);
 
-    // calculate optimizer memory allocation
-    long memorySize = Runtime.getRuntime().maxMemory() / 1024 / 1024;
-    optimizerConfig.setMemorySize((int) memorySize);
-
     RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
     String processId = runtimeMXBean.getName().split("@")[0];
     optimizer.getToucher().withRegisterProperty(Resource.PROPERTY_JOB_ID, processId);


### PR DESCRIPTION
Remove `org.apache.amoro.optimizer.common.OptimizerConfig#memorySize` and related code. 

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2787.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Remove `org.apache.amoro.optimizer.common.OptimizerConfig#memorySize` and related code. 

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
no.
