### PR TITLE
[AMORO-3033]IndexOutOfBoundsException when start up AMS during selectProcessInputFiles  because of no optimizing process_id

### DIFF
--- a/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/persistence/TaskFilesPersistence.java
+++ b/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/persistence/TaskFilesPersistence.java
@@ -46,7 +46,7 @@ public class TaskFilesPersistence {
     List<byte[]> bytes =
         persistence.getAs(
             OptimizingMapper.class, mapper -> mapper.selectProcessInputFiles(processId));
-    if (bytes == null) {
+    if (bytes == null || bytes.isEmpty()) {
       return Collections.emptyMap();
     } else {
       return SerializationUtil.simpleDeserialize(CompressUtil.unGzip(bytes.get(0)));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close https://github.com/apache/amoro/issues/3033.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- avoid IndexOutOfBoundsException

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
