### PR TITLE
[Hotfix] Use `propertyAsLong` instead of `propertyAsInt` for `total-records`

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/plan/OptimizingEvaluator.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/plan/OptimizingEvaluator.java
@@ -236,7 +236,8 @@ public class OptimizingEvaluator {
           PropertyUtil.propertyAsInt(summary, SnapshotSummary.TOTAL_DELETE_FILES_PROP, 0);
       int totalDataFiles =
           PropertyUtil.propertyAsInt(summary, SnapshotSummary.TOTAL_DATA_FILES_PROP, 0);
-      totalFileRecords = PropertyUtil.propertyAsInt(summary, SnapshotSummary.TOTAL_RECORDS_PROP, 0);
+      totalFileRecords =
+          PropertyUtil.propertyAsLong(summary, SnapshotSummary.TOTAL_RECORDS_PROP, 0);
       totalFileSize = PropertyUtil.propertyAsLong(summary, SnapshotSummary.TOTAL_FILE_SIZE_PROP, 0);
       totalFileCount = totalDeleteFiles + totalDataFiles;
       danglingDeleteFileCount =


### PR DESCRIPTION
## Why are the changes needed?

```
2024-10-21 14:35:12,212 ERROR [async-table-runtime-refresh-executor-0] [org.apache.amoro.server.table.executor.TableRuntimeRefreshExecutor] [] - Refreshing table iceberg.xxx.xxx(tableId=198) failed.
java.lang.NumberFormatException: For input string: "2498622972"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[?:1.8.0_392]
        at java.lang.Integer.parseInt(Integer.java:583) ~[?:1.8.0_392]
        at java.lang.Integer.parseInt(Integer.java:615) ~[?:1.8.0_392]
        at org.apache.iceberg.util.PropertyUtil.propertyAsInt(PropertyUtil.java:64) ~[iceberg-core-1.4.3.jar:?]
        at org.apache.amoro.server.optimizing.plan.OptimizingEvaluator$PendingInput.<init>(OptimizingEvaluator.java:239) ~[amoro-ams-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
        at org.apache.amoro.server.optimizing.plan.OptimizingEvaluator.getPendingInput(OptimizingEvaluator.java:191) ~[amoro-ams-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
        at org.apache.amoro.server.table.executor.TableRuntimeRefreshExecutor.tryEvaluatingPendingInput(TableRuntimeRefreshExecutor.java:66) ~[amoro-ams-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
        at org.apache.amoro.server.table.executor.TableRuntimeRefreshExecutor.execute(TableRuntimeRefreshExecutor.java:96) ~[amoro-ams-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
        at org.apache.amoro.server.table.executor.BaseTableExecutor.executeTask(BaseTableExecutor.java:82) ~[amoro-ams-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
        at org.apache.amoro.server.table.executor.BaseTableExecutor.lambda$scheduleIfNecessary$2(BaseTableExecutor.java:93) ~[amoro-ams-0.8-SNAPSHOT.jar:0.8-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_392]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_392]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_392]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:1.8.0_392]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_392]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_392]
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_392]
```


## Brief change log

- Use `propertyAsLong` instead of `propertyAsInt` for `total-records`.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
