### PR TITLE
[Hotfix] Fix the value of authType is always null

### DIFF
--- a/amoro-core/src/main/java/org/apache/amoro/utils/MixedCatalogUtil.java
+++ b/amoro-core/src/main/java/org/apache/amoro/utils/MixedCatalogUtil.java
@@ -179,26 +179,22 @@ public class MixedCatalogUtil {
     }
 
     // cover auth configs from ams with auth configs in properties
-    String authType =
-        catalogMeta.getCatalogProperties().get(CatalogMetaProperties.AUTH_CONFIGS_KEY_TYPE);
+    String authType = catalogMeta.getAuthConfigs().get(CatalogMetaProperties.AUTH_CONFIGS_KEY_TYPE);
     if (StringUtils.isNotEmpty(authType)) {
       LOG.info("TableMetaStore use auth config in properties, authType is {}", authType);
       if (CatalogMetaProperties.AUTH_CONFIGS_VALUE_TYPE_SIMPLE.equalsIgnoreCase(authType)) {
         String hadoopUsername =
             catalogMeta
-                .getCatalogProperties()
+                .getAuthConfigs()
                 .get(CatalogMetaProperties.AUTH_CONFIGS_KEY_HADOOP_USERNAME);
         builder.withSimpleAuth(hadoopUsername);
       } else if (CatalogMetaProperties.AUTH_CONFIGS_VALUE_TYPE_KERBEROS.equalsIgnoreCase(
           authType)) {
-        String krb5 =
-            catalogMeta.getCatalogProperties().get(CatalogMetaProperties.AUTH_CONFIGS_KEY_KRB5);
+        String krb5 = catalogMeta.getAuthConfigs().get(CatalogMetaProperties.AUTH_CONFIGS_KEY_KRB5);
         String keytab =
-            catalogMeta.getCatalogProperties().get(CatalogMetaProperties.AUTH_CONFIGS_KEY_KEYTAB);
+            catalogMeta.getAuthConfigs().get(CatalogMetaProperties.AUTH_CONFIGS_KEY_KEYTAB);
         String principal =
-            catalogMeta
-                .getCatalogProperties()
-                .get(CatalogMetaProperties.AUTH_CONFIGS_KEY_PRINCIPAL);
+            catalogMeta.getAuthConfigs().get(CatalogMetaProperties.AUTH_CONFIGS_KEY_PRINCIPAL);
         builder.withBase64KrbAuth(keytab, krb5, principal);
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?

As title.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

We should use `CatalogMeta#getAuthConfigs` instead of `CatalogMeta#getCatalogProperties`.
```
CatalogMeta(catalogName:test, catalogType:custom, storageConfigs:{storage.type=S3}, authConfigs:{auth.type=ak/sk}, catalogProperties:{s3.access-key-id=c, s3.secret-access-key=b, table.self-optimizing.group=test, s3.endpoint=a, catalog-impl=org.apache.iceberg.rest.ABCD, table-formats=ICEBERG, client.region=a})
```

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
