### PR TITLE
[hotfix] ams-mysql-init.sql fix error init

### DIFF
--- a/amoro-ams/src/main/resources/mysql/ams-mysql-init.sql
+++ b/amoro-ams/src/main/resources/mysql/ams-mysql-init.sql
@@ -122,8 +122,7 @@ CREATE TABLE `table_runtime`
     `last_major_optimizing_time`    timestamp NULL DEFAULT NULL COMMENT 'Latest Major Optimize time for all partitions',
     `last_minor_optimizing_time`    timestamp NULL DEFAULT NULL COMMENT 'Latest Minor Optimize time for all partitions',
     `last_full_optimizing_time`     timestamp NULL DEFAULT NULL COMMENT 'Latest Full Optimize time for all partitions',
-    `optimizing_status_code`        int DEFAULT 700 COMMENT 'Table optimize status code: 100(FULL_OPTIMIZING),' ||
-        ' 200(MAJOR_OPTIMIZING), 300(MINOR_OPTIMIZING), 400(COMMITTING), 500(PLANING), 600(PENDING), 700(IDLE)',
+    `optimizing_status_code`        int DEFAULT 700 COMMENT 'Table optimize status code: 100(FULL_OPTIMIZING), 200(MAJOR_OPTIMIZING), 300(MINOR_OPTIMIZING), 400(COMMITTING), 500(PLANING), 600(PENDING), 700(IDLE)',
     `optimizing_status_start_time`  timestamp default CURRENT_TIMESTAMP COMMENT 'Table optimize status start time',
     `optimizing_process_id`         bigint(20) NOT NULL COMMENT 'optimizing_procedure UUID',
     `optimizer_group`               varchar(64) NOT NULL,
@@ -132,8 +131,8 @@ CREATE TABLE `table_runtime`
     `pending_input`                 mediumtext,
     `table_summary`                 mediumtext,
     PRIMARY KEY (`table_id`),
-    UNIQUE KEY `table_index` (`catalog_name`,`db_name`,`table_name`)
-    INDEX idx_optimizer_status_and_time (optimizing_status_code, optimizing_status_start_time DESC);
+    UNIQUE KEY `table_index` (`catalog_name`,`db_name`,`table_name`),
+    INDEX idx_optimizer_status_and_time (optimizing_status_code, optimizing_status_start_time DESC)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'Optimize running information of each table' ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `table_optimizing_process`


### PR DESCRIPTION
## Why are the changes needed?

In ams-mysql-init.sql, the SQL for creating the table_runtime table is incorrect, which will cause the service to fail to start when redeploying Amoro.



