### PR TITLE
[AMORO-2857] Fix http client class not found error in mixed-format spark runtime jars

### DIFF
--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-runtime-3.2/pom.xml
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-runtime-3.2/pom.xml
@@ -91,7 +91,6 @@
                                     </include>
                                     <include>org.apache.iceberg:iceberg-bundled-guava</include>
                                     <include>org.apache.orc:*</include>
-
                                     <include>org.apache.thrift:libthrift</include>
                                     <include>org.apache.avro:avro</include>
                                     <include>org.apache.parquet:parquet-avro</include>
@@ -99,6 +98,8 @@
                                     <include>org.apache.commons:commons-lang3</include>
                                     <include>org.apache.commons:commons-collections</include>
                                     <include>com.github.ben-manes.caffeine:caffeine</include>
+                                    <include>org.apache.httpcomponents.client5:*</include>
+                                    <include>org.apache.httpcomponents.core5:*</include>
                                 </includes>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>
@@ -486,7 +487,11 @@
                                         </include>
                                     </includes>
                                 </relocation>
-
+                                <relocation>
+                                    <pattern>org.apache.hc</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.hc
+                                    </shadedPattern>
+                                </relocation>
                             </relocations>
                             <finalName>${project.artifactId}-${project.version}</finalName>
                         </configuration>

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-runtime-3.3/pom.xml
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-runtime-3.3/pom.xml
@@ -97,6 +97,8 @@
                                     <include>org.apache.commons:commons-lang3</include>
                                     <include>org.apache.commons:commons-collections</include>
                                     <include>com.github.ben-manes.caffeine:caffeine</include>
+                                    <include>org.apache.httpcomponents.client5:*</include>
+                                    <include>org.apache.httpcomponents.core5:*</include>
                                 </includes>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>
@@ -502,7 +504,11 @@
                                         </include>
                                     </includes>
                                 </relocation>
-
+                                <relocation>
+                                    <pattern>org.apache.hc</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.hc
+                                    </shadedPattern>
+                                </relocation>
                             </relocations>
                             <finalName>${project.artifactId}-${project.version}</finalName>
                         </configuration>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2857.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Shade HTTP client classes for mixed-format spark runtime jars.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

<img width="1229" alt="image" src="https://github.com/apache/amoro/assets/7424437/cd8ded3b-4e76-4450-bf70-bc6065b23a1f">

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
