### PR TITLE
[Improvement] Remove not necessary imports

### DIFF
--- a/amoro-web/src/views/overview/components/MultipleDataCard.vue
+++ b/amoro-web/src/views/overview/components/MultipleDataCard.vue
@@ -18,10 +18,10 @@ limitations under the License.
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { defineProps } from 'vue'
 import type { IKeyAndValue } from '@/types/common.type'
 
 const props = defineProps<{ title: string, data: IKeyAndValue[] }>()
+
 const { t } = useI18n()
 </script>
 

--- a/amoro-web/src/views/overview/components/SingleDataCard.vue
+++ b/amoro-web/src/views/overview/components/SingleDataCard.vue
@@ -17,8 +17,6 @@ limitations under the License.
 / -->
 
 <script setup lang="ts">
-import { defineProps } from 'vue'
-
 const props = defineProps<{ title: string, value: string }>()
 </script>
 


### PR DESCRIPTION
It is not necessary to import `defineProps` api about vue.

![image](https://github.com/user-attachments/assets/4d00dd43-b0f6-49ee-a438-65e8a62a102d)
