### PR TITLE
[AMORO-3152] Make git-commit-plugin fail on no git dir configurable

### DIFF
--- a/amoro-ams/amoro-ams-server/pom.xml
+++ b/amoro-ams/amoro-ams-server/pom.xml
@@ -34,6 +34,10 @@
     <name>Amoro Project AMS Server</name>
     <url>https://amoro.apache.org</url>
 
+    <properties>
+        <git-commit-id-plugin.fail-on-no-git-dir>false</git-commit-id-plugin.fail-on-no-git-dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.amoro</groupId>
@@ -415,8 +419,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
-                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+                    <failOnNoGitDirectory>${git-commit-id-plugin.fail-on-no-git-dir}</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>${git-commit-id-plugin.fail-on-no-git-dir}</failOnUnableToExtractRepoInfo>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>
@@ -490,6 +494,12 @@
                     <artifactId>amoro-hudi-format</artifactId>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>fail-on-no-git-dir</id>
+            <properties>
+                <git-commit-id-plugin.fail-on-no-git-dir>true</git-commit-id-plugin.fail-on-no-git-dir>
+            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Why are the changes needed?

We add conf to fail silent when no git dir before, so that it would not block the
release process, but it may not fail in normal mode also, in this commit
we move the configuration to profile and can be enabled in the release process

Close #3125 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
