### PR TITLE
[AMORO-3038] Unify the API set for dashboard and open API

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
@@ -74,6 +74,8 @@ public class DashboardServer {
   public static final Logger LOG = LoggerFactory.getLogger(DashboardServer.class);
 
   private static final String AUTH_TYPE_BASIC = "basic";
+  private static final String X_REQUEST_SOURCE_HEADER = "X-Request-Source";
+  private static final String X_REQUEST_SOURCE_WEB = "Web";
 
   private final CatalogController catalogController;
   private final HealthCheckController healthCheckController;
@@ -189,14 +191,13 @@ public class DashboardServer {
 
       // for dashboard api
       path(
-          "/ams/v1",
+          "/api/ams/v1",
           () -> {
             // login controller
             get("/login/current", loginController::getCurrent);
             post("/login", loginController::login);
             post("/logout", loginController::logout);
           });
-      path("ams/v1", apiGroup());
 
       // for open api
       path("/api/ams/v1", apiGroup());
@@ -356,7 +357,8 @@ public class DashboardServer {
 
   public void preHandleRequest(Context ctx) {
     String uriPath = ctx.path();
-    if (needApiKeyCheck(uriPath)) {
+    String requestSource = ctx.header(X_REQUEST_SOURCE_HEADER);
+    if (needApiKeyCheck(uriPath) && !X_REQUEST_SOURCE_WEB.equalsIgnoreCase(requestSource)) {
       if (AUTH_TYPE_BASIC.equalsIgnoreCase(authType)) {
         BasicAuthCredentials cred = ctx.basicAuthCredentials();
         if (!(basicAuthUser.equals(cred.component1())
@@ -392,10 +394,10 @@ public class DashboardServer {
   }
 
   private static final String[] urlWhiteList = {
-    "/ams/v1/versionInfo",
-    "/ams/v1/login",
-    "/ams/v1/health/status",
-    "/ams/v1/login/current",
+    "/api/ams/v1/versionInfo",
+    "/api/ams/v1/login",
+    "/api/ams/v1/health/status",
+    "/api/ams/v1/login/current",
     "/",
     "/overview",
     "/introduce",

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/CatalogController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/CatalogController.java
@@ -610,7 +610,7 @@ public class CatalogController {
   /** Construct a url */
   private String constructCatalogConfigFileUrl(String catalogName, String type, String key) {
     return String.format(
-        "/ams/v1/catalogs/%s/config/%s/%s", catalogName, type, key.replaceAll("\\.", "-"));
+        "/api/ams/v1/catalogs/%s/config/%s/%s", catalogName, type, key.replaceAll("\\.", "-"));
   }
 
   /** Get the config file content uri("/catalogs/{catalogName}/config/{type}/{key} */

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/PlatformFileInfoController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/PlatformFileInfoController.java
@@ -64,7 +64,7 @@ public class PlatformFileInfoController {
     Integer fid = platformFileInfoService.addFile(name, content);
     Map<String, String> result = new HashMap<>();
     result.put("id", String.valueOf(fid));
-    result.put("url", "/ams/v1/files/" + fid);
+    result.put("url", "/api/ams/v1/files/" + fid);
     ctx.json(OkResponse.of(result));
   }
 

--- a/amoro-web/mock/modules/catalogs.js
+++ b/amoro-web/mock/modules/catalogs.js
@@ -18,7 +18,7 @@
 
 export default [
   {
-    url: '/mock/ams/v1/catalogs',
+    url: '/mock/api/ams/v1/catalogs',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -56,27 +56,27 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/catalogs',
+    url: '/mock/api/ams/v1/catalogs',
     method: 'post',
     response: () => ({"message":"success","code":200,"result":""}),
   },
 
   {
-    url: '/mock/ams/v1/catalogs/test_catalog/databases',
+    url: '/mock/api/ams/v1/catalogs/test_catalog/databases',
     method: 'get',
     response: () => {
       return { "message": "success", "code": 200, "result": ["db", "test", "acc"] }
     },
   },
   {
-    url: '/mock/ams/v1/catalogs/test_catalog/databases/db/tables',
+    url: '/mock/api/ams/v1/catalogs/test_catalog/databases/db/tables',
     method: 'get',
     response: () => {
       return { "message": "success", "code": 200, "result": [{ "name": "user", "type": "ICEBERG" },{ "name": "wf", "type": "ICEBERG" }, { "name": "xcvz", "type": "ICEBERG" }] };
     },
   },
   {
-    url: '/mock/ams/v1/catalogs/:id',
+    url: '/mock/api/ams/v1/catalogs/:id',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -92,15 +92,15 @@ export default [
           "storage.type": "Hadoop",
           "hive.site": {
             "fileName": "hive-site.xml",
-            "fileUrl": "/ams/v1/catalogs/test_catalog/config/storage-config/hive-site"
+            "fileUrl": "/api/ams/v1/catalogs/test_catalog/config/storage-config/hive-site"
           },
           "hadoop.core.site": {
             "fileName": "core-site.xml",
-            "fileUrl": "/ams/v1/catalogs/test_catalog/config/storage-config/hadoop-core-site"
+            "fileUrl": "/api/ams/v1/catalogs/test_catalog/config/storage-config/hadoop-core-site"
           },
           "hadoop.hdfs.site": {
             "fileName": "hdfs-site.xml",
-            "fileUrl": "/ams/v1/catalogs/test_catalog/config/storage-config/hadoop-hdfs-site"
+            "fileUrl": "/api/ams/v1/catalogs/test_catalog/config/storage-config/hadoop-hdfs-site"
           }
         },
         "authConfig": {
@@ -116,22 +116,22 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/catalogs/:id',
+    url: '/mock/api/ams/v1/catalogs/:id',
     method: 'put',
     response: () => ({ "message": "success", "code": 200, "result": null }),
   },
   {
-    url: '/mock/ams/v1/catalogs/:id',
+    url: '/mock/api/ams/v1/catalogs/:id',
     method: 'delete',
     response: () => ({ "message": "success", "code": 200, "result": true }),
   },
   {
-    url: '/mock/ams/v1/catalogs/:id/delete/check',
+    url: '/mock/api/ams/v1/catalogs/:id/delete/check',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": true }),
   },
   {
-    url: '/mock/ams/v1/catalogs/metastore/types',
+    url: '/mock/api/ams/v1/catalogs/metastore/types',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -161,7 +161,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/:catalog/dbs/:dbId/tables/:tableName/optimizing-processes/:processesId/tasks',
+    url: '/mock/api/ams/v1/tables/catalogs/:catalog/dbs/:dbId/tables/:tableName/optimizing-processes/:processesId/tasks',
     method: 'get',
     response: () => ({
       "message": "success",

--- a/amoro-web/mock/modules/common.js
+++ b/amoro-web/mock/modules/common.js
@@ -18,7 +18,7 @@
 
 export default [
   {
-    url: '/mock/ams/v1/login/current',
+    url: '/mock/api/ams/v1/login/current',
     method: 'get',
     response: () => ({
       code: 200,
@@ -30,7 +30,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/login',
+    url: '/mock/api/ams/v1/login',
     method: 'post',
     response: () => ({
       code: 200,
@@ -39,7 +39,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/versionInfo',
+    url: '/mock/api/ams/v1/versionInfo',
     method: 'get',
     response: () => ({
       code: 200,
@@ -51,7 +51,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/upgrade/properties',
+    url: '/mock/api/ams/v1/upgrade/properties',
     method: 'get',
     response: () => ({
       code: 200,
@@ -63,7 +63,7 @@ export default [
     })
   },
   {
-    url: '/mock/ams/v1/logout',
+    url: '/mock/api/ams/v1/logout',
     method: 'post',
     response: () => ({
       code: 200,

--- a/amoro-web/mock/modules/optimize.js
+++ b/amoro-web/mock/modules/optimize.js
@@ -18,7 +18,7 @@
 
 export default [
   {
-    url: '/mock/ams/v1/optimize/resourceGroups/get',
+    url: '/mock/api/ams/v1/optimize/resourceGroups/get',
     method: 'get',
     response: () => ({
       code: 200,
@@ -29,7 +29,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/containers/get',
+    url: '/mock/api/ams/v1/optimize/containers/get',
     method: 'get',
     response: () => ({
       code: 200,
@@ -38,7 +38,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/actions',
+    url: '/mock/api/ams/v1/optimize/actions',
     method: 'get',
     response: () => ({
       code: 200,
@@ -47,7 +47,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/optimizerGroups/:groups/tables',
+    url: '/mock/api/ams/v1/optimize/optimizerGroups/:groups/tables',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -85,12 +85,12 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/optimizerGroups/local/optimizers',
+    url: '/mock/api/ams/v1/optimize/optimizerGroups/local/optimizers',
     method: 'post',
     response: () => ({ "message": "success", "code": 200, "result": "success to scaleOut optimizer" }),
   },
   {
-    url: '/mock/ams/v1/optimize/resourceGroups',
+    url: '/mock/api/ams/v1/optimize/resourceGroups',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -133,7 +133,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/resourceGroups',
+    url: '/mock/api/ams/v1/optimize/resourceGroups',
     method: 'put',
     response: () => ({
       "message": "success",
@@ -142,7 +142,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/resourceGroups',
+    url: '/mock/api/ams/v1/optimize/resourceGroups',
     method: 'post',
     response: () => ({
       "message": "success",
@@ -151,12 +151,12 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/resourceGroups/:id/delete/check',
+    url: '/mock/api/ams/v1/optimize/resourceGroups/:id/delete/check',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": true }),
   },
   {
-    url: '/mock/ams/v1/optimize/resourceGroups/:id',
+    url: '/mock/api/ams/v1/optimize/resourceGroups/:id',
     method: 'delete',
     response: () => ({
       "message": "success",
@@ -165,7 +165,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/optimize/optimizerGroups/all/optimizers',
+    url: '/mock/api/ams/v1/optimize/optimizerGroups/all/optimizers',
     method: 'get',
     response: () => ({
       "message": "success",

--- a/amoro-web/mock/modules/overview.js
+++ b/amoro-web/mock/modules/overview.js
@@ -18,7 +18,7 @@
 
 export default [
   {
-    url: '/mock/ams/v1/overview/summary',
+    url: '/mock/api/ams/v1/overview/summary',
     method: 'get',
     response: () => ({
       code: 200,
@@ -33,7 +33,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/overview/optimizing',
+    url: '/mock/api/ams/v1/overview/optimizing',
     method: 'get',
     response: () => ({
       code: 200,
@@ -48,7 +48,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/overview/top',
+    url: '/mock/api/ams/v1/overview/top',
     method: 'get',
     response: () => ({
       code: 200,
@@ -68,7 +68,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/overview/resource',
+    url: '/mock/api/ams/v1/overview/resource',
     method: 'get',
     response: () => ({
       code: 200,
@@ -97,7 +97,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/overview/dataSize',
+    url: '/mock/api/ams/v1/overview/dataSize',
     method: 'get',
     response: () => ({
       code: 200,

--- a/amoro-web/mock/modules/settings.js
+++ b/amoro-web/mock/modules/settings.js
@@ -18,7 +18,7 @@
 
 export default [
   {
-    url: '/mock/ams/v1/settings/system',
+    url: '/mock/api/ams/v1/settings/system',
     method: 'get',
     response: () => ({
       code: 200,
@@ -30,7 +30,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/settings/containers',
+    url: '/mock/api/ams/v1/settings/containers',
     method: 'get',
     response: () => ({
       code: 200,

--- a/amoro-web/mock/modules/table.js
+++ b/amoro-web/mock/modules/table.js
@@ -18,7 +18,7 @@
 
 export default [
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/details',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/details',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -91,7 +91,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/partitions',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/partitions',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -120,7 +120,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/branches',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/branches',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -141,12 +141,12 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/tags',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/tags',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": { "list": [], "total": 0 } }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/snapshots',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/snapshots',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -193,12 +193,12 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/operations',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/operations',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": { "list": [], "total": 0 } }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/partitions/:filter/files',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/partitions/:filter/files',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -223,7 +223,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/snapshots/:snapshotId/detail',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/snapshots/:snapshotId/detail',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -260,7 +260,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/optimizing-processes',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/optimizing-processes',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -307,7 +307,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/optimizing-types',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/optimizing-types',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -320,7 +320,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/operations',
+    url: '/mock/api/ams/v1/tables/catalogs/test_catalog/dbs/db/tables/user/operations',
     method: 'get',
     response: () => ({
       "message": "success",

--- a/amoro-web/mock/modules/terminal.js
+++ b/amoro-web/mock/modules/terminal.js
@@ -18,7 +18,7 @@
 
 export default [
   {
-    url: '/mock/ams/v1/terminal/examples',
+    url: '/mock/api/ams/v1/terminal/examples',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -36,12 +36,12 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/terminal/latestInfos',
+    url: '/mock/api/ams/v1/terminal/latestInfos',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": { "sessionId": "", "sql": "" } }),
   },
   {
-    url: '/mock/ams/v1/terminal/catalogs/:catalogName/execute',
+    url: '/mock/api/ams/v1/terminal/catalogs/:catalogName/execute',
     method: 'post',
     response: () => ({
       "message": "success",
@@ -52,7 +52,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/terminal/:sessionId/logs',
+    url: '/mock/api/ams/v1/terminal/:sessionId/logs',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -96,23 +96,23 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/terminal/:sessionId/result',
+    url: '/mock/api/ams/v1/terminal/:sessionId/result',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": [] }),
   },
   {
-    url: '/mock/ams/v1/terminal/:sessionId/result',
+    url: '/mock/api/ams/v1/terminal/:sessionId/result',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": [] }),
   },
   {
-    url: '/mock/ams/v1/terminal/:sessionId/stop',
+    url: '/mock/api/ams/v1/terminal/:sessionId/stop',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": null }),
   },
 
   {
-    url: '/mock/ams/v1/terminal/examples/CreateTable',
+    url: '/mock/api/ams/v1/terminal/examples/CreateTable',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -121,12 +121,12 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/terminal/examples/DeleteTable',
+    url: '/mock/api/ams/v1/terminal/examples/DeleteTable',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": "drop table db_name.table_name;" }),
   },
   {
-    url: '/mock/ams/v1/terminal/examples/EditTable',
+    url: '/mock/api/ams/v1/terminal/examples/EditTable',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -135,7 +135,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/terminal/examples/SetProperties',
+    url: '/mock/api/ams/v1/terminal/examples/SetProperties',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -144,7 +144,7 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/terminal/examples/UnsetProperties',
+    url: '/mock/api/ams/v1/terminal/examples/UnsetProperties',
     method: 'get',
     response: () => ({
       "message": "success",
@@ -153,17 +153,17 @@ export default [
     }),
   },
   {
-    url: '/mock/ams/v1/terminal/examples/ShowDatabases',
+    url: '/mock/api/ams/v1/terminal/examples/ShowDatabases',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": "show databases;" }),
   },
   {
-    url: '/mock/ams/v1/terminal/examples/ShowTables',
+    url: '/mock/api/ams/v1/terminal/examples/ShowTables',
     method: 'get',
     response: () => ({ "message": "success", "code": 200, "result": "show tables;" }),
   },
   {
-    url: '/mock/ams/v1/terminal/examples/Describe',
+    url: '/mock/api/ams/v1/terminal/examples/Describe',
     method: 'get',
     response: () => ({"message":"success","code":200,"result":"desc db_name.table_name;"}),
   },

--- a/amoro-web/src/services/global.service.ts
+++ b/amoro-web/src/services/global.service.ts
@@ -19,5 +19,5 @@
 import request from '@/utils/request'
 
 export function getVersionInfo() {
-  return request.get('ams/v1/versionInfo')
+  return request.get('api/ams/v1/versionInfo')
 }

--- a/amoro-web/src/services/login.service.ts
+++ b/amoro-web/src/services/login.service.ts
@@ -26,18 +26,18 @@ export class LoginService {
     user: string
     password: string
   }) {
-    return request.post('ams/v1/login', params, { returnCode: true })
+    return request.post('api/ams/v1/login', params, { returnCode: true })
   }
 
   public logout() {
-    return request.post('ams/v1/logout', { handleError: false, returnCode: true })
+    return request.post('api/ams/v1/logout', { handleError: false, returnCode: true })
   }
 
   /**
    * Check the login interface
    */
   public getCurUserInfo(token: string) {
-    return request.get('ams/v1/login/current', { handleError: false, params: { token } }).then((res) => {
+    return request.get('api/ams/v1/login/current', { handleError: false, params: { token } }).then((res) => {
       // if (res) {
       //   store.updateUserInfo({
       //     userName: res.userName

--- a/amoro-web/src/services/optimize.service.ts
+++ b/amoro-web/src/services/optimize.service.ts
@@ -19,11 +19,11 @@
 import request from '@/utils/request'
 
 export function getOptimizerGroups() {
-  return request.get('ams/v1/optimize/optimizerGroups')
+  return request.get('api/ams/v1/optimize/optimizerGroups')
 }
 
 export function getOptimizerAction() {
-  return request.get('/ams/v1/optimize/actions')
+  return request.get('api/ams/v1/optimize/actions')
 }
 
 export function getOptimizerTableList(
@@ -37,7 +37,7 @@ export function getOptimizerTableList(
   },
 ) {
   const { optimizerGroup, dbSearchInput, tableSearchInput, page, pageSize, actions } = params
-  return request.get(`ams/v1/optimize/optimizerGroups/${optimizerGroup}/tables`, { params: { dbSearchInput, tableSearchInput, page, pageSize, actions } })
+  return request.get(`api/ams/v1/optimize/optimizerGroups/${optimizerGroup}/tables`, { params: { dbSearchInput, tableSearchInput, page, pageSize, actions } })
 }
 
 export function getOptimizerResourceList(
@@ -48,13 +48,13 @@ export function getOptimizerResourceList(
   },
 ) {
   const { optimizerGroup, page, pageSize } = params
-  return request.get(`ams/v1/optimize/optimizerGroups/${optimizerGroup}/optimizers`, { params: { page, pageSize } })
+  return request.get(`api/ams/v1/optimize/optimizerGroups/${optimizerGroup}/optimizers`, { params: { page, pageSize } })
 }
 
 export function getQueueResourceInfo(
   optimizerGroup: string,
 ) {
-  return request.get(`ams/v1/optimize/optimizerGroups/${optimizerGroup}/info`)
+  return request.get(`api/ams/v1/optimize/optimizerGroups/${optimizerGroup}/info`)
 }
 
 export function scaleoutResource(
@@ -64,7 +64,7 @@ export function scaleoutResource(
   },
 ) {
   const { optimizerGroup, parallelism } = params
-  return request.post(`ams/v1/optimize/optimizerGroups/${optimizerGroup}/optimizers`, { parallelism })
+  return request.post(`api/ams/v1/optimize/optimizerGroups/${optimizerGroup}/optimizers`, { parallelism })
 }
 
 export function createOptimizerResource(
@@ -74,7 +74,7 @@ export function createOptimizerResource(
   },
 ) {
   const { optimizerGroup, parallelism } = params
-  return request.post(`ams/v1/optimize/optimizers`, { optimizerGroup, parallelism })
+  return request.post(`api/ams/v1/optimize/optimizers`, { optimizerGroup, parallelism })
 }
 
 export function releaseResource(
@@ -84,31 +84,31 @@ export function releaseResource(
   },
 ) {
   const { jobId } = params
-  return request.delete(`ams/v1/optimize/optimizers/${jobId}`)
+  return request.delete(`api/ams/v1/optimize/optimizers/${jobId}`)
 }
 
 export async function getResourceGroupsListAPI() {
-  const result = await request.get('ams/v1/optimize/resourceGroups')
+  const result = await request.get('api/ams/v1/optimize/resourceGroups')
   return result
 }
 
 export async function getGroupContainerListAPI() {
-  const result = await request.get('ams/v1/optimize/containers/get')
+  const result = await request.get('api/ams/v1/optimize/containers/get')
   return result
 }
 
 export function addResourceGroupsAPI(params: { name: string, container: string, properties: { [prop: string]: string } }) {
-  return request.post('ams/v1/optimize/resourceGroups', params)
+  return request.post('api/ams/v1/optimize/resourceGroups', params)
 }
 
 export function updateResourceGroupsAPI(params: { name: string, container: string, properties: { [prop: string]: string } }) {
-  return request.put('ams/v1/optimize/resourceGroups', params)
+  return request.put('api/ams/v1/optimize/resourceGroups', params)
 }
 
 export function groupDeleteCheckAPI(params: { name: string }) {
-  return request.get(`/ams/v1/optimize/resourceGroups/${params.name}/delete/check`)
+  return request.get(`/api/ams/v1/optimize/resourceGroups/${params.name}/delete/check`)
 }
 
 export function groupDeleteAPI(params: { name: string }) {
-  return request.delete(`/ams/v1/optimize/resourceGroups/${params.name}`)
+  return request.delete(`/api/ams/v1/optimize/resourceGroups/${params.name}`)
 }

--- a/amoro-web/src/services/overview.service.ts
+++ b/amoro-web/src/services/overview.service.ts
@@ -19,19 +19,19 @@
 import request from '@/utils/request'
 
 export function getOverviewSummary() {
-  return request.get('ams/v1/overview/summary')
+  return request.get('api/ams/v1/overview/summary')
 }
 
 export function getOverviewFormat() {
-  return request.get('ams/v1/overview/format')
+  return request.get('api/ams/v1/overview/format')
 }
 
 export function getOverviewOptimizingStatus() {
-  return request.get('ams/v1/overview/optimizing')
+  return request.get('api/ams/v1/overview/optimizing')
 }
 
 export function getOverviewOperations() {
-  return request.get('ams/v1/overview/operations')
+  return request.get('api/ams/v1/overview/operations')
 }
 
 export function getTop10TableList(params: {
@@ -40,7 +40,7 @@ export function getTop10TableList(params: {
   count?: number
 }) {
   const { order, orderBy, count } = params
-  return request.get(`ams/v1/overview/top`, {
+  return request.get(`api/ams/v1/overview/top`, {
     params: {
       order: order || 'asc',
       orderBy: orderBy || 'healthScore',
@@ -50,9 +50,9 @@ export function getTop10TableList(params: {
 }
 
 export function getResourceUsageList(startTime: number) {
-  return request.get(`ams/v1/overview/resource`, { params: { startTime } })
+  return request.get(`api/ams/v1/overview/resource`, { params: { startTime } })
 }
 
 export function getDataSizeList(startTime: number) {
-  return request.get(`ams/v1/overview/dataSize`, { params: { startTime } })
+  return request.get(`api/ams/v1/overview/dataSize`, { params: { startTime } })
 }

--- a/amoro-web/src/services/setting.services.ts
+++ b/amoro-web/src/services/setting.services.ts
@@ -20,16 +20,16 @@ import type { IMap } from '@/types/common.type'
 import request from '@/utils/request'
 
 export function getCatalogsTypes() {
-  return request.get('ams/v1/catalogs/metastore/types')
+  return request.get('api/ams/v1/catalogs/metastore/types')
 }
 export function getCatalogsSetting(catalogName: string) {
-  return request.get(`ams/v1/catalogs/${catalogName}`)
+  return request.get(`api/ams/v1/catalogs/${catalogName}`)
 }
 export function delCatalog(catalogName: string) {
-  return request.delete(`ams/v1/catalogs/${catalogName}`)
+  return request.delete(`api/ams/v1/catalogs/${catalogName}`)
 }
 export function checkCatalogStatus(catalogName: string) {
-  return request.get(`ams/v1/catalogs/${catalogName}/delete/check`)
+  return request.get(`api/ams/v1/catalogs/${catalogName}/delete/check`)
 }
 export function saveCatalogsSetting(params: {
   name: string
@@ -43,13 +43,13 @@ export function saveCatalogsSetting(params: {
   const { isCreate, name } = params
   delete params.isCreate
   if (isCreate) {
-    return request.post('ams/v1/catalogs', { ...params })
+    return request.post('api/ams/v1/catalogs', { ...params })
   }
-  return request.put(`ams/v1/catalogs/${name}`, { ...params })
+  return request.put(`api/ams/v1/catalogs/${name}`, { ...params })
 }
 export function getSystemSetting() {
-  return request.get('ams/v1/settings/system')
+  return request.get('api/ams/v1/settings/system')
 }
 export function getContainersSetting() {
-  return request.get('ams/v1/settings/containers')
+  return request.get('api/ams/v1/settings/containers')
 }

--- a/amoro-web/src/services/table.service.ts
+++ b/amoro-web/src/services/table.service.ts
@@ -21,14 +21,14 @@ import type { ICatalogItem, IMap } from '@/types/common.type'
 import request from '@/utils/request'
 
 export function getCatalogList(): Promise<ICatalogItem[]> {
-  return request.get('ams/v1/catalogs')
+  return request.get('api/ams/v1/catalogs')
 }
 export function getDatabaseList(params: {
   catalog: string
   keywords: string
 }): Promise<string[]> {
   const { catalog, keywords } = params
-  return request.get(`ams/v1/catalogs/${catalog}/databases`, { params: { keywords } })
+  return request.get(`api/ams/v1/catalogs/${catalog}/databases`, { params: { keywords } })
 }
 
 export function getTableList(params: {
@@ -37,26 +37,26 @@ export function getTableList(params: {
   keywords: string
 }) {
   const { catalog, db, keywords } = params
-  return request.get(`ams/v1/catalogs/${catalog}/databases/${db}/tables`, { params: { keywords } })
+  return request.get(`api/ams/v1/catalogs/${catalog}/databases/${db}/tables`, { params: { keywords } })
 }
 
 // get tables detail
 export function getTableDetail(
   { catalog = '' as string, db = '' as string, table = '' as string, token = '' as string },
 ) {
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/details`, { params: { token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/details`, { params: { token } })
 }
 
 export function getHiveTableDetail(
   { catalog = '' as string, db = '' as string, table = '' as string },
 ) {
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/hive/details`)
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/hive/details`)
 }
 
 export function getUpgradeStatus(
   { catalog = '' as string, db = '' as string, table = '' as string },
 ) {
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/upgrade/status`)
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/upgrade/status`)
 }
 // get partions table
 export function getPartitionTable(
@@ -71,7 +71,7 @@ export function getPartitionTable(
   },
 ) {
   const { catalog, db, table, filter, page, pageSize, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/partitions`, { params: { filter, page, pageSize, token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/partitions`, { params: { filter, page, pageSize, token } })
 }
 
 // get partions
@@ -86,7 +86,7 @@ export function getPartitions(
   },
 ) {
   const { catalog, db, table, page, pageSize, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/partitions`, { params: { page, pageSize, token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/partitions`, { params: { page, pageSize, token } })
 }
 // get partions-files
 export function getPartitionFiles(
@@ -102,7 +102,7 @@ export function getPartitionFiles(
   },
 ) {
   const { catalog, db, table, partition, specId, page, pageSize, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/partitions/${partition}/files`, { params: { specId, page, pageSize, token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/partitions/${partition}/files`, { params: { specId, page, pageSize, token } })
 }
 // get snapshots
 export function getSnapshots(
@@ -118,7 +118,7 @@ export function getSnapshots(
   },
 ) {
   const { catalog, db, table, page, pageSize, token, ref, operation } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/snapshots`, { params: { page, pageSize, token, ref, operation } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/snapshots`, { params: { page, pageSize, token, ref, operation } })
 }
 
 // get Snapshot detail
@@ -134,7 +134,7 @@ export function getDetailBySnapshotId(
   },
 ) {
   const { catalog, db, table, snapshotId, page, pageSize, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/snapshots/${snapshotId}/detail`, { params: { page, pageSize, token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/snapshots/${snapshotId}/detail`, { params: { page, pageSize, token } })
 }
 // get operations
 export function getOperations(
@@ -148,7 +148,7 @@ export function getOperations(
   },
 ) {
   const { catalog, db, table, page, pageSize, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/operations`, { params: { page, pageSize, token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/operations`, { params: { page, pageSize, token } })
 }
 // get optimizing processes
 export function getOptimizingProcesses(
@@ -164,7 +164,7 @@ export function getOptimizingProcesses(
   },
 ) {
   const { catalog, db, table, type, status, page, pageSize, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-processes`, { params: { page, pageSize, token, type, status } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-processes`, { params: { page, pageSize, token, type, status } })
 }
 
 // get optimizing process types
@@ -177,7 +177,7 @@ export function getTableOptimizingTypes(
   },
 ) {
   const { catalog, db, table, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-types`, { params: { token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-types`, { params: { token } })
 }
 
 // get optimizing taskes
@@ -193,38 +193,38 @@ export function getTasksByOptimizingProcessId(
   },
 ) {
   const { catalog, db, table, processId, page, pageSize, token } = params
-  return request.get(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-processes/${processId}/tasks`, { params: { page, pageSize, token } })
+  return request.get(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-processes/${processId}/tasks`, { params: { page, pageSize, token } })
 }
 
 export function upgradeHiveTable(
   { catalog = '' as string, db = '' as string, table = '' as string, properties = {} as IMap<string>, pkList = [] as IMap<string>[] },
 ) {
-  return request.post(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/upgrade`, {
+  return request.post(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/upgrade`, {
     properties,
     pkList,
   })
 }
 
 export function getUpgradeProperties() {
-  return request.get('ams/v1/upgrade/properties')
+  return request.get('api/ams/v1/upgrade/properties')
 }
 
 export function cancelOptimizingProcess(
   { catalog = '' as string, db = '' as string, table = '' as string, processId = '' as string },
 ) {
-  return request.post(`ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-processes/${processId}/cancel`)
+  return request.post(`api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/optimizing-processes/${processId}/cancel`)
 }
 
 export function getBranches(params: { catalog: string, db: string, table: string }) {
   const { catalog, db, table } = params
-  return request.get(`/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/branches`)
+  return request.get(`/api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/branches`)
 }
 
 export function getTags(params: { catalog: string, db: string, table: string }) {
   const { catalog, db, table } = params
-  return request.get(`/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/tags`)
+  return request.get(`/api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/tags`)
 }
 export function getConsumers(params: { catalog: string, db: string, table: string }) {
   const { catalog, db, table } = params
-  return request.get(`/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/consumers`)
+  return request.get(`/api/ams/v1/tables/catalogs/${catalog}/dbs/${db}/tables/${table}/consumers`)
 }

--- a/amoro-web/src/services/terminal.service.ts
+++ b/amoro-web/src/services/terminal.service.ts
@@ -19,15 +19,15 @@
 import request from '@/utils/request'
 
 export function getJobDebugResult(sessionId: string) {
-  return request.get(`ams/v1/terminal/${sessionId}/result`)
+  return request.get(`api/ams/v1/terminal/${sessionId}/result`)
 }
 
 export function getShortcutsList() {
-  return request.get('ams/v1/terminal/examples')
+  return request.get('api/ams/v1/terminal/examples')
 }
 
 export function getExampleSqlCode(exampleName: string) {
-  return request.get(`ams/v1/terminal/examples/${exampleName}`)
+  return request.get(`api/ams/v1/terminal/examples/${exampleName}`)
 }
 
 export function executeSql(params: {
@@ -35,18 +35,18 @@ export function executeSql(params: {
   sql: string
 }) {
   const { catalog, sql } = params
-  return request.post(`ams/v1/terminal/catalogs/${catalog}/execute`, { sql })
+  return request.post(`api/ams/v1/terminal/catalogs/${catalog}/execute`, { sql })
 }
 
 export function stopSql(sessionId: string) {
-  return request.put(`ams/v1/terminal/${sessionId}/stop`)
+  return request.put(`api/ams/v1/terminal/${sessionId}/stop`)
 }
 
 export function getLogsResult(sessionId: string) {
-  return request.get(`ams/v1/terminal/${sessionId}/logs`)
+  return request.get(`api/ams/v1/terminal/${sessionId}/logs`)
 }
 
 // get the last executed sql and sessionId
 export function getLastDebugInfo() {
-  return request.get('ams/v1/terminal/latestInfos')
+  return request.get('api/ams/v1/terminal/latestInfos')
 }

--- a/amoro-web/src/utils/request.ts
+++ b/amoro-web/src/utils/request.ts
@@ -64,6 +64,7 @@ const DEFAULT_CONFIG = {
   timeout: 45000,
   headers: {
     'Content-Type': 'application/json',
+    'X-Request-Source' : 'Web'
   },
 }
 

--- a/amoro-web/src/views/catalogs/Detail.vue
+++ b/amoro-web/src/views/catalogs/Detail.vue
@@ -91,7 +91,7 @@ const isEdit = computed(() => {
   return props.isEdit
 })
 const uploadUrl = computed(() => {
-  return '/ams/v1/files'
+  return '/api/ams/v1/files'
 })
 const isNewCatalog = computed(() => {
   const catalog = (route.query?.catalogname || '').toString()

--- a/charts/amoro/templates/amoro-deployment.yaml
+++ b/charts/amoro/templates/amoro-deployment.yaml
@@ -83,7 +83,7 @@ spec: {{/* TODO If Support Replica can be use more than 1 */}}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /ams/v1/health/status
+              path: /api/ams/v1/health/status
               port: rest
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -94,7 +94,7 @@ spec: {{/* TODO If Support Replica can be use more than 1 */}}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: ams/v1/versionInfo
+              path: api/ams/v1/versionInfo
               port: rest
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}


### PR DESCRIPTION
## Why are the changes needed?

Close #3038.

## Brief change log

Unify the API set for both dashboard and Open API in the same url [ /api/ams/v1 ]. 

Previously, frontend requests and external interface requests were distinguished by using the paths **ams/v1** and **api/ams/v1** respectively. Frontend requests required cookie validation for login status, while external interface requests needed to pass an apikey parameter for verification. In this design, the request paths from both sources are unified to **api/ams/v1**. For frontend requests, an additional header parameter **_X-Request-Source: frontend_** will be included. This allows the source of the request to be distinguished and routed to different validation logic accordingly.

## How was this patch tested?

- [ ☑️ ] Add screenshots for manual tests if appropriate
![image](https://github.com/user-attachments/assets/0efb7533-7381-41ac-8d85-1caf6b896027)

- [ ☑️ ] Run test locally before making a pull request
