### PR TITLE
[AMORO-3110] Do not throw exception when retry task in optimizer keeper

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
@@ -33,6 +33,7 @@ import org.apache.amoro.properties.CatalogMetaProperties;
 import org.apache.amoro.resource.Resource;
 import org.apache.amoro.resource.ResourceGroup;
 import org.apache.amoro.server.exception.ForbiddenException;
+import org.apache.amoro.server.exception.IllegalTaskStateException;
 import org.apache.amoro.server.exception.ObjectNotExistsException;
 import org.apache.amoro.server.exception.PluginRetryAuthException;
 import org.apache.amoro.server.exception.TaskNotFoundException;
@@ -147,8 +148,8 @@ public class DefaultOptimizingService extends StatedPersistentBase
         .forEach(groupName -> LOG.warn("Unloaded task runtime in group {}", groupName));
   }
 
-  private void registerOptimizer(OptimizerInstance optimizer, boolean needPersistency) {
-    if (needPersistency) {
+  private void registerOptimizer(OptimizerInstance optimizer, boolean needPersistent) {
+    if (needPersistent) {
       doAs(OptimizerMapper.class, mapper -> mapper.insertOptimizer(optimizer));
     }
 
@@ -565,7 +566,14 @@ public class DefaultOptimizingService extends StatedPersistentBase
           task.getTaskId(),
           task.getResourceDesc());
       // optimizing task of suspending optimizer would not be counted for retrying
-      queue.retryTask(task);
+      try {
+        queue.retryTask(task);
+      } catch (IllegalTaskStateException e) {
+        LOG.error(
+            "Retry task {} failed due to {}, will check it in next round",
+            task.getTaskId(),
+            e.getMessage());
+      }
     }
 
     private Predicate<TaskRuntime> buildSuspendingPredication(Set<String> activeTokens) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

If OptimizerKeeper reset task status illegally(SUCCESS -> PLAN), optimizer may not be released or touched. In the meantime, the optimizer is restart, then the remaning task will never be executed.
Close #3110 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- 

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
