### PR TITLE
[Hotfix] Fix loading custom auth s3 catalog issue

### DIFF
--- a/amoro-common/src/main/java/org/apache/amoro/table/TableMetaStore.java
+++ b/amoro-common/src/main/java/org/apache/amoro/table/TableMetaStore.java
@@ -767,7 +767,7 @@ public class TableMetaStore implements Serializable {
         return new TableMetaStore(configuration);
       } else {
         readProperties();
-        if (!AUTH_METHOD_AK_SK.equals(authMethod)) {
+        if (AUTH_METHOD_SIMPLE.equals(authMethod) || AUTH_METHOD_KERBEROS.equals(authMethod)) {
           Preconditions.checkNotNull(hdfsSite);
           Preconditions.checkNotNull(coreSite);
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

When loading a custom auth type catalog, we should not check the hdfs/core site files.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Check hdfs/core site files only for simple and Kerberos auth.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
