### PR TITLE
[Improvement] Support env.sh and add HADOOP_CONF_DIR and HIVE_CONF_DIR to CLASSPATH

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
@@ -439,6 +439,8 @@ public class AmoroServiceContainer {
 
     private Map<String, Object> initEnvConfig() {
       LOG.info("initializing system env configuration...");
+      Map<String, String> envs = System.getenv();
+      envs.forEach((k, v) -> LOG.info("export {}={}", k, v));
       String prefix = AmoroManagementConf.SYSTEM_CONFIG.toUpperCase();
       return ConfigHelpers.convertConfigurationKeys(prefix, System.getenv());
     }

--- a/dist/src/main/amoro-bin/bin/ams.sh
+++ b/dist/src/main/amoro-bin/bin/ams.sh
@@ -83,7 +83,12 @@ if [ -z "$JAVA_OPTS" ]; then
 fi
 
 
-export CLASSPATH=$AMORO_HOME/conf:$AMORO_CONF_DIR:$LIB_PATH/:$(find $LIB_PATH/ -type f -name "*.jar" | sort | paste -sd':' -)
+export CLASSPATH=$AMORO_CONF_DIR:$LIB_PATH/:$(find $LIB_PATH/ -type f -name "*.jar" | sort | paste -sd':' -)
+
+if [ -n "${AMORO_ADDITION_CLASSPATH}" ]; then
+    export CLASSPATH=$AMORO_ADDITION_CLASSPATH:$CLASSPATH
+fi
+
 CMDS="$JAVA_RUN -Dlog4j.configurationFile=${AMORO_LOG_CONF_FILE} -Dlog.home=${AMORO_LOG_DIR} -Dlog.dir=${AMORO_LOG_DIR} -Duser.dir=${AMORO_HOME}  $JAVA_OPTS ${RUN_SERVER}"
 #0:pid bad and proc OK;   1:pid ok and proc bad;    2:pid bad
 function status(){

--- a/dist/src/main/amoro-bin/bin/load-config.sh
+++ b/dist/src/main/amoro-bin/bin/load-config.sh
@@ -38,6 +38,8 @@ if [ -z "$AMORO_LOG_CONF_FILE" ]; then
     export AMORO_LOG_CONF_FILE="${AMORO_CONF_DIR}/log4j2.xml"
 fi
 
+export AMORO_ENV_FILE=${AMORO_CONF_DIR}/env.sh
+
 JVM_PROPERTIES=${AMORO_CONF_DIR}/jvm.properties
 JVM_VALUE=
 parseJvmArgs() {
@@ -63,3 +65,20 @@ export JVM_XMX_CONFIG
 export JVM_XMS_CONFIG
 export JMX_REMOTE_PORT_CONFIG
 export JVM_EXTRA_CONFIG
+
+test -f ${AMORO_ENV_FILE} && source ${AMORO_ENV_FILE}
+
+# set env variable amoro-addition-classpath if not exists
+if [ -z "${AMORO_ADDITION_CLASSPATH}" ]; then
+    export AMORO_ADDITION_CLASSPATH=
+fi
+
+# add hadoop_conf_dir to amoro addition classpath
+if [ -n "${HADOOP_CONF_DIR}" ]; then
+    export AMORO_ADDITION_CLASSPATH=$AMORO_ADDITION_CLASSPATH:$HADOOP_CONF_DIR
+fi
+
+# add hive_conf_dir to amoro addition classpath
+if [ -n "${HIVE_CONF_DIR}" ]; then
+    export AMORO_ADDITION_CLASSPATH=${AMORO_ADDITION_CLASSPATH}:${HIVE_CONF_DIR}
+fi

--- a/dist/src/main/amoro-bin/conf/env.sh
+++ b/dist/src/main/amoro-bin/conf/env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is used to export env variables for AMORO
+
+# set your hadoop conf dir
+# export HADOOP_CONF_DIR=
+
+# set your hive conf dir
+# export HIVE_CONF_DIR=
+
+# set your addition classpath dir
+# export AMORO_ADDITION_CLASSPATH=

--- a/dist/src/main/assemblies/bin.xml
+++ b/dist/src/main/assemblies/bin.xml
@@ -59,9 +59,9 @@
             <fileMode>0644</fileMode>
         </file>
         <file>
-            <source>src/main/amoro-bin/conf/config.yaml</source>
+            <source>src/main/amoro-bin/conf/env.sh</source>
             <outputDirectory>conf</outputDirectory>
-            <fileMode>0644</fileMode>
+            <fileMode>0755</fileMode>
         </file>
         <file>
             <source>../LICENSE-binary</source>


### PR DESCRIPTION

## Why are the changes needed?

HiveConf can load the existing hive-site.xml from the classpath during initialization.

So Amoro should support adding some directories to the classpath at startup.

In addition, user-defined environment variable configuration files need to be supported.


## Brief change log

- Add a env.sh in ${AMORO_CONF_DIR} 
- If exists env variables HADOOP_CONF_DIR and HIVE_CONF_DIR, add them to CLASSPATH
- Support add additional directories by env variable AMORO_ADDITION_CLASSPATH.
- Print all env variables and their value at startup.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
