### PR TITLE
[Hotfix] Meet NPE when loading tables which use s3 storage

### DIFF
--- a/amoro-core/src/main/java/org/apache/amoro/table/TableMetaStore.java
+++ b/amoro-core/src/main/java/org/apache/amoro/table/TableMetaStore.java
@@ -510,8 +510,12 @@ public class TableMetaStore implements Serializable {
 
     private Configuration buildConfiguration(TableMetaStore metaStore) {
       Configuration configuration = new Configuration();
-      configuration.addResource(new ByteArrayInputStream(metaStore.getCoreSite()));
-      configuration.addResource(new ByteArrayInputStream(metaStore.getHdfsSite()));
+      if (!ArrayUtils.isEmpty(metaStore.getCoreSite())) {
+        configuration.addResource(new ByteArrayInputStream(metaStore.getCoreSite()));
+      }
+      if (!ArrayUtils.isEmpty(metaStore.getHdfsSite())) {
+        configuration.addResource(new ByteArrayInputStream(metaStore.getHdfsSite()));
+      }
       if (!ArrayUtils.isEmpty(metaStore.getMetaStoreSite())) {
         configuration.addResource(new ByteArrayInputStream(metaStore.getMetaStoreSite()));
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Using ams internal catalog and s3 as storage, but NPE occurs. The root cause is that 
`org.apache.amoro.server.utils.InternalTableUtil#newIcebergFileIo L86 -> Configuration conf = store.getConfiguration();`

core-site and hdfs-site is null when using s3 storage.

>  

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
