### PR TITLE
[Hotfix] Fix NoSuchFileException when deploy on k8s

### DIFF
--- a/amoro-ams/dist/src/main/amoro-bin/conf/config.yaml
+++ b/amoro-ams/dist/src/main/amoro-bin/conf/config.yaml
@@ -141,7 +141,7 @@ containers:
 # - name: KubernetesContainer
 #   container-impl: org.apache.amoro.server.manager.KubernetesOptimizerContainer
 #    properties:
-#     kube-config-path: ～/.kube/config
+#     kube-config-path: ~/.kube/config
 #     image: apache/amoro:{version}
 #     namespace: default
 

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -255,7 +255,7 @@ optimizer:
     enabled: true
     properties:
       namespace: "default"
-      kube-config-path: "～/.kube/config"
+      kube-config-path: "~/.kube/config"
       image: "apache/amoro:latest"
       pullPolicy: "IfNotPresent"
   extra: []

--- a/docs/admin-guides/managing-optimizers.md
+++ b/docs/admin-guides/managing-optimizers.md
@@ -55,7 +55,7 @@ containers:
   - name: KubernetesContainer
     container-impl: org.apache.amoro.server.manager.KubernetesOptimizerContainer
     properties:
-      kube-config-path: ～/.kube/config
+      kube-config-path: ~/.kube/config
       image: apache/amoro:{version}
       pullPolicy: IfNotPresent
 ```


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?

hotfix.

```
2024-06-20 03:37:44,219 ERROR [main] [org.apache.amoro.server.AmoroServiceContainer] [] - AMS encountered an unknown exception, will exist
java.lang.RuntimeException: java.nio.file.NoSuchFileException: ～/.kube/config
	at org.apache.amoro.server.manager.KubernetesOptimizerContainer.getKubeConfigContent(KubernetesOptimizerContainer.java:187) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.manager.KubernetesOptimizerContainer.init(KubernetesOptimizerContainer.java:72) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.resource.ResourceContainers$ContainerWrapper.loadResourceContainer(ResourceContainers.java:98) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.resource.ResourceContainers$ContainerWrapper.<init>(ResourceContainers.java:78) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.resource.ResourceContainers.lambda$init$0(ResourceContainers.java:45) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at java.util.ArrayList.forEach(ArrayList.java:1259) ~[?:1.8.0_412]
	at org.apache.amoro.server.resource.ResourceContainers.init(ResourceContainers.java:44) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.AmoroServiceContainer$ConfigurationHelper.initContainerConfig(AmoroServiceContainer.java:453) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.AmoroServiceContainer$ConfigurationHelper.init(AmoroServiceContainer.java:384) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.AmoroServiceContainer.initConfig(AmoroServiceContainer.java:193) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.AmoroServiceContainer.<init>(AmoroServiceContainer.java:98) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	at org.apache.amoro.server.AmoroServiceContainer.main(AmoroServiceContainer.java:104) [amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
Caused by: java.nio.file.NoSuchFileException: ～/.kube/config
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86) ~[?:1.8.0_412]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102) ~[?:1.8.0_412]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107) ~[?:1.8.0_412]
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214) ~[?:1.8.0_412]
	at java.nio.file.Files.newByteChannel(Files.java:361) ~[?:1.8.0_412]
	at java.nio.file.Files.newByteChannel(Files.java:407) ~[?:1.8.0_412]
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384) ~[?:1.8.0_412]
	at java.nio.file.Files.newInputStream(Files.java:152) ~[?:1.8.0_412]
	at org.apache.amoro.server.manager.KubernetesOptimizerContainer.getKubeConfigContent(KubernetesOptimizerContainer.java:185) ~[amoro-ams-server-0.7-SNAPSHOT.jar:0.7-SNAPSHOT]
	... 11 more
```

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->



## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
