### PR TITLE
[AMORO-3220] Optimize table summary metrics to fetch data

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/plan/OptimizingEvaluator.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/plan/OptimizingEvaluator.java
@@ -37,11 +37,14 @@ import org.apache.amoro.table.MixedTable;
 import org.apache.amoro.utils.MixedTableUtil;
 import org.apache.amoro.utils.TablePropertyUtil;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,6 +180,13 @@ public class OptimizingEvaluator {
     if (!isInitialized) {
       initEvaluator();
     }
+    // Dangling delete files will cause the data scanned by TableScan
+    // to be inconsistent with the snapshot summary of iceberg
+    if (TableFormat.ICEBERG == mixedTable.format()) {
+      Snapshot snapshot = mixedTable.asUnkeyedTable().snapshot(currentSnapshot.snapshotId());
+      return new PendingInput(partitionPlanMap.values(), snapshot);
+    }
+
     return new PendingInput(partitionPlanMap.values());
   }
 
@@ -191,37 +201,73 @@ public class OptimizingEvaluator {
 
     @JsonIgnore private final Map<Integer, Set<StructLike>> partitions = Maps.newHashMap();
 
+    private int totalFileCount = 0;
+    private long totalFileSize = 0L;
+    private long totalFileRecords = 0L;
     private int dataFileCount = 0;
-    private long dataFileSize = 0;
-    private long dataFileRecords = 0;
+    private long dataFileSize = 0L;
+    private long dataFileRecords = 0L;
     private int equalityDeleteFileCount = 0;
     private int positionalDeleteFileCount = 0;
     private long positionalDeleteBytes = 0L;
     private long equalityDeleteBytes = 0L;
     private long equalityDeleteFileRecords = 0L;
     private long positionalDeleteFileRecords = 0L;
+    private int danglingDeleteFileCount = 0;
     private int healthScore = -1; // -1 means not calculated
 
     public PendingInput() {}
 
     public PendingInput(Collection<PartitionEvaluator> evaluators) {
+      initialize(evaluators);
+      totalFileCount = dataFileCount + positionalDeleteFileCount + equalityDeleteFileCount;
+      totalFileSize = dataFileSize + positionalDeleteBytes + equalityDeleteBytes;
+      totalFileRecords = dataFileRecords + positionalDeleteFileRecords + equalityDeleteFileRecords;
+    }
+
+    public PendingInput(Collection<PartitionEvaluator> evaluators, Snapshot snapshot) {
+      initialize(evaluators);
+      Map<String, String> summary = snapshot.summary();
+      int totalDeleteFiles =
+          PropertyUtil.propertyAsInt(summary, SnapshotSummary.TOTAL_DELETE_FILES_PROP, 0);
+      int totalDataFiles =
+          PropertyUtil.propertyAsInt(summary, SnapshotSummary.TOTAL_DATA_FILES_PROP, 0);
+      totalFileRecords = PropertyUtil.propertyAsInt(summary, SnapshotSummary.TOTAL_RECORDS_PROP, 0);
+      totalFileSize = PropertyUtil.propertyAsLong(summary, SnapshotSummary.TOTAL_FILE_SIZE_PROP, 0);
+      totalFileCount = totalDeleteFiles + totalDataFiles;
+      danglingDeleteFileCount =
+          totalDeleteFiles - equalityDeleteFileCount - positionalDeleteFileCount;
+    }
+
+    private void initialize(Collection<PartitionEvaluator> evaluators) {
       double totalHealthScore = 0;
       for (PartitionEvaluator evaluator : evaluators) {
-        partitions
-            .computeIfAbsent(evaluator.getPartition().first(), ignore -> Sets.newHashSet())
-            .add(evaluator.getPartition().second());
-        dataFileCount += evaluator.getFragmentFileCount() + evaluator.getSegmentFileCount();
-        dataFileSize += evaluator.getFragmentFileSize() + evaluator.getSegmentFileSize();
-        dataFileRecords += evaluator.getFragmentFileRecords() + evaluator.getSegmentFileRecords();
-        positionalDeleteBytes += evaluator.getPosDeleteFileSize();
-        positionalDeleteFileRecords += evaluator.getPosDeleteFileRecords();
-        positionalDeleteFileCount += evaluator.getPosDeleteFileCount();
-        equalityDeleteBytes += evaluator.getEqualityDeleteFileSize();
-        equalityDeleteFileRecords += evaluator.getEqualityDeleteFileRecords();
-        equalityDeleteFileCount += evaluator.getEqualityDeleteFileCount();
+        addPartitionData(evaluator);
         totalHealthScore += evaluator.getHealthScore();
       }
-      healthScore = (int) Math.ceil(totalHealthScore / evaluators.size());
+      healthScore = avgHealthScore(totalHealthScore, evaluators.size());
+    }
+
+    private void addPartitionData(PartitionEvaluator evaluator) {
+      partitions
+          .computeIfAbsent(evaluator.getPartition().first(), ignore -> Sets.newHashSet())
+          .add(evaluator.getPartition().second());
+      dataFileCount += evaluator.getFragmentFileCount() + evaluator.getSegmentFileCount();
+      dataFileSize += evaluator.getFragmentFileSize() + evaluator.getSegmentFileSize();
+      dataFileRecords += evaluator.getFragmentFileRecords() + evaluator.getSegmentFileRecords();
+      positionalDeleteBytes += evaluator.getPosDeleteFileSize();
+      positionalDeleteFileRecords += evaluator.getPosDeleteFileRecords();
+      positionalDeleteFileCount += evaluator.getPosDeleteFileCount();
+      equalityDeleteBytes += evaluator.getEqualityDeleteFileSize();
+      equalityDeleteFileRecords += evaluator.getEqualityDeleteFileRecords();
+      equalityDeleteFileCount += evaluator.getEqualityDeleteFileCount();
+    }
+
+    private int avgHealthScore(double totalHealthScore, int partitionCount) {
+      if (partitionCount == 0) {
+        return 0;
+      }
+      return (int) Math.ceil(totalHealthScore / partitionCount);
     }
 
     public Map<Integer, Set<StructLike>> getPartitions() {
@@ -268,9 +314,28 @@ public class OptimizingEvaluator {
       return healthScore;
     }
 
+    public int getTotalFileCount() {
+      return totalFileCount;
+    }
+
+    public long getTotalFileSize() {
+      return totalFileSize;
+    }
+
+    public long getTotalFileRecords() {
+      return totalFileRecords;
+    }
+
+    public int getDanglingDeleteFileCount() {
+      return danglingDeleteFileCount;
+    }
+
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
+          .add("totalFileCount", totalFileCount)
+          .add("totalFileSize", totalFileSize)
+          .add("totalFileRecords", totalFileRecords)
           .add("partitions", partitions)
           .add("dataFileCount", dataFileCount)
           .add("dataFileSize", dataFileSize)
@@ -282,6 +347,7 @@ public class OptimizingEvaluator {
           .add("equalityDeleteFileRecords", equalityDeleteFileRecords)
           .add("positionalDeleteFileRecords", positionalDeleteFileRecords)
           .add("healthScore", healthScore)
+          .add("danglingDeleteFileCount", danglingDeleteFileCount)
           .toString();
     }
   }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestTableSummaryMetrics.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestTableSummaryMetrics.java
@@ -18,6 +18,7 @@
 
 package org.apache.amoro.server.table;
 
+import static org.apache.amoro.server.table.TableSummaryMetrics.TABLE_SUMMARY_DANGLING_DELETE_FILES;
 import static org.apache.amoro.server.table.TableSummaryMetrics.TABLE_SUMMARY_DATA_FILES;
 import static org.apache.amoro.server.table.TableSummaryMetrics.TABLE_SUMMARY_DATA_FILES_RECORDS;
 import static org.apache.amoro.server.table.TableSummaryMetrics.TABLE_SUMMARY_DATA_FILES_SIZE;
@@ -154,6 +155,8 @@ public class TestTableSummaryMetrics extends AMSTableTestBase {
     Gauge<Long> dataFiles = getMetric(metrics, identifier, TABLE_SUMMARY_DATA_FILES);
     Gauge<Long> posDelFiles = getMetric(metrics, identifier, TABLE_SUMMARY_POSITION_DELETE_FILES);
     Gauge<Long> eqDelFiles = getMetric(metrics, identifier, TABLE_SUMMARY_EQUALITY_DELETE_FILES);
+    Gauge<Long> danglingDelFiles =
+        getMetric(metrics, identifier, TABLE_SUMMARY_DANGLING_DELETE_FILES);
 
     Gauge<Long> totalSize = getMetric(metrics, identifier, TABLE_SUMMARY_TOTAL_FILES_SIZE);
     Gauge<Long> dataSize = getMetric(metrics, identifier, TABLE_SUMMARY_DATA_FILES_SIZE);
@@ -177,6 +180,7 @@ public class TestTableSummaryMetrics extends AMSTableTestBase {
     Assertions.assertEquals(0, dataFiles.getValue());
     Assertions.assertEquals(0, posDelFiles.getValue());
     Assertions.assertEquals(0, eqDelFiles.getValue());
+    Assertions.assertEquals(0, danglingDelFiles.getValue());
 
     Assertions.assertEquals(0, totalSize.getValue());
     Assertions.assertEquals(0, dataSize.getValue());

--- a/docs/user-guides/metrics.md
+++ b/docs/user-guides/metrics.md
@@ -108,6 +108,7 @@ Amoro has supported built-in metrics to measure status of table self-optimizing 
 | table_summary_data_files                      | Gauge   | catalog, database, table | Number of data files in the table             |
 | table_summary_equality_delete_files           | Gauge   | catalog, database, table | Number of equality delete files in the table  |
 | table_summary_position_delete_files           | Gauge   | catalog, database, table | Number of position delete files in the table  |
+| table_summary_dangling_delete_files           | Gauge   | catalog, database, table | Number of dangling delete files in the table  |
 | table_summary_total_files_size                | Gauge   | catalog, database, table | Total size of files in the table              |
 | table_summary_data_files_size                 | Gauge   | catalog, database, table | Size of data files in the table               |
 | table_summary_equality_delete_files_size      | Gauge   | catalog, database, table | Size of equality delete files in the table    |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3220.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

*  fetch `totalFileRecords`,`totalFileSize`,`totalFileCount` from snapshot summary
* add `table_summary_dangling_delete_files` metric  
danglingDeleteFiles = totalDeleteFiles - eqDeleteFiles - posDeleteFiles

## How was this patch tested?

- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
