### PR TITLE
[AMORO-3288] Status color of running and submitted

### DIFF
--- a/amoro-web/src/views/tables/components/Optimizing.vue
+++ b/amoro-web/src/views/tables/components/Optimizing.vue
@@ -30,7 +30,8 @@ const hasBreadcrumb = ref<boolean>(false)
 
 const statusMap = {
   PENDING: { title: 'PENDING', color: '#ffcc00' },
-  ACTIVE: { title: 'ACTIVE', color: '#1890ff' },
+  RUNNING: { title: 'RUNNING', color: '#1890ff' },
+  SUBMITTED: { title: 'SUBMITTED', color: '#4169E1' },
   CLOSED: { title: 'CLOSED', color: '#c9cdd4' },
   SUCCESS: { title: 'SUCCESS', color: '#0ad787' },
   FAILED: { title: 'FAILED', color: '#f5222d' },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
It fixes the RUNNING and SUBMITTED state color in the frontend dashboard.

Closes #3288.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
