### PR TITLE
[AMORO-3132]High available service should not close curator client before LeaderLatch closing

### DIFF
--- a/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/HighAvailabilityContainer.java
+++ b/amoro-ams/amoro-ams-server/src/main/java/org/apache/amoro/server/HighAvailabilityContainer.java
@@ -122,8 +122,8 @@ public class HighAvailabilityContainer implements LeaderLatchListener {
   public void close() {
     if (leaderLatch != null) {
       try {
-        this.zkClient.close();
         this.leaderLatch.close();
+        this.zkClient.close();
       } catch (IOException e) {
         LOG.error("Close high availability services failed", e);
       }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3132 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->
Refact the logic of closing resources in HighAvailabiltyContainer.
-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
