### PR TITLE
[AMORO-3143] Supports executing the spotless apply command on a single module

### DIFF
--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-format/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-format/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <flink.version>1.17.1</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-iceberg-bridge/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-iceberg-bridge/pom.xml
@@ -35,6 +35,7 @@
         <assertj.version>3.21.0</assertj.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <flink.version>1.17.1</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
@@ -38,6 +38,7 @@
         <assertj.version>3.21.0</assertj.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <flink.version>1.17.1</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/pom.xml
@@ -51,5 +51,6 @@
         <kafka.version>2.4.1</kafka.version>
         <gson.version>2.9.0</gson.version>
         <jackson.vesion>2.10.2</jackson.vesion>
+        <root.dir>${project.parent.parent.basedir}</root.dir>
     </properties>
 </project>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.15/amoro-mixed-flink-1.15/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.15/amoro-mixed-flink-1.15/pom.xml
@@ -38,6 +38,7 @@
         <assertj.version>3.21.0</assertj.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <flink.version>1.15.3</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.15/amoro-mixed-flink-runtime-1.15/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.15/amoro-mixed-flink-runtime-1.15/pom.xml
@@ -33,6 +33,7 @@
 
     <properties>
         <flink.version>1.15.3</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.16/amoro-mixed-flink-1.16/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.16/amoro-mixed-flink-1.16/pom.xml
@@ -38,6 +38,7 @@
         <assertj.version>3.21.0</assertj.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <flink.version>1.16.2</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.16/amoro-mixed-flink-runtime-1.16/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.16/amoro-mixed-flink-runtime-1.16/pom.xml
@@ -33,6 +33,7 @@
 
     <properties>
         <flink.version>1.16.2</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.17/amoro-mixed-flink-1.17/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.17/amoro-mixed-flink-1.17/pom.xml
@@ -38,6 +38,7 @@
         <assertj.version>3.21.0</assertj.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <flink.version>1.17.1</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.17/amoro-mixed-flink-runtime-1.17/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.17/amoro-mixed-flink-runtime-1.17/pom.xml
@@ -33,6 +33,7 @@
 
     <properties>
         <flink.version>1.17.1</flink.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-hive/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-hive/pom.xml
@@ -31,6 +31,10 @@
     <name>Amoro Project Mixed Hive Format</name>
     <url>https://amoro.apache.org</url>
 
+    <properties>
+        <root.dir>${project.parent.parent.basedir}</root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.amoro</groupId>

--- a/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <spark.version>3.2.4</spark.version>
         <scala.version>2.12.15</scala.version>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
     <dependencies>
 

--- a/amoro-format-mixed/amoro-mixed-spark/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/pom.xml
@@ -31,6 +31,10 @@
     <name>Amoro Project Mixed Format Spark Parent</name>
     <url>https://amoro.apache.org</url>
 
+    <properties>
+        <root.dir>${project.parent.parent.basedir}</root.dir>
+    </properties>
+
     <modules>
         <module>amoro-mixed-spark-3-common</module>
         <module>v3.2/amoro-mixed-spark-3.2</module>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-3.2/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-3.2/pom.xml
@@ -38,6 +38,7 @@
         <spark.version>3.2.4</spark.version>
         <scala.version>2.12.15</scala.version>
         <scala.collection.compat>2.11.0</scala.collection.compat>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-runtime-3.2/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-runtime-3.2/pom.xml
@@ -33,6 +33,10 @@
     <name>Amoro Project Mixed Format Spark 3.2 Runtime</name>
     <url>https://amoro.apache.org</url>
 
+    <properties>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.amoro</groupId>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/pom.xml
@@ -38,6 +38,7 @@
         <spark.version>3.3.2</spark.version>
         <scala.version>2.12.15</scala.version>
         <scala.collection.compat>2.11.0</scala.collection.compat>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-runtime-3.3/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-runtime-3.3/pom.xml
@@ -33,6 +33,10 @@
     <name>Amoro Project Mixed Format Spark 3.3 Runtime</name>
     <url>https://amoro.apache.org</url>
 
+    <properties>
+        <root.dir>${project.parent.parent.parent.basedir}</root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.amoro</groupId>

--- a/amoro-format-mixed/amoro-mixed-trino/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-trino/pom.xml
@@ -50,6 +50,7 @@
         <jol.version>0.16</jol.version>
         <surefire-testng.version>3.2.5</surefire-testng.version>
         <skip-build-mixed-format-trino>true</skip-build-mixed-format-trino>
+        <root.dir>${project.parent.parent.basedir}</root.dir>
     </properties>
 
     <dependencies>

--- a/amoro-format-mixed/pom.xml
+++ b/amoro-format-mixed/pom.xml
@@ -33,6 +33,10 @@
     <name>Amoro Project Mixed Format Parent</name>
     <url>https://amoro.apache.org</url>
 
+    <properties>
+        <root.dir>${project.parent.basedir}</root.dir>
+    </properties>
+
     <modules>
         <module>amoro-mixed-flink</module>
         <module>amoro-mixed-spark</module>


### PR DESCRIPTION
## Why are the changes needed?

Close #3143.

## Brief change log

- Modify the configuration file address of the spotless plug-in

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
