### PR TITLE
[Amoro-3196]: Fix scheduling hungry issue

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/SchedulingPolicy.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/SchedulingPolicy.java
@@ -78,9 +78,9 @@ public class SchedulingPolicy {
 
   private Comparator<TableRuntime> createSorterByPolicy() {
     if (policyName.equalsIgnoreCase(QUOTA)) {
-        return new QuotaOccupySorter();
+      return new QuotaOccupySorter();
     } else if (policyName.equalsIgnoreCase(BALANCED)) {
-        return new BalancedSorter();
+      return new BalancedSorter();
     } else {
       throw new IllegalArgumentException("Illegal scheduling policy: " + policyName);
     }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/SchedulingPolicy.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/SchedulingPolicy.java
@@ -41,7 +41,6 @@ public class SchedulingPolicy {
 
   private final Map<ServerTableIdentifier, TableRuntime> tableRuntimeMap = new HashMap<>();
   private volatile String policyName;
-  private Comparator<TableRuntime> tableSorter;
   private final Lock tableLock = new ReentrantLock();
 
   public SchedulingPolicy(ResourceGroup group) {
@@ -55,17 +54,6 @@ public class SchedulingPolicy {
           Optional.ofNullable(optimizerGroup.getProperties())
               .orElseGet(Maps::newHashMap)
               .getOrDefault(SCHEDULING_POLICY_PROPERTY_NAME, QUOTA);
-      if (policyName.equalsIgnoreCase(QUOTA)) {
-        if (tableSorter == null || !(tableSorter instanceof QuotaOccupySorter)) {
-          tableSorter = new QuotaOccupySorter();
-        }
-      } else if (policyName.equalsIgnoreCase(BALANCED)) {
-        if (tableSorter == null || !(tableSorter instanceof BalancedSorter)) {
-          tableSorter = new BalancedSorter();
-        }
-      } else {
-        throw new IllegalArgumentException("Illegal scheduling policy: " + policyName);
-      }
     } finally {
       tableLock.unlock();
     }
@@ -81,10 +69,20 @@ public class SchedulingPolicy {
       fillSkipSet(skipSet);
       return tableRuntimeMap.values().stream()
           .filter(tableRuntime -> !skipSet.contains(tableRuntime.getTableIdentifier()))
-          .min(tableSorter)
+          .min(createSorterByPolicy())
           .orElse(null);
     } finally {
       tableLock.unlock();
+    }
+  }
+
+  private Comparator<TableRuntime> createSorterByPolicy() {
+    if (policyName.equalsIgnoreCase(QUOTA)) {
+        return new QuotaOccupySorter();
+    } else if (policyName.equalsIgnoreCase(BALANCED)) {
+        return new BalancedSorter();
+    } else {
+      throw new IllegalArgumentException("Illegal scheduling policy: " + policyName);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3196.

The real issue is scheduling hunger problem
## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

The table runtime quotas are cached in the sorter once it has been calculated.
The correct logic is calculating quota on every single scheduling phase, and only cache quota result in a single phase.

So the fix is create a sorter for every schedule call.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
