### PR TITLE
[AMORO-3091] Support TIMESTAMP in `MixedDataFiles.fromPartitionString()`

### DIFF
--- a/amoro-core/src/main/java/org/apache/amoro/utils/MixedDataFiles.java
+++ b/amoro-core/src/main/java/org/apache/amoro/utils/MixedDataFiles.java
@@ -95,6 +95,12 @@ public class MixedDataFiles {
         return new BigDecimal(asString);
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
+      case TIMESTAMP:
+        if (((Types.TimestampType) type).shouldAdjustToUTC()) {
+          return Literal.of(asString).to(Types.TimestampType.withZone()).value();
+        } else {
+          return Literal.of(asString).to(Types.TimestampType.withoutZone()).value();
+        }
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);

--- a/amoro-core/src/test/java/org/apache/amoro/utils/TestMixedDataFiles.java
+++ b/amoro-core/src/test/java/org/apache/amoro/utils/TestMixedDataFiles.java
@@ -217,5 +217,5 @@ public class TestMixedDataFiles {
     StructLikeWrapper p2 = StructLikeWrapper.forType(spec.partitionType());
     p2.set(partitionData);
     Assert.assertEquals(p1, p2);
-  } 
+  }
 }


### PR DESCRIPTION
fix issues [3091](https://github.com/apache/amoro/issues/3091)
support TIMESTAMP in `MixedDataFiles.fromPartitionString()`