### PR TITLE
[AMORO-3097] Improve the default configuration for AMS

### DIFF
--- a/amoro-ams/dist/src/main/amoro-bin/conf/config.yaml
+++ b/amoro-ams/dist/src/main/amoro-bin/conf/config.yaml
@@ -120,7 +120,6 @@ ams:
 
   terminal:
     backend: local
-    local.spark.sql.iceberg.handle-timestamp-without-timezone: false
     result:
       limit: 1000
     stop-on-error: false
@@ -128,6 +127,7 @@ ams:
       timeout: 30
     local:
       using-session-catalog-for-hive: false
+      spark.sql.iceberg.handle-timestamp-without-timezone: false
 
 #  Kyuubi terminal backend configuration.
 #  terminal:

--- a/amoro-ams/dist/src/main/amoro-bin/conf/config.yaml
+++ b/amoro-ams/dist/src/main/amoro-bin/conf/config.yaml
@@ -33,6 +33,7 @@ ams:
 
   http-server:
     bind-port: 1630
+    rest-auth-type: token
 
   refresh-external-catalogs:
     interval: 180000 # 3min
@@ -71,11 +72,11 @@ ams:
     thread-count: 10
 
   sync-hive-tables:
-    enabled: true
+    enabled: false
     thread-count: 10
 
   data-expiration:
-    enabled: false
+    enabled: true
     thread-count: 10
     interval: 1d
 
@@ -83,6 +84,9 @@ ams:
     enabled: true
     thread-count: 3
     interval: 60000 # 1min
+
+  table-manifest-io:
+    thread-count: 20
 
   database:
     type: derby
@@ -117,6 +121,13 @@ ams:
   terminal:
     backend: local
     local.spark.sql.iceberg.handle-timestamp-without-timezone: false
+    result:
+      limit: 1000
+    stop-on-error: false
+    session:
+      timeout: 30
+    local:
+      using-session-catalog-for-hive: false
 
 #  Kyuubi terminal backend configuration.
 #  terminal:


### PR DESCRIPTION
## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
Close #3097 
The current default configurations of AMS are somewhat unreasonable, and we should improve them.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

Turn off the sync-hive-tables service (change ams.sync-hive-tables.enabled to false).
Turn on the data-expiration service (change ams.data-expiration.enabled to true).
Add table-manifest-io.thread-count configuration example (add ams.table-manifest-io.thread-count and set default value to 20)
Add http-server.rest-auth-type configuration example (add ams.http-server.rest-auth-type and set default value to token)
Add terminal.result.limit configuration example(add terminal.result.limit and set default value to 1000)
Add terminal.stop-on-error configuration example(add terminal.stop-on-error and set default value to false)
Add terminal.session.timeout configuration example(add terminal.session.timeout and set default value to 30)
Add local.using-session-catalog-for-hive example (add terminal.local.using-session-catalog-for-hive and set default value to false)


