### PR TITLE
[AMORO-3277] enable jvm parameter ExitOnOutOfMemoryError and HeapDumpOnOutOfMemoryError for ams

### DIFF
--- a/dist/src/main/amoro-bin/conf/jvm.properties
+++ b/dist/src/main/amoro-bin/conf/jvm.properties
@@ -17,4 +17,4 @@
 xms=8196
 xmx=8196
 jmx.remote.port=
-extra.options="-XX:NewRatio=1 -XX:SurvivorRatio=3"
+extra.options="-XX:NewRatio=1 -XX:SurvivorRatio=3 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3277 .