### PR TITLE
[AMORO_3053]Add system metric for ams service

### DIFF
--- a/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
+++ b/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
@@ -93,6 +93,7 @@ public class AmoroServiceContainer {
   private TServer tableManagementServer;
   private TServer optimizingServiceServer;
   private Javalin httpServer;
+  private AmsServiceMetrics amsServiceMetrics;
 
   public AmoroServiceContainer() throws Exception {
     initConfig();
@@ -156,6 +157,7 @@ public class AmoroServiceContainer {
 
     initHttpService();
     startHttpService();
+    registerAmsServiceMetric();
   }
 
   private void addHandlerChain(RuntimeHandlerChain chain) {
@@ -183,6 +185,10 @@ public class AmoroServiceContainer {
       terminalManager = null;
     }
     optimizingService = null;
+
+    if (amsServiceMetrics != null) {
+      amsServiceMetrics.unregister();
+    }
 
     EventsManager.dispose();
     MetricManager.dispose();
@@ -275,6 +281,11 @@ public class AmoroServiceContainer {
             + "      https://amoro.apache.org/       \n");
 
     LOG.info("Http server start at {}.", port);
+  }
+
+  private void registerAmsServiceMetric() {
+    amsServiceMetrics = new AmsServiceMetrics(MetricManager.getInstance().getGlobalRegistry());
+    amsServiceMetrics.register();
   }
 
   private void initThriftService() throws TTransportException {

--- a/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/AmsServiceMetrics.java
+++ b/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/AmsServiceMetrics.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server;
+
+import static org.apache.amoro.api.metrics.MetricDefine.defineGauge;
+
+import org.apache.amoro.api.metrics.Metric;
+import org.apache.amoro.api.metrics.MetricDefine;
+import org.apache.amoro.api.metrics.MetricKey;
+import org.apache.amoro.server.metrics.MetricRegistry;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryUsage;
+import java.util.Collections;
+import java.util.List;
+
+public class AmsServiceMetrics {
+  public static final MetricDefine AMS_STATUS_JVM_CPU_LOAD =
+      defineGauge("ams_status_jvm_cpu_load")
+          .withDescription("The recent CPU usage of the AMS.")
+          .build();
+  public static final MetricDefine AMS_STATUS_JVM_CPU_TIME =
+      defineGauge("ams_status_jvm_cpu_time")
+          .withDescription("The CPU time used by the AMS")
+          .build();
+
+  public static final MetricDefine AMS_STATUS_JVM_MEMORY_HEAP_USED =
+      defineGauge("ams_status_jvm_memory_heap_used")
+          .withDescription("The amount of heap memory currently used (in bytes) by the AMS.")
+          .build();
+
+  public static final MetricDefine AMS_STATUS_JVM_MEMORY_HEAP_COMMITTED =
+      defineGauge("ams_status_jvm_memory_heap_committed")
+          .withDescription(
+              "The amount of memory in the heap that is committed for the JVM to use (in bytes).")
+          .build();
+
+  public static final MetricDefine AMS_STATUS_JVM_MEMORY_HEAP_MAX =
+      defineGauge("ams_status_jvm_memory_heap_max")
+          .withDescription(
+              "The maximum amount of memory in the heap (in bytes), It's equal to the value specified through -Xmx.")
+          .build();
+
+  public static final MetricDefine AMS_STATUS_JVM_THREADS_COUNT =
+      defineGauge("ams_status_jvm_threads_count")
+          .withDescription("The total number of live threads used by the AMS.")
+          .build();
+
+  public static final String AMS_STATUS_JVM_GARBAGE_COLLECTOR = "ams_status_jvm_GarbageCollector";
+  private final MetricRegistry registry;
+  private List<MetricKey> registeredMetricKeys = Lists.newArrayList();
+
+  public AmsServiceMetrics(MetricRegistry registry) {
+    this.registry = registry;
+  }
+
+  public void register() {
+    registerHeapMetric();
+    registerThreadMetric();
+    registerCPuMetric();
+    registerGarbageCollectorMetrics();
+  }
+
+  public void unregister() {
+    registeredMetricKeys.forEach(registry::unregister);
+    registeredMetricKeys.clear();
+  }
+
+  private void registerHeapMetric() {
+    MemoryUsage heapMemoryUsage = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
+    registerMetric(
+        registry,
+        AMS_STATUS_JVM_MEMORY_HEAP_USED,
+        (org.apache.amoro.api.metrics.Gauge<Long>) () -> heapMemoryUsage.getUsed());
+
+    registerMetric(
+        registry,
+        AMS_STATUS_JVM_MEMORY_HEAP_COMMITTED,
+        (org.apache.amoro.api.metrics.Gauge<Long>) () -> heapMemoryUsage.getCommitted());
+
+    registerMetric(
+        registry,
+        AMS_STATUS_JVM_MEMORY_HEAP_MAX,
+        (org.apache.amoro.api.metrics.Gauge<Long>) () -> heapMemoryUsage.getMax());
+  }
+
+  private void registerThreadMetric() {
+    registerMetric(
+        registry,
+        AMS_STATUS_JVM_THREADS_COUNT,
+        (org.apache.amoro.api.metrics.Gauge<Integer>)
+            () -> ManagementFactory.getThreadMXBean().getThreadCount());
+  }
+
+  private void registerCPuMetric() {
+    final com.sun.management.OperatingSystemMXBean mxBean =
+        (com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+    registerMetric(
+        registry,
+        AMS_STATUS_JVM_CPU_LOAD,
+        (org.apache.amoro.api.metrics.Gauge<Double>) () -> mxBean.getProcessCpuLoad());
+    registerMetric(
+        registry,
+        AMS_STATUS_JVM_CPU_TIME,
+        (org.apache.amoro.api.metrics.Gauge<Long>) () -> mxBean.getProcessCpuTime());
+  }
+
+  private void registerGarbageCollectorMetrics() {
+    List<GarbageCollectorMXBean> garbageCollectorMXBeans =
+        ManagementFactory.getGarbageCollectorMXBeans();
+
+    for (final GarbageCollectorMXBean garbageCollector : garbageCollectorMXBeans) {
+      MetricDefine count = formatGarbageCollectorMetricDefine(garbageCollector.getName(), "count");
+      MetricDefine time = formatGarbageCollectorMetricDefine(garbageCollector.getName(), "time");
+      registerMetric(
+          registry,
+          count,
+          (org.apache.amoro.api.metrics.Gauge<Long>) () -> garbageCollector.getCollectionCount());
+      registerMetric(
+          registry,
+          time,
+          (org.apache.amoro.api.metrics.Gauge<Long>) () -> garbageCollector.getCollectionTime());
+    }
+  }
+
+  private MetricDefine formatGarbageCollectorMetricDefine(
+      String garbageCollector, String identify) {
+    return defineGauge(
+            AMS_STATUS_JVM_GARBAGE_COLLECTOR
+                + "_"
+                + garbageCollector.replaceAll("\\s", "_")
+                + "_"
+                + identify)
+        .withDescription("The " + identify + " of the JVM's Garbage Collector.")
+        .build();
+  }
+
+  private void registerMetric(MetricRegistry registry, MetricDefine define, Metric metric) {
+    MetricKey key = registry.register(define, Collections.emptyMap(), metric);
+    registeredMetricKeys.add(key);
+  }
+}

--- a/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/AmsServiceMetrics.java
+++ b/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/AmsServiceMetrics.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class AmsServiceMetrics {
   public static final MetricDefine AMS_STATUS_JVM_CPU_LOAD =
       defineGauge("ams_status_jvm_cpu_load")
-          .withDescription("The recent CPU usage of the AMS.")
+          .withDescription("The recent CPU usage of the AMS")
           .build();
   public static final MetricDefine AMS_STATUS_JVM_CPU_TIME =
       defineGauge("ams_status_jvm_cpu_time")
@@ -44,24 +44,24 @@ public class AmsServiceMetrics {
 
   public static final MetricDefine AMS_STATUS_JVM_MEMORY_HEAP_USED =
       defineGauge("ams_status_jvm_memory_heap_used")
-          .withDescription("The amount of heap memory currently used (in bytes) by the AMS.")
+          .withDescription("The amount of heap memory currently used (in bytes) by the AMS")
           .build();
 
   public static final MetricDefine AMS_STATUS_JVM_MEMORY_HEAP_COMMITTED =
       defineGauge("ams_status_jvm_memory_heap_committed")
           .withDescription(
-              "The amount of memory in the heap that is committed for the JVM to use (in bytes).")
+              "The amount of memory in the heap that is committed for the JVM to use (in bytes)")
           .build();
 
   public static final MetricDefine AMS_STATUS_JVM_MEMORY_HEAP_MAX =
       defineGauge("ams_status_jvm_memory_heap_max")
           .withDescription(
-              "The maximum amount of memory in the heap (in bytes), It's equal to the value specified through -Xmx.")
+              "The maximum amount of memory in the heap (in bytes), It's equal to the value specified through -Xmx")
           .build();
 
   public static final MetricDefine AMS_STATUS_JVM_THREADS_COUNT =
       defineGauge("ams_status_jvm_threads_count")
-          .withDescription("The total number of live threads used by the AMS.")
+          .withDescription("The total number of live threads used by the AMS")
           .build();
 
   public static final String AMS_STATUS_JVM_GARBAGE_COLLECTOR = "ams_status_jvm_GarbageCollector";
@@ -149,7 +149,7 @@ public class AmsServiceMetrics {
                 + garbageCollector.replaceAll("\\s", "_")
                 + "_"
                 + identify)
-        .withDescription("The " + identify + " of the JVM's Garbage Collector.")
+        .withDescription("The " + identify + " of the JVM's Garbage Collector")
         .build();
   }
 

--- a/amoro-ams/amoro-ams-server/src/test/java/org/apache/amoro/server/TestAmsServiceMetrics.java
+++ b/amoro-ams/amoro-ams-server/src/test/java/org/apache/amoro/server/TestAmsServiceMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server;
+
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_CPU_LOAD;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_CPU_TIME;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_MEMORY_HEAP_COMMITTED;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_MEMORY_HEAP_MAX;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_MEMORY_HEAP_USED;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_THREADS_COUNT;
+
+import org.apache.amoro.api.metrics.Gauge;
+import org.apache.amoro.api.metrics.MetricKey;
+import org.apache.amoro.server.manager.MetricManager;
+import org.apache.amoro.server.metrics.MetricRegistry;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+public class TestAmsServiceMetrics {
+  private static final AmsEnvironment amsEnv = AmsEnvironment.getIntegrationInstances();
+
+  @BeforeAll
+  public static void before() throws Exception {
+    amsEnv.start();
+  }
+
+  @Test
+  public void testAmsServiceMetrics() throws Exception {
+    MetricRegistry registry = MetricManager.getInstance().getGlobalRegistry();
+    Gauge<Long> heapMx =
+        (Gauge<Long>)
+            registry
+                .getMetrics()
+                .get(new MetricKey(AMS_STATUS_JVM_MEMORY_HEAP_MAX, Collections.emptyMap()));
+    Assert.assertTrue(heapMx.getValue().longValue() > 0);
+
+    Gauge<Long> heapUsed =
+        (Gauge<Long>)
+            registry
+                .getMetrics()
+                .get(new MetricKey(AMS_STATUS_JVM_MEMORY_HEAP_USED, Collections.emptyMap()));
+    Assert.assertTrue(heapUsed.getValue().longValue() > 0);
+
+    Gauge<Long> heapCommitted =
+        (Gauge<Long>)
+            registry
+                .getMetrics()
+                .get(new MetricKey(AMS_STATUS_JVM_MEMORY_HEAP_COMMITTED, Collections.emptyMap()));
+    Assert.assertTrue(heapCommitted.getValue().longValue() > 0);
+
+    Gauge<Integer> threadsCount =
+        (Gauge<Integer>)
+            registry
+                .getMetrics()
+                .get(new MetricKey(AMS_STATUS_JVM_THREADS_COUNT, Collections.emptyMap()));
+    Assert.assertTrue(threadsCount.getValue().intValue() > 0);
+
+    Gauge<Double> cpuLoad =
+        (Gauge<Double>)
+            registry
+                .getMetrics()
+                .get(new MetricKey(AMS_STATUS_JVM_CPU_LOAD, Collections.emptyMap()));
+    Assert.assertNotNull(cpuLoad);
+
+    Gauge<Long> cpuTime =
+        (Gauge<Long>)
+            registry
+                .getMetrics()
+                .get(new MetricKey(AMS_STATUS_JVM_CPU_TIME, Collections.emptyMap()));
+    Assert.assertTrue(cpuTime.getValue().longValue() > 0);
+
+    amsEnv.stop();
+  }
+}

--- a/amoro-ams/amoro-ams-server/src/test/java/org/apache/amoro/server/TestAmsServiceMetrics.java
+++ b/amoro-ams/amoro-ams-server/src/test/java/org/apache/amoro/server/TestAmsServiceMetrics.java
@@ -18,14 +18,17 @@
 
 package org.apache.amoro.server;
 
-import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_CPU_LOAD;
-import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_CPU_TIME;
-import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_MEMORY_HEAP_COMMITTED;
-import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_MEMORY_HEAP_MAX;
-import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_MEMORY_HEAP_USED;
-import static org.apache.amoro.server.AmsServiceMetrics.AMS_STATUS_JVM_THREADS_COUNT;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_CPU_LOAD;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_CPU_TIME;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_GARBAGE_COLLECTOR_COUNT;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_GARBAGE_COLLECTOR_TIME;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_MEMORY_HEAP_COMMITTED;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_MEMORY_HEAP_MAX;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_MEMORY_HEAP_USED;
+import static org.apache.amoro.server.AmsServiceMetrics.AMS_JVM_THREADS_COUNT;
 
 import org.apache.amoro.api.metrics.Gauge;
+import org.apache.amoro.api.metrics.Metric;
 import org.apache.amoro.api.metrics.MetricKey;
 import org.apache.amoro.server.manager.MetricManager;
 import org.apache.amoro.server.metrics.MetricRegistry;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.Map;
 
 public class TestAmsServiceMetrics {
   private static final AmsEnvironment amsEnv = AmsEnvironment.getIntegrationInstances();
@@ -50,43 +54,55 @@ public class TestAmsServiceMetrics {
         (Gauge<Long>)
             registry
                 .getMetrics()
-                .get(new MetricKey(AMS_STATUS_JVM_MEMORY_HEAP_MAX, Collections.emptyMap()));
+                .get(new MetricKey(AMS_JVM_MEMORY_HEAP_MAX, Collections.emptyMap()));
     Assert.assertTrue(heapMx.getValue().longValue() > 0);
+    registry.unregister(new MetricKey(AMS_JVM_MEMORY_HEAP_MAX, Collections.emptyMap()));
 
     Gauge<Long> heapUsed =
         (Gauge<Long>)
             registry
                 .getMetrics()
-                .get(new MetricKey(AMS_STATUS_JVM_MEMORY_HEAP_USED, Collections.emptyMap()));
+                .get(new MetricKey(AMS_JVM_MEMORY_HEAP_USED, Collections.emptyMap()));
     Assert.assertTrue(heapUsed.getValue().longValue() > 0);
+    registry.unregister(new MetricKey(AMS_JVM_MEMORY_HEAP_USED, Collections.emptyMap()));
 
     Gauge<Long> heapCommitted =
         (Gauge<Long>)
             registry
                 .getMetrics()
-                .get(new MetricKey(AMS_STATUS_JVM_MEMORY_HEAP_COMMITTED, Collections.emptyMap()));
+                .get(new MetricKey(AMS_JVM_MEMORY_HEAP_COMMITTED, Collections.emptyMap()));
     Assert.assertTrue(heapCommitted.getValue().longValue() > 0);
+    registry.unregister(new MetricKey(AMS_JVM_MEMORY_HEAP_COMMITTED, Collections.emptyMap()));
 
     Gauge<Integer> threadsCount =
         (Gauge<Integer>)
-            registry
-                .getMetrics()
-                .get(new MetricKey(AMS_STATUS_JVM_THREADS_COUNT, Collections.emptyMap()));
+            registry.getMetrics().get(new MetricKey(AMS_JVM_THREADS_COUNT, Collections.emptyMap()));
     Assert.assertTrue(threadsCount.getValue().intValue() > 0);
+    registry.unregister(new MetricKey(AMS_JVM_THREADS_COUNT, Collections.emptyMap()));
 
     Gauge<Double> cpuLoad =
         (Gauge<Double>)
-            registry
-                .getMetrics()
-                .get(new MetricKey(AMS_STATUS_JVM_CPU_LOAD, Collections.emptyMap()));
+            registry.getMetrics().get(new MetricKey(AMS_JVM_CPU_LOAD, Collections.emptyMap()));
     Assert.assertNotNull(cpuLoad);
+    registry.unregister(new MetricKey(AMS_JVM_CPU_LOAD, Collections.emptyMap()));
 
     Gauge<Long> cpuTime =
         (Gauge<Long>)
-            registry
-                .getMetrics()
-                .get(new MetricKey(AMS_STATUS_JVM_CPU_TIME, Collections.emptyMap()));
+            registry.getMetrics().get(new MetricKey(AMS_JVM_CPU_TIME, Collections.emptyMap()));
     Assert.assertTrue(cpuTime.getValue().longValue() > 0);
+    registry.unregister(new MetricKey(AMS_JVM_CPU_TIME, Collections.emptyMap()));
+
+    Map<MetricKey, Metric> metrics = registry.getMetrics();
+    Assert.assertTrue(
+        metrics.keySet().stream()
+            .anyMatch(
+                key ->
+                    key.getDefine().getName().equals(AMS_JVM_GARBAGE_COLLECTOR_COUNT.getName())));
+
+    Assert.assertTrue(
+        metrics.keySet().stream()
+            .anyMatch(
+                key -> key.getDefine().getName().equals(AMS_JVM_GARBAGE_COLLECTOR_TIME.getName())));
 
     amsEnv.stop();
   }

--- a/docs/user-guides/metrics.md
+++ b/docs/user-guides/metrics.md
@@ -70,3 +70,16 @@ Amoro has supported built-in metrics to measure status of table self-optimizing 
 | optimizer_group_optimizer_instances    | Gauge  | group | Number of optimizer instances in optimizer group |
 | optimizer_group_memory_bytes_allocated | Gauge  | group | Memory bytes allocated in optimizer group        |
 | optimizer_group_threads                | Gauge  | group | Number of total threads in optimizer group       |
+
+
+## Ams service metrics
+| Metric Name                                                   | Type   | Tags  | Description                                                      |
+|---------------------------------------------------------------|--------|-------|------------------------------------------------------------------|
+| ams_status_jvm_cpu_load                                       | Gauge  |       | The recent CPU usage of the AMS                                  |
+| ams_status_jvm_cpu_time                                       | Gauge  |       | The CPU time used by the AMS                                     |
+| ams_status_jvm_memory_heap_used                               | Gauge  |       | The amount of heap memory currently used (in bytes) by the AMS   |
+| ams_status_jvm_memory_heap_committed                          | Gauge  |       | The amount of memory in the heap committed for JVM use (bytes)   |
+| ams_status_jvm_memory_heap_max                                | Gauge  |       | The maximum heap memory (bytes), set by -Xmx JVM argument        |
+| ams_status_jvm_threads_count                                  | Gauge  |       | The total number of live threads used by the AMS                 |
+| ams_status_jvm_GarbageCollector_`{GarbageCollector}`_count    | Gauge  |       | The count of the JVM's Garbage Collector,such as G1 Young        |
+| ams_status_jvm_GarbageCollector_`{GarbageCollector}`_time     | Gauge  |       | The time spent by the JVM's Garbage Collector,such as G1 Young   |

--- a/docs/user-guides/metrics.md
+++ b/docs/user-guides/metrics.md
@@ -73,13 +73,13 @@ Amoro has supported built-in metrics to measure status of table self-optimizing 
 
 
 ## Ams service metrics
-| Metric Name                                                   | Type   | Tags  | Description                                                      |
-|---------------------------------------------------------------|--------|-------|------------------------------------------------------------------|
-| ams_status_jvm_cpu_load                                       | Gauge  |       | The recent CPU usage of the AMS                                  |
-| ams_status_jvm_cpu_time                                       | Gauge  |       | The CPU time used by the AMS                                     |
-| ams_status_jvm_memory_heap_used                               | Gauge  |       | The amount of heap memory currently used (in bytes) by the AMS   |
-| ams_status_jvm_memory_heap_committed                          | Gauge  |       | The amount of memory in the heap committed for JVM use (bytes)   |
-| ams_status_jvm_memory_heap_max                                | Gauge  |       | The maximum heap memory (bytes), set by -Xmx JVM argument        |
-| ams_status_jvm_threads_count                                  | Gauge  |       | The total number of live threads used by the AMS                 |
-| ams_status_jvm_GarbageCollector_`{GarbageCollector}`_count    | Gauge  |       | The count of the JVM's Garbage Collector,such as G1 Young        |
-| ams_status_jvm_GarbageCollector_`{GarbageCollector}`_time     | Gauge  |       | The time spent by the JVM's Garbage Collector,such as G1 Young   |
+| Metric Name                                            | Type   |     Tags        | Description                                                      |
+|--------------------------------------------------------|--------|-----------------|------------------------------------------------------------------|
+| ams_jvm_cpu_load                                       | Gauge  |                 | The recent CPU usage of the AMS                                  |
+| ams_jvm_cpu_time                                       | Gauge  |                 | The CPU time used by the AMS                                     |
+| ams_jvm_memory_heap_used                               | Gauge  |                 | The amount of heap memory currently used (in bytes) by the AMS   |
+| ams_jvm_memory_heap_committed                          | Gauge  |                 | The amount of memory in the heap committed for JVM use (bytes)   |
+| ams_jvm_memory_heap_max                                | Gauge  |                 | The maximum heap memory (bytes), set by -Xmx JVM argument        |
+| ams_jvm_threads_count                                  | Gauge  |                 | The total number of live threads used by the AMS                 |
+| ams_jvm_garbage_collector_count                        | Gauge  |garbage_collector| The count of the JVM's Garbage Collector, such as G1 Young        |
+| ams_jvm_garbage_collector_time                         | Gauge  |garbage_collector| The time spent by the JVM's Garbage Collector, such as G1 Young   |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close https://github.com/apache/amoro/issues/3053.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->
1. collect system metric for jvm  using api from jdk
it's refer from flink jvm system metric https://github.com/apache/flink/blob/af7d2b3ab0e0ecc4157005704bebac9c767f2e1a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java#L129
2. register metric in AmoroServiceContainer  during start ams httpserver by using amoro metric plugin  



## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

I had test HEAP_USED,HEAP_COMMITTED,HEAP_MAX,THREADS_COUNT ,the count collected by jdk api is meet expectations
But I'm not sure  the number of CPU_LOAD and CPU_TIME collected by jdk api is equals to the number collect from machinery system

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
