### PR TITLE
[AMORO-2925] Fix the issue of clean-orphan-file mistakenly deleting data files.

### DIFF
--- a/amoro-core/src/main/java/org/apache/amoro/io/AuthenticatedHadoopFileIO.java
+++ b/amoro-core/src/main/java/org/apache/amoro/io/AuthenticatedHadoopFileIO.java
@@ -100,7 +100,7 @@ public class AuthenticatedHadoopFileIO extends HadoopFileIO
                             new PathInfo(
                                 status.getPath().toString(),
                                 status.getLen(),
-                                status.getAccessTime(),
+                                status.getModificationTime(),
                                 status.isDirectory()))
                     .iterator();
             return () -> it;


### PR DESCRIPTION
## Why are the changes needed?
When creating an Iceberg table on OSS and executing clean-orphan-file, there are normal data_files (just created but not yet committed to Iceberg) being cleaned up. The clean-orphan-file.min-existing-time-minutes parameter is not taking effect.  

Through debugging, it was found that because OSS does not record the file access time, getAccessTime returns 0, causing the clean-orphan-file.min-existing-time-minutes parameter to become ineffective.  

At the same time, the [listPrefix](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java#L133-L152) function of Iceberg also uses getModificationTime. So using getModificationTime should be a better choice.

## Brief change log
- In the listDirectory function, replace getAccessTime with getModificationTime.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1474" alt="image" src="https://github.com/apache/amoro/assets/5699014/505ab557-371d-4414-9b5a-f062add1f334">


- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
