### PR TITLE
[AMORO-2872] "Merge into when not matched" may result in incorrect writing of floating-point field data.

### DIFF
--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/pom.xml
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/pom.xml
@@ -37,9 +37,16 @@
         <hive.version>2.3.9</hive.version>
         <spark.version>3.2.4</spark.version>
         <scala.version>2.12.15</scala.version>
+        <scala.collection.compat>2.11.0</scala.collection.compat>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
+            <version>${scala.collection.compat}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
@@ -37,6 +37,7 @@ class MixedFormatSparkExtensions extends (SparkSessionExtensions => Unit) {
       case (_, parser) => new MixedFormatSqlExtensionsParser(parser)
     }
     // resolve mixed-format command
+    extensions.injectResolutionRule { _ => MixedFormatAlignRowLevelCommandAssignments }
     extensions.injectResolutionRule { spark => ResolveMixedFormatCommand(spark) }
     extensions.injectResolutionRule { spark => ResolveMergeIntoMixedFormatTableReferences(spark) }
     extensions.injectResolutionRule { spark => RewriteMixedFormatMergeIntoTable(spark) }

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
@@ -37,9 +37,9 @@ class MixedFormatSparkExtensions extends (SparkSessionExtensions => Unit) {
       case (_, parser) => new MixedFormatSqlExtensionsParser(parser)
     }
     // resolve mixed-format command
-    extensions.injectResolutionRule { _ => MixedFormatAlignRowLevelCommandAssignments }
     extensions.injectResolutionRule { spark => ResolveMixedFormatCommand(spark) }
     extensions.injectResolutionRule { spark => ResolveMergeIntoMixedFormatTableReferences(spark) }
+    extensions.injectResolutionRule { _ => MixedFormatAlignRowLevelCommandAssignments }
     extensions.injectResolutionRule { spark => RewriteMixedFormatMergeIntoTable(spark) }
 
     extensions.injectPostHocResolutionRule(spark => RewriteMixedFormatCommand(spark))

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.AssignmentUtils
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 
-import org.apache.amoro.spark.sql.catalyst.plans.UnresolvedMergeIntoMixedFormatTable
+import org.apache.amoro.spark.sql.catalyst.plans.{MergeIntoMixedFormatTable, UnresolvedMergeIntoMixedFormatTable}
 
 /**
  * A rule that aligns assignments in UPDATE and MERGE operations.
@@ -35,7 +35,7 @@ object MixedFormatAlignRowLevelCommandAssignments
   extends Rule[LogicalPlan] with MixedFormatAssignmentAlignmentSupport {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case m: UnresolvedMergeIntoMixedFormatTable if m.resolved && !m.aligned =>
+    case m: MergeIntoMixedFormatTable if m.resolved && !m.aligned =>
       val alignedMatchedActions = m.matchedActions.map {
         case u @ UpdateAction(_, assignments) =>
           u.copy(assignments = alignAssignments(m.targetTable, assignments))

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.analysis.MixedFormatAssignmentAlignmentSupport
+import org.apache.spark.sql.catalyst.expressions.AssignmentUtils
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+
+import org.apache.amoro.spark.sql.catalyst.plans.UnresolvedMergeIntoMixedFormatTable
+
+/**
+ * A rule that aligns assignments in UPDATE and MERGE operations.
+ *
+ * Note that this rule must be run before rewriting row-level commands.
+ */
+object MixedFormatAlignRowLevelCommandAssignments
+  extends Rule[LogicalPlan] with MixedFormatAssignmentAlignmentSupport {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case m: UnresolvedMergeIntoMixedFormatTable if m.resolved && !m.aligned =>
+      val alignedMatchedActions = m.matchedActions.map {
+        case u @ UpdateAction(_, assignments) =>
+          u.copy(assignments = alignAssignments(m.targetTable, assignments))
+        case d: DeleteAction =>
+          d
+        case _ =>
+          throw new AnalysisException(
+            "Matched actions can only contain UPDATE or DELETE",
+            Array.empty[String])
+      }
+
+      val alignedNotMatchedActions = m.notMatchedActions.map {
+        case i @ InsertAction(_, assignments) =>
+          // check no nested columns are present
+          val refs = assignments.map(_.key).map(AssignmentUtils.toAssignmentRef)
+          refs.foreach { ref =>
+            if (ref.size > 1) {
+              throw new AnalysisException(
+                "Nested fields are not supported inside INSERT clauses of MERGE operations: " +
+                  s"${ref.mkString("`", "`.`", "`")}",
+                Array.empty[String])
+            }
+          }
+
+          val colNames = refs.map(_.head)
+
+          // check there are no duplicates
+          val duplicateColNames = colNames.groupBy(identity).collect {
+            case (name, matchingNames) if matchingNames.size > 1 => name
+          }
+
+          if (duplicateColNames.nonEmpty) {
+            throw new AnalysisException(
+              s"Duplicate column names inside INSERT clause: ${duplicateColNames.mkString(", ")}",
+              Array.empty[String])
+          }
+
+          // reorder assignments by the target table column order
+          val assignmentMap = colNames.zip(assignments).toMap
+          i.copy(assignments = alignInsertActionAssignments(m.targetTable, assignmentMap))
+
+        case _ =>
+          throw new AnalysisException(
+            "Not matched actions can only contain INSERT",
+            Array.empty[String])
+      }
+
+      m.copy(matchedActions = alignedMatchedActions, notMatchedActions = alignedNotMatchedActions)
+  }
+
+  private def alignInsertActionAssignments(
+      targetTable: LogicalPlan,
+      assignmentMap: Map[String, Assignment]): Seq[Assignment] = {
+
+    val resolver = conf.resolver
+
+    targetTable.output.map { targetAttr =>
+      val assignment = assignmentMap
+        .find { case (name, _) => resolver(name, targetAttr.name) }
+        .map { case (_, assignment) => assignment }
+
+      if (assignment.isEmpty) {
+        throw new AnalysisException(
+          s"Cannot find column '${targetAttr.name}' of the target table among " +
+            s"the INSERT columns: ${assignmentMap.keys.mkString(", ")}. " +
+            "INSERT clauses must provide values for all columns of the target table.",
+          Array.empty[String])
+      }
+
+      val key = assignment.get.key
+      val value = castIfNeeded(targetAttr, assignment.get.value, resolver)
+      AssignmentUtils.handleCharVarcharLimits(Assignment(key, value))
+    }
+  }
+}

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/spark/sql/amoro/catalyst/AssignmentHelper.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/spark/sql/amoro/catalyst/AssignmentHelper.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.amoro.catalyst
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, ExtractValue, GetStructField}
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, LogicalPlan}
+import org.apache.spark.sql.types.DataType
+
+object AssignmentHelper extends SQLConfHelper {
+
+  /**
+   * Checks whether assignments are aligned and match table columns.
+   *
+   * @param table       a target table
+   * @param assignments assignments to check
+   * @return true if the assignments are aligned
+   */
+  def aligned(table: LogicalPlan, assignments: Seq[Assignment]): Boolean = {
+    val sameSize = table.output.size == assignments.size
+    sameSize && table.output.zip(assignments).forall { case (attr, assignment) =>
+      val key = assignment.key
+      val value = assignment.value
+      val refsEqual = toAssignmentRef(attr).zip(toAssignmentRef(key))
+        .forall { case (attrRef, keyRef) => conf.resolver(attrRef, keyRef) }
+
+      refsEqual &&
+      DataType.equalsIgnoreCompatibleNullability(value.dataType, attr.dataType) &&
+      (attr.nullable || !value.nullable)
+    }
+  }
+
+  def toAssignmentRef(expr: Expression): Seq[String] = expr match {
+    case attr: AttributeReference =>
+      Seq(attr.name)
+    case Alias(child, _) =>
+      toAssignmentRef(child)
+    case GetStructField(child, _, Some(name)) =>
+      toAssignmentRef(child) :+ name
+    case other: ExtractValue =>
+      throw new AnalysisException(s"Updating nested fields is only supported for structs: $other")
+    case other =>
+      throw new AnalysisException(s"Cannot convert to a reference, unsupported expression: $other")
+  }
+}

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/spark/sql/catalyst/analysis/MixedFormatAssignmentAlignmentSupport.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/main/scala/org/apache/spark/sql/catalyst/analysis/MixedFormatAssignmentAlignmentSupport.scala
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import scala.collection.compat.immutable.ArraySeq
+import scala.collection.mutable
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.catalyst.expressions.{Alias, AnsiCast, Cast, CreateNamedStruct, Expression, GetStructField, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.AssignmentUtils._
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, LogicalPlan}
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
+
+trait MixedFormatAssignmentAlignmentSupport extends CastSupport {
+
+  self: SQLConfHelper =>
+
+  private case class ColumnUpdate(ref: Seq[String], expr: Expression)
+
+  /**
+   * Aligns assignments to match table columns.
+   * <p>
+   * This method processes and reorders given assignments so that each target column gets
+   * an expression it should be set to. If a column does not have a matching assignment,
+   * it will be set to its current value. For example, if one passes a table with columns c1, c2
+   * and an assignment c2 = 1, this method will return c1 = c1, c2 = 1.
+   * <p>
+   * This method also handles updates to nested columns. If there is an assignment to a particular
+   * nested field, this method will construct a new struct with one field updated
+   * preserving other fields that have not been modified. For example, if one passes a table with
+   * columns c1, c2 where c2 is a struct with fields n1 and n2 and an assignment c2.n2 = 1,
+   * this method will return c1 = c1, c2 = struct(c2.n1, 1).
+   *
+   * @param table a target table
+   * @param assignments assignments to align
+   * @return aligned assignments that match table columns
+   */
+  protected def alignAssignments(
+      table: LogicalPlan,
+      assignments: Seq[Assignment]): Seq[Assignment] = {
+
+    val columnUpdates = assignments.map(a => ColumnUpdate(toAssignmentRef(a.key), a.value))
+    val outputExprs = applyUpdates(table.output, columnUpdates)
+    outputExprs.zip(table.output).map {
+      case (expr, attr) => handleCharVarcharLimits(Assignment(attr, expr))
+    }
+  }
+
+  private def applyUpdates(
+      cols: Seq[NamedExpression],
+      updates: Seq[ColumnUpdate],
+      resolver: Resolver = conf.resolver,
+      namePrefix: Seq[String] = Nil): Seq[Expression] = {
+
+    // iterate through columns at the current level and find which column updates match
+    cols.map { col =>
+      // find matches for this column or any of its children
+      val prefixMatchedUpdates = updates.filter(a => resolver(a.ref.head, col.name))
+      prefixMatchedUpdates match {
+        // if there is no exact match and no match for children, return the column as is
+        case updates if updates.isEmpty =>
+          col
+
+        // if there is an exact match, return the assigned expression
+        case Seq(update) if isExactMatch(update, col, resolver) =>
+          castIfNeeded(col, update.expr, resolver)
+
+        // if there are matches only for children
+        case updates if !hasExactMatch(updates, col, resolver) =>
+          col.dataType match {
+            case StructType(fields) =>
+              // build field expressions
+              val fieldExprs = fields.zipWithIndex.map { case (field, ordinal) =>
+                Alias(GetStructField(col, ordinal, Some(field.name)), field.name)()
+              }
+
+              // recursively apply this method on nested fields
+              val newUpdates = updates.map(u => u.copy(ref = u.ref.tail))
+              val updatedFieldExprs = applyUpdates(
+                ArraySeq.unsafeWrapArray(fieldExprs),
+                newUpdates,
+                resolver,
+                namePrefix :+ col.name)
+
+              // construct a new struct with updated field expressions
+              toNamedStruct(ArraySeq.unsafeWrapArray(fields), updatedFieldExprs)
+
+            case otherType =>
+              val colName = (namePrefix :+ col.name).mkString(".")
+              throw new AnalysisException(
+                "Updating nested fields is only supported for StructType " +
+                  s"but $colName is of type $otherType",
+                Array.empty[String])
+          }
+
+        // if there are conflicting updates, throw an exception
+        // there are two illegal scenarios:
+        // - multiple updates to the same column
+        // - updates to a top-level struct and its nested fields (e.g., a.b and a.b.c)
+        case updates if hasExactMatch(updates, col, resolver) =>
+          val conflictingCols = updates.map(u => (namePrefix ++ u.ref).mkString("."))
+          throw new AnalysisException(
+            "Updates are in conflict for these columns: " +
+              conflictingCols.distinct.mkString(", "),
+            Array.empty[String])
+      }
+    }
+  }
+
+  private def toNamedStruct(fields: Seq[StructField], fieldExprs: Seq[Expression]): Expression = {
+    val namedStructExprs = fields.zip(fieldExprs).flatMap { case (field, expr) =>
+      Seq(Literal(field.name), expr)
+    }
+    CreateNamedStruct(namedStructExprs)
+  }
+
+  private def hasExactMatch(
+      updates: Seq[ColumnUpdate],
+      col: NamedExpression,
+      resolver: Resolver): Boolean = {
+
+    updates.exists(assignment => isExactMatch(assignment, col, resolver))
+  }
+
+  private def isExactMatch(
+      update: ColumnUpdate,
+      col: NamedExpression,
+      resolver: Resolver): Boolean = {
+
+    update.ref match {
+      case Seq(namePart) if resolver(namePart, col.name) => true
+      case _ => false
+    }
+  }
+
+  protected def castIfNeeded(
+      tableAttr: NamedExpression,
+      expr: Expression,
+      resolver: Resolver): Expression = {
+
+    val storeAssignmentPolicy = conf.storeAssignmentPolicy
+
+    // run the type check and catch type errors
+    storeAssignmentPolicy match {
+      case StoreAssignmentPolicy.STRICT | StoreAssignmentPolicy.ANSI =>
+        if (expr.nullable && !tableAttr.nullable) {
+          throw new AnalysisException(
+            s"Cannot write nullable values to non-null column '${tableAttr.name}'",
+            Array.empty[String])
+        }
+
+        // use byName = true to catch cases when struct field names don't match
+        // e.g. a struct with fields (a, b) is assigned as a struct with fields (a, c) or (b, a)
+        val errors = new mutable.ArrayBuffer[String]()
+        val canWrite = DataType.canWrite(
+          expr.dataType,
+          tableAttr.dataType,
+          byName = true,
+          resolver,
+          tableAttr.name,
+          storeAssignmentPolicy,
+          err => errors += err)
+
+        if (!canWrite) {
+          throw new AnalysisException(
+            s"Cannot write incompatible data:\n- ${errors.mkString("\n- ")}",
+            Array.empty[String])
+        }
+
+      case _ => // OK
+    }
+
+    storeAssignmentPolicy match {
+      case _ if tableAttr.dataType.sameType(expr.dataType) =>
+        expr
+      case StoreAssignmentPolicy.ANSI =>
+        AnsiCast(expr, tableAttr.dataType, Option(conf.sessionLocalTimeZone))
+      case _ =>
+        Cast(expr, tableAttr.dataType, Option(conf.sessionLocalTimeZone))
+    }
+  }
+}

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/test/java/org/apache/amoro/spark/test/suites/sql/TestMergeIntoSQL.java
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.2/amoro-mixed-format-spark-3.2/src/test/java/org/apache/amoro/spark/test/suites/sql/TestMergeIntoSQL.java
@@ -50,25 +50,28 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
       new Schema(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.required(2, "data", Types.StringType.get()),
-          Types.NestedField.required(3, "pt", Types.StringType.get()));
+          Types.NestedField.required(3, "fdata", Types.FloatType.get()),
+          Types.NestedField.required(4, "ddata", Types.DoubleType.get()),
+          Types.NestedField.required(5, "pt", Types.StringType.get()));
+
   private static final PrimaryKeySpec pk =
       PrimaryKeySpec.builderFor(schema).addColumn("id").build();
 
   private static final List<Record> base =
       Lists.newArrayList(
-          RecordGenerator.newRecord(schema, 1, "a", "001"),
-          RecordGenerator.newRecord(schema, 2, "b", "002"));
+          RecordGenerator.newRecord(schema, 1, "a", 1.1f, 1.1D, "001"),
+          RecordGenerator.newRecord(schema, 2, "b", 1.1f, 1.1D, "002"));
   private static final List<Record> change =
       Lists.newArrayList(
-          RecordGenerator.newRecord(schema, 3, "c", "001"),
-          RecordGenerator.newRecord(schema, 4, "d", "002"));
+          RecordGenerator.newRecord(schema, 3, "c", 1.1f, 1.1D, "001"),
+          RecordGenerator.newRecord(schema, 4, "d", 1.1f, 1.1D, "002"));
 
   private static final List<Record> source =
       Lists.newArrayList(
-          RecordGenerator.newRecord(schema, 1, "s1", "001"),
-          RecordGenerator.newRecord(schema, 2, "s2", "002"),
-          RecordGenerator.newRecord(schema, 5, "s5", "001"),
-          RecordGenerator.newRecord(schema, 6, "s6", "003"));
+          RecordGenerator.newRecord(schema, 1, "s1", 1.1f, 1.1D, "001"),
+          RecordGenerator.newRecord(schema, 2, "s2", 1.1f, 1.1D, "002"),
+          RecordGenerator.newRecord(schema, 5, "s5", 1.1f, 1.1D, "001"),
+          RecordGenerator.newRecord(schema, 6, "s6", 1.1f, 1.1D, "003"));
 
   private final List<Record> target = Lists.newArrayList();
 
@@ -108,13 +111,20 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
             + " AS s ON t.id == s.id "
             + "WHEN MATCHED AND t.id = 1 THEN DELETE "
             + "WHEN MATCHED AND t.id = 2 THEN UPDATE SET * "
-            + "WHEN NOT MATCHED AND s.id != 5 THEN INSERT *");
+            + "WHEN NOT MATCHED AND s.id != 5 THEN INSERT (t.data, t.pt, t.id, t.fdata,t.ddata) values ( s.data, s.pt, 1000,1.1,1.1)");
 
     List<Record> expects =
         ExpectResultUtil.expectMergeResult(target, source, r -> r.getField("id"))
             .whenMatched((t, s) -> t.getField("id").equals(1), (t, s) -> null)
             .whenMatched((t, s) -> t.getField("id").equals(2), (t, s) -> s)
-            .whenNotMatched(s -> !s.getField("id").equals(5), Function.identity())
+            .whenNotMatched(
+                s -> !s.getField("id").equals(5),
+                s -> {
+                  s.setField("id", 1000);
+                  s.setField("fdata", 1.1f);
+                  s.setField("ddata", 1.1D);
+                  return s;
+                })
             .results();
 
     MixedTable table = loadTable();
@@ -135,7 +145,7 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
             + " AS t USING "
             + source()
             + " AS s ON t.id == s.id "
-            + "WHEN MATCHED AND t.id = 2 THEN UPDATE SET t.data = 'ccc' ");
+            + "WHEN MATCHED AND t.id = 2 THEN UPDATE SET t.data = 'ccc', t.fdata = 1.1, t.ddata = 1.1");
 
     List<Record> expects =
         ExpectResultUtil.expectMergeResult(target, source, r -> r.getField("id"))
@@ -240,7 +250,7 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
             + source()
             + " AS s ON t.id == s.id "
             + "WHEN MATCHED THEN UPDATE SET t.id = s.id, t.data = s.pt, t.pt = s.pt "
-            + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id) values ( s.pt, s.pt, s.id) ");
+            + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id, t.fdata,t.ddata) values ( s.pt, s.pt, s.id,s.fdata,s.ddata) ");
 
     Function<Record, Record> dataAsPt =
         s -> {
@@ -279,7 +289,7 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
               + source()
               + " AS s ON t.pt == s.id "
               + "WHEN MATCHED THEN UPDATE SET t.id = s.id, t.data = s.pt, t.pt = s.pt "
-              + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id) values ( s.pt, s.pt, s.id) ");
+              + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id,t.fdata,t.ddata) values ( s.pt, s.data, s.id,s.fdata,s.ddata) ");
     } catch (Exception e) {
       catched = true;
     }
@@ -293,8 +303,8 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
     setupTest(pk);
     List<Record> source =
         Lists.newArrayList(
-            RecordGenerator.newRecord(schema, 1, "s1", "001"),
-            RecordGenerator.newRecord(schema, 1, "s2", "001"));
+            RecordGenerator.newRecord(schema, 1, "s1", 1.1f, 2.2D, "001"),
+            RecordGenerator.newRecord(schema, 1, "s2", 1.1f, 2.2D, "001"));
     createViewSource(schema, source);
 
     boolean catched = false;
@@ -306,7 +316,7 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
               + source()
               + " AS s ON t.id == s.id "
               + "WHEN MATCHED THEN UPDATE SET t.id = s.id, t.data = s.pt, t.pt = s.pt "
-              + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id) values ( s.pt, s.pt, s.id) ");
+              + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id, t.fdata, t.ddata) values ( s.data, s.pt, s.id, s.fdata, s.ddata) ");
     } catch (Exception e) {
       catched = true;
     }

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/pom.xml
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/pom.xml
@@ -41,7 +41,6 @@
     </properties>
 
     <dependencies>
-        <!-- for AmoroExtendedDataSourceV2Strategy.scala -->
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/pom.xml
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/pom.xml
@@ -37,9 +37,17 @@
         <hive.version>2.3.9</hive.version>
         <spark.version>3.3.2</spark.version>
         <scala.version>2.12.15</scala.version>
+        <scala.collection.compat>2.11.0</scala.collection.compat>
     </properties>
 
     <dependencies>
+        <!-- for AmoroExtendedDataSourceV2Strategy.scala -->
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-compat_${scala.binary.version}</artifactId>
+            <version>${scala.collection.compat}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.execution.datasources.v2.{ExtendedDataSourceV2Strate
 import org.apache.spark.sql.execution.dynamicpruning.RowLevelCommandDynamicPruning
 
 import org.apache.amoro.spark.sql.catalyst.analysis
+import org.apache.amoro.spark.sql.catalyst.analysis.{MixedFormatAlignRowLevelCommandAssignments, QueryWithConstraintCheck}
 import org.apache.amoro.spark.sql.catalyst.analysis.{QueryWithConstraintCheck, ResolveMergeIntoMixedFormatTableReferences, ResolveMixedFormatCommand, RewriteMixedFormatCommand, RewriteMixedFormatMergeIntoTable}
 import org.apache.amoro.spark.sql.catalyst.optimize.{OptimizeWriteRule, RewriteAppendMixedFormatTable, RewriteDeleteFromMixedFormatTable, RewriteUpdateMixedFormatTable}
 import org.apache.amoro.spark.sql.catalyst.parser.MixedFormatSqlExtensionsParser
@@ -38,6 +39,7 @@ class MixedFormatSparkExtensions extends (SparkSessionExtensions => Unit) {
       case (_, parser) => new MixedFormatSqlExtensionsParser(parser)
     }
     // resolve mixed-format command
+    extensions.injectResolutionRule { _ => MixedFormatAlignRowLevelCommandAssignments }
     extensions.injectResolutionRule { spark => ResolveMixedFormatCommand(spark) }
     extensions.injectResolutionRule { spark => ResolveMergeIntoMixedFormatTableReferences(spark) }
     extensions.injectResolutionRule { spark => RewriteMixedFormatMergeIntoTable(spark) }

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/MixedFormatSparkExtensions.scala
@@ -39,9 +39,9 @@ class MixedFormatSparkExtensions extends (SparkSessionExtensions => Unit) {
       case (_, parser) => new MixedFormatSqlExtensionsParser(parser)
     }
     // resolve mixed-format command
-    extensions.injectResolutionRule { _ => MixedFormatAlignRowLevelCommandAssignments }
     extensions.injectResolutionRule { spark => ResolveMixedFormatCommand(spark) }
     extensions.injectResolutionRule { spark => ResolveMergeIntoMixedFormatTableReferences(spark) }
+    extensions.injectResolutionRule { _ => MixedFormatAlignRowLevelCommandAssignments }
     extensions.injectResolutionRule { spark => RewriteMixedFormatMergeIntoTable(spark) }
 
     extensions.injectPostHocResolutionRule(spark => RewriteMixedFormatCommand(spark))

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.UpdateAction
 import org.apache.spark.sql.catalyst.rules.Rule
 
-import org.apache.amoro.spark.sql.catalyst.plans.UnresolvedMergeIntoMixedFormatTable
+import org.apache.amoro.spark.sql.catalyst.plans.{MergeIntoMixedFormatTable, UnresolvedMergeIntoMixedFormatTable}
 
 /**
  * A rule that aligns assignments in UPDATE and MERGE operations.
@@ -39,7 +39,7 @@ object MixedFormatAlignRowLevelCommandAssignments
   extends Rule[LogicalPlan] with MixedFormatAssignmentAlignmentSupport {
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
-    case m: UnresolvedMergeIntoMixedFormatTable if m.resolved && !m.aligned =>
+    case m: MergeIntoMixedFormatTable if m.resolved && !m.aligned =>
       val alignedMatchedActions = m.matchedActions.map {
         case u @ UpdateAction(_, assignments) =>
           u.copy(assignments = alignAssignments(m.targetTable, assignments))

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/MixedFormatAlignRowLevelCommandAssignments.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.analysis.MixedFormatAssignmentAlignmentSupport
+import org.apache.spark.sql.catalyst.expressions.AssignmentUtils
+import org.apache.spark.sql.catalyst.plans.logical.Assignment
+import org.apache.spark.sql.catalyst.plans.logical.DeleteAction
+import org.apache.spark.sql.catalyst.plans.logical.InsertAction
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.UpdateAction
+import org.apache.spark.sql.catalyst.rules.Rule
+
+import org.apache.amoro.spark.sql.catalyst.plans.UnresolvedMergeIntoMixedFormatTable
+
+/**
+ * A rule that aligns assignments in UPDATE and MERGE operations.
+ *
+ * Note that this rule must be run before rewriting row-level commands.
+ */
+object MixedFormatAlignRowLevelCommandAssignments
+  extends Rule[LogicalPlan] with MixedFormatAssignmentAlignmentSupport {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case m: UnresolvedMergeIntoMixedFormatTable if m.resolved && !m.aligned =>
+      val alignedMatchedActions = m.matchedActions.map {
+        case u @ UpdateAction(_, assignments) =>
+          u.copy(assignments = alignAssignments(m.targetTable, assignments))
+        case d: DeleteAction =>
+          d
+        case _ =>
+          throw new AnalysisException(
+            "Matched actions can only contain UPDATE or DELETE",
+            Array.empty[String])
+      }
+
+      val alignedNotMatchedActions = m.notMatchedActions.map {
+        case i @ InsertAction(_, assignments) =>
+          // check no nested columns are present
+          val refs = assignments.map(_.key).map(AssignmentUtils.toAssignmentRef)
+          refs.foreach { ref =>
+            if (ref.size > 1) {
+              throw new AnalysisException(
+                "Nested fields are not supported inside INSERT clauses of MERGE operations: " +
+                  s"${ref.mkString("`", "`.`", "`")}",
+                Array.empty[String])
+            }
+          }
+
+          val colNames = refs.map(_.head)
+
+          // check there are no duplicates
+          val duplicateColNames = colNames.groupBy(identity).collect {
+            case (name, matchingNames) if matchingNames.size > 1 => name
+          }
+
+          if (duplicateColNames.nonEmpty) {
+            throw new AnalysisException(
+              s"Duplicate column names inside INSERT clause: ${duplicateColNames.mkString(", ")}",
+              Array.empty[String])
+          }
+
+          // reorder assignments by the target table column order
+          val assignmentMap = colNames.zip(assignments).toMap
+          i.copy(assignments = alignInsertActionAssignments(m.targetTable, assignmentMap))
+
+        case _ =>
+          throw new AnalysisException(
+            "Not matched actions can only contain INSERT",
+            Array.empty[String])
+      }
+
+      m.copy(matchedActions = alignedMatchedActions, notMatchedActions = alignedNotMatchedActions)
+  }
+
+  private def alignInsertActionAssignments(
+      targetTable: LogicalPlan,
+      assignmentMap: Map[String, Assignment]): Seq[Assignment] = {
+
+    val resolver = conf.resolver
+
+    targetTable.output.map { targetAttr =>
+      val assignment = assignmentMap
+        .find { case (name, _) => resolver(name, targetAttr.name) }
+        .map { case (_, assignment) => assignment }
+
+      if (assignment.isEmpty) {
+        throw new AnalysisException(
+          s"Cannot find column '${targetAttr.name}' of the target table among " +
+            s"the INSERT columns: ${assignmentMap.keys.mkString(", ")}. " +
+            "INSERT clauses must provide values for all columns of the target table.",
+          Array.empty[String])
+      }
+
+      val key = assignment.get.key
+      val value = castIfNeeded(targetAttr, assignment.get.value, resolver)
+      AssignmentUtils.handleCharVarcharLimits(Assignment(key, value))
+    }
+  }
+}

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/spark/sql/catalyst/analysis/MixedFormatAssignmentAlignmentSupport.scala
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/main/scala/org/apache/spark/sql/catalyst/analysis/MixedFormatAssignmentAlignmentSupport.scala
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import scala.collection.compat.immutable.ArraySeq
+import scala.collection.mutable
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.catalyst.expressions.{Alias, AnsiCast, Cast, CreateNamedStruct, Expression, GetStructField, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.AssignmentUtils._
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, LogicalPlan}
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
+
+trait MixedFormatAssignmentAlignmentSupport extends CastSupport {
+
+  self: SQLConfHelper =>
+
+  private case class ColumnUpdate(ref: Seq[String], expr: Expression)
+
+  /**
+   * Aligns assignments to match table columns.
+   * <p>
+   * This method processes and reorders given assignments so that each target column gets
+   * an expression it should be set to. If a column does not have a matching assignment,
+   * it will be set to its current value. For example, if one passes a table with columns c1, c2
+   * and an assignment c2 = 1, this method will return c1 = c1, c2 = 1.
+   * <p>
+   * This method also handles updates to nested columns. If there is an assignment to a particular
+   * nested field, this method will construct a new struct with one field updated
+   * preserving other fields that have not been modified. For example, if one passes a table with
+   * columns c1, c2 where c2 is a struct with fields n1 and n2 and an assignment c2.n2 = 1,
+   * this method will return c1 = c1, c2 = struct(c2.n1, 1).
+   *
+   * @param table a target table
+   * @param assignments assignments to align
+   * @return aligned assignments that match table columns
+   */
+  protected def alignAssignments(
+      table: LogicalPlan,
+      assignments: Seq[Assignment]): Seq[Assignment] = {
+
+    val columnUpdates = assignments.map(a => ColumnUpdate(toAssignmentRef(a.key), a.value))
+    val outputExprs = applyUpdates(table.output, columnUpdates)
+    outputExprs.zip(table.output).map {
+      case (expr, attr) => handleCharVarcharLimits(Assignment(attr, expr))
+    }
+  }
+
+  private def applyUpdates(
+      cols: Seq[NamedExpression],
+      updates: Seq[ColumnUpdate],
+      resolver: Resolver = conf.resolver,
+      namePrefix: Seq[String] = Nil): Seq[Expression] = {
+
+    // iterate through columns at the current level and find which column updates match
+    cols.map { col =>
+      // find matches for this column or any of its children
+      val prefixMatchedUpdates = updates.filter(a => resolver(a.ref.head, col.name))
+      prefixMatchedUpdates match {
+        // if there is no exact match and no match for children, return the column as is
+        case updates if updates.isEmpty =>
+          col
+
+        // if there is an exact match, return the assigned expression
+        case Seq(update) if isExactMatch(update, col, resolver) =>
+          castIfNeeded(col, update.expr, resolver)
+
+        // if there are matches only for children
+        case updates if !hasExactMatch(updates, col, resolver) =>
+          col.dataType match {
+            case StructType(fields) =>
+              // build field expressions
+              val fieldExprs = fields.zipWithIndex.map { case (field, ordinal) =>
+                Alias(GetStructField(col, ordinal, Some(field.name)), field.name)()
+              }
+
+              // recursively apply this method on nested fields
+              val newUpdates = updates.map(u => u.copy(ref = u.ref.tail))
+              val updatedFieldExprs = applyUpdates(
+                ArraySeq.unsafeWrapArray(fieldExprs),
+                newUpdates,
+                resolver,
+                namePrefix :+ col.name)
+
+              // construct a new struct with updated field expressions
+              toNamedStruct(ArraySeq.unsafeWrapArray(fields), updatedFieldExprs)
+
+            case otherType =>
+              val colName = (namePrefix :+ col.name).mkString(".")
+              throw new AnalysisException(
+                "Updating nested fields is only supported for StructType " +
+                  s"but $colName is of type $otherType",
+                Array.empty[String])
+          }
+
+        // if there are conflicting updates, throw an exception
+        // there are two illegal scenarios:
+        // - multiple updates to the same column
+        // - updates to a top-level struct and its nested fields (e.g., a.b and a.b.c)
+        case updates if hasExactMatch(updates, col, resolver) =>
+          val conflictingCols = updates.map(u => (namePrefix ++ u.ref).mkString("."))
+          throw new AnalysisException(
+            "Updates are in conflict for these columns: " +
+              conflictingCols.distinct.mkString(", "),
+            Array.empty[String])
+      }
+    }
+  }
+
+  private def toNamedStruct(fields: Seq[StructField], fieldExprs: Seq[Expression]): Expression = {
+    val namedStructExprs = fields.zip(fieldExprs).flatMap { case (field, expr) =>
+      Seq(Literal(field.name), expr)
+    }
+    CreateNamedStruct(namedStructExprs)
+  }
+
+  private def hasExactMatch(
+      updates: Seq[ColumnUpdate],
+      col: NamedExpression,
+      resolver: Resolver): Boolean = {
+
+    updates.exists(assignment => isExactMatch(assignment, col, resolver))
+  }
+
+  private def isExactMatch(
+      update: ColumnUpdate,
+      col: NamedExpression,
+      resolver: Resolver): Boolean = {
+
+    update.ref match {
+      case Seq(namePart) if resolver(namePart, col.name) => true
+      case _ => false
+    }
+  }
+
+  protected def castIfNeeded(
+      tableAttr: NamedExpression,
+      expr: Expression,
+      resolver: Resolver): Expression = {
+
+    val storeAssignmentPolicy = conf.storeAssignmentPolicy
+
+    // run the type check and catch type errors
+    storeAssignmentPolicy match {
+      case StoreAssignmentPolicy.STRICT | StoreAssignmentPolicy.ANSI =>
+        if (expr.nullable && !tableAttr.nullable) {
+          throw new AnalysisException(
+            s"Cannot write nullable values to non-null column '${tableAttr.name}'",
+            Array.empty[String])
+        }
+
+        // use byName = true to catch cases when struct field names don't match
+        // e.g. a struct with fields (a, b) is assigned as a struct with fields (a, c) or (b, a)
+        val errors = new mutable.ArrayBuffer[String]()
+        val canWrite = DataType.canWrite(
+          expr.dataType,
+          tableAttr.dataType,
+          byName = true,
+          resolver,
+          tableAttr.name,
+          storeAssignmentPolicy,
+          err => errors += err)
+
+        if (!canWrite) {
+          throw new AnalysisException(
+            s"Cannot write incompatible data:\n- ${errors.mkString("\n- ")}",
+            Array.empty[String])
+        }
+
+      case _ => // OK
+    }
+
+    storeAssignmentPolicy match {
+      case _ if tableAttr.dataType.sameType(expr.dataType) =>
+        expr
+      case StoreAssignmentPolicy.ANSI =>
+        AnsiCast(expr, tableAttr.dataType, Option(conf.sessionLocalTimeZone))
+      case _ =>
+        Cast(expr, tableAttr.dataType, Option(conf.sessionLocalTimeZone))
+    }
+  }
+}

--- a/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/test/java/org/apache/amoro/spark/test/suites/sql/TestMergeIntoSQL.java
+++ b/amoro-mixed-format/amoro-mixed-format-spark/v3.3/amoro-mixed-format-spark-3.3/src/test/java/org/apache/amoro/spark/test/suites/sql/TestMergeIntoSQL.java
@@ -32,7 +32,6 @@ import org.apache.amoro.table.PrimaryKeySpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -130,16 +129,6 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
 
     MixedTable table = loadTable();
     List<Record> actual = TestTableUtil.tableRecords(table);
-    // check fdata/ddata of row with id 100。
-    Record record = actual.stream().filter(r -> r.getField("id").equals(1000)).findFirst().get();
-    Assert.assertNotNull(record);
-
-    Assert.assertTrue(
-        String.format(
-            "fdata %s != 1.1, data %s != 1.1",
-            record.getField("fdata"), record.getField("fdata").toString()),
-        record.getField("fdata").toString().equals("1.1")
-            && record.getField("fdata").toString().equals("1.1"));
     DataComparator.build(expects, actual).ignoreOrder("id").assertRecordsEqual();
   }
 
@@ -261,7 +250,7 @@ public class TestMergeIntoSQL extends MixedTableTestBase {
             + source()
             + " AS s ON t.id == s.id "
             + "WHEN MATCHED THEN UPDATE SET t.id = s.id, t.data = s.pt, t.pt = s.pt "
-            + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id, t.fdata,t.ddata) values ( s.data, s.pt, s.id,s.fdata,s.ddata) ");
+            + "WHEN NOT MATCHED THEN INSERT (t.data, t.pt, t.id, t.fdata,t.ddata) values ( s.pt, s.pt, s.id,s.fdata,s.ddata) ");
 
     Function<Record, Record> dataAsPt =
         s -> {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2872 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- add  MixedFormatAlignRowLevelCommandAssignments  to cast constant to the field type
- add unittest

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
