### PR TITLE
[Improvement]: Disable jmxremote when jmxremote.port is not set.

### DIFF
--- a/dist/src/main/amoro-bin/bin/ams.sh
+++ b/dist/src/main/amoro-bin/bin/ams.sh
@@ -28,9 +28,6 @@ JAVA_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=200 \
 -Xloggc:$AMORO_LOG_DIR/gc.log -XX:+PrintGCDateStamps -XX:+IgnoreUnrecognizedVMOptions -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M \
 -Xms${JVM_XMS_CONFIG}m -Xmx${JVM_XMX_CONFIG}m \
 -verbose:gc -XX:+PrintGCDetails \
--Dcom.sun.management.jmxremote \
--Dcom.sun.management.jmxremote.ssl=false \
--Dcom.sun.management.jmxremote.authenticate=false \
 --add-opens=java.base/java.lang=ALL-UNNAMED \
 --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
 --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
@@ -47,7 +44,11 @@ JAVA_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=200 \
 "
 
 if [ -n "$JMX_REMOTE_PORT_CONFIG" ];then
-        JAVA_OPTS="${JAVA_OPTS} -Dcom.sun.management.jmxremote.port=${JMX_REMOTE_PORT_CONFIG} "
+  JAVA_OPTS="${JAVA_OPTS} -Dcom.sun.management.jmxremote.port=${JMX_REMOTE_PORT_CONFIG} \
+  -Dcom.sun.management.jmxremote \
+  -Dcom.sun.management.jmxremote.ssl=false \
+  -Dcom.sun.management.jmxremote.authenticate=false \
+  "
 fi
 
 if [ ! -z "$JVM_EXTRA_CONFIG" ];then


### PR DESCRIPTION
 
## Why are the changes needed?

When `-Dcom.sun.management.jmxremote` is set, jvm will listen on a random port as jmxremote.port.  

## Brief change log

- Only set jmxremote params when jmxremote.port is set.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
