### PR TITLE
[AMORO-3253] Optijmizing getOPtimizingProcessTasks and getOptimizingTypes rest efficiency

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -338,8 +338,6 @@ public class TableController {
     String db = ctx.pathParam("db");
     String table = ctx.pathParam("table");
     TableIdentifier tableIdentifier = TableIdentifier.of(catalog, db, table);
-    ServerCatalog serverCatalog = tableService.getServerCatalog(catalog);
-    Preconditions.checkState(serverCatalog.tableExists(db, table), "no such table");
 
     Map<String, String> values =
         tableDescriptor.getTableOptimizingTypes(tableIdentifier.buildTableIdentifier());
@@ -361,10 +359,8 @@ public class TableController {
 
     int offset = (page - 1) * pageSize;
     int limit = pageSize;
-    ServerCatalog serverCatalog = tableService.getServerCatalog(catalog);
     Preconditions.checkArgument(offset >= 0, "offset[%s] must >= 0", offset);
     Preconditions.checkArgument(limit >= 0, "limit[%s] must >= 0", limit);
-    Preconditions.checkState(serverCatalog.tableExists(db, table), "no such table");
 
     TableIdentifier tableIdentifier = TableIdentifier.of(catalog, db, table);
     List<OptimizingTaskInfo> optimizingTaskInfos =


### PR DESCRIPTION

## Why are the changes needed?

Close #3253.

## Brief change log
Before the change we'll check whether the table exists by loading the table, the loading step maybe too expensive, and it's redundant because the table exists will be checked in the folllowing step when loading table to retrieve the info.

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
