### PR TITLE
[hotfix] k8s helm support using the default Kubernetes client configuration

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/KubernetesOptimizerContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/KubernetesOptimizerContainer.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.apache.amoro.resource.Resource;
@@ -51,6 +52,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** Kubernetes Optimizer Container with Standalone Optimizer */
@@ -77,8 +79,12 @@ public class KubernetesOptimizerContainer extends AbstractResourceContainer {
   public void init(String name, Map<String, String> containerProperties) {
     super.init(name, containerProperties);
     // start k8s job using k8s client
-    String kubeConfigPath = checkAndGetProperty(containerProperties, KUBE_CONFIG_PATH);
-    Config config = Config.fromKubeconfig(getKubeConfigContent(kubeConfigPath));
+    Optional<String> kubeConfigPath =
+        Optional.ofNullable(containerProperties.get(KUBE_CONFIG_PATH));
+    Config config =
+        kubeConfigPath
+            .map(path -> Config.fromKubeconfig(getKubeConfigContent(path)))
+            .orElseGet(() -> new ConfigBuilder().build());
     this.client = new KubernetesClientBuilder().withConfig(config).build();
   }
 

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -261,7 +261,8 @@ optimizer:
     enabled: true
     properties:
       namespace: "default"
-      kube-config-path: "~/.kube/config"
+      # if service account rbac not have, need kube config set in optimizer deployment
+      #kube-config-path: "~/.kube/config"
       image: "apache/amoro:latest"
       pullPolicy: "IfNotPresent"
   extra: []


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->



## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Helm value.yaml remove **kube-config-path** value.
- KubernetesOptimizerContainer Support default Kubernetes client configuration.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible
- [x] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
