### PR TITLE
[AMORO-3041] Config failOnNoGitDirectory and failOnUnableToExtractRepoInfo to false for git-commit-id-plugin

### DIFF
--- a/amoro-ams/amoro-ams-server/pom.xml
+++ b/amoro-ams/amoro-ams-server/pom.xml
@@ -387,6 +387,8 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>


### PR DESCRIPTION
## Why are the changes needed?

Close #3041 .

## Brief change log

- Config `failOnNoGitDirectory` to `false`
- Config `failOnUnableToExtractRepoInfo` to `false`, refer to https://issues.apache.org/jira/browse/FLINK-18655

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
