### PR TITLE
[AMORO-1865]build a rule of relationship between table and resource group

### DIFF
--- a/amoro-ams/pom.xml
+++ b/amoro-ams/pom.xml
@@ -443,6 +443,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- check regexp whether intersect -->
+        <!-- https://mvnrepository.com/artifact/dk.brics/automaton -->
+        <dependency>
+            <groupId>dk.brics</groupId>
+            <artifactId>automaton</artifactId>
+            <version>1.12-4</version>
+        </dependency>
 
     </dependencies>
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
@@ -319,7 +319,7 @@ public class DefaultOptimizingService extends StatedPersistentBase
                   maxPlanningParallelism);
           optimizingQueueByGroup.put(resourceGroup.getName(), optimizingQueue);
         });
-    tableService.notify(TableService.NotifyEvent.RESOURCE_GROUP_INSERT, resourceGroup.getName());
+    tableService.notify(TableService.NotifyEvent.RESOURCE_GROUP_INSERT, resourceGroup);
   }
 
   @Override

--- a/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
@@ -319,6 +319,7 @@ public class DefaultOptimizingService extends StatedPersistentBase
                   maxPlanningParallelism);
           optimizingQueueByGroup.put(resourceGroup.getName(), optimizingQueue);
         });
+    tableService.notify(TableService.NotifyEvent.RESOURCE_GROUP_INSERT, resourceGroup.getName());
   }
 
   @Override
@@ -327,6 +328,7 @@ public class DefaultOptimizingService extends StatedPersistentBase
       doAs(ResourceMapper.class, mapper -> mapper.deleteResourceGroup(groupName));
       OptimizingQueue optimizingQueue = optimizingQueueByGroup.remove(groupName);
       optimizingQueue.dispose();
+      tableService.notify(TableService.NotifyEvent.RESOURCE_GROUP_DELETE, groupName);
     } else {
       throw new RuntimeException(
           String.format(
@@ -341,6 +343,7 @@ public class DefaultOptimizingService extends StatedPersistentBase
     Optional.ofNullable(optimizingQueueByGroup.get(resourceGroup.getName()))
         .ifPresent(queue -> queue.updateOptimizerGroup(resourceGroup));
     doAs(ResourceMapper.class, mapper -> mapper.updateResourceGroup(resourceGroup));
+    tableService.notify(TableService.NotifyEvent.RESOURCE_GROUP_UPDATE, resourceGroup);
   }
 
   @Override

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/OptimizerGroupController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/OptimizerGroupController.java
@@ -42,6 +42,7 @@ import org.apache.amoro.server.resource.OptimizerInstance;
 import org.apache.amoro.server.resource.ResourceContainers;
 import org.apache.amoro.server.table.TableRuntime;
 import org.apache.amoro.server.table.TableService;
+import org.apache.amoro.shade.guava32.com.google.common.base.Objects;
 import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -49,7 +50,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.BadRequestException;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /** The controller that handles optimizer requests. */
@@ -85,7 +93,7 @@ public class OptimizerGroupController {
    * @param other
    * @return
    */
-  private boolean RegExpIntersect(String one, String other) {
+  private boolean regExpIntersect(String one, String other) {
     RegExp regExp1 = new RegExp(one);
     RegExp regExp2 = new RegExp(other);
     Automaton automaton1 = regExp1.toAutomaton();
@@ -110,9 +118,9 @@ public class OptimizerGroupController {
                       otherRule -> {
                         List<String> otherRuleSpace = splitRuleNamespace(otherRule);
                         // if there have some intersection, we return false;
-                        if (RegExpIntersect(newRuleSpace.get(2), otherRuleSpace.get(2))
-                            && RegExpIntersect(newRuleSpace.get(1), otherRuleSpace.get(1))
-                            && RegExpIntersect(newRuleSpace.get(0), otherRuleSpace.get(0))) {
+                        if (regExpIntersect(newRuleSpace.get(2), otherRuleSpace.get(2))
+                            && regExpIntersect(newRuleSpace.get(1), otherRuleSpace.get(1))
+                            && regExpIntersect(newRuleSpace.get(0), otherRuleSpace.get(0))) {
                           result.add(
                               String.format("%s -> %s:%s", newRule, otherGroupName, otherRule));
                         }
@@ -130,7 +138,7 @@ public class OptimizerGroupController {
   private List<List<String>> groupRuleOverlap(String newRules, String newName) {
     List<List<String>> result =
         optimizerManager.listResourceGroups().stream()
-            .filter(item -> !Objects.equals(item.getName(), newName))
+            .filter(item -> !Objects.equal(item.getName(), newName))
             .filter(item -> item.getOptimizeGroupRule() != null)
             .map(item -> groupRuleOverlap(newRules, item.getOptimizeGroupRule(), item.getName()))
             .filter(olItem -> olItem.size() > 0)
@@ -385,7 +393,7 @@ public class OptimizerGroupController {
     // check if the new rules is conflict with others
     String oldRules = optimizerManager.getResourceGroup(name).getOptimizeGroupRule();
     String newRules = newGroup.getOptimizeGroupRule();
-    if (!Objects.equals(oldRules, newRules)) {
+    if (!Objects.equal(oldRules, newRules)) {
       // only check the rule updated
       List<List<String>> intersectionMsg = groupRuleOverlap(newRules, name);
       if (intersectionMsg.size() > 0) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/OptimizerGroupController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/OptimizerGroupController.java
@@ -136,6 +136,9 @@ public class OptimizerGroupController {
    * @return
    */
   private List<List<String>> groupRuleOverlap(String newRules, String newName) {
+    if (newRules == null) {
+      return new ArrayList<>();
+    }
     List<List<String>> result =
         optimizerManager.listResourceGroups().stream()
             .filter(item -> !Objects.equal(item.getName(), newName))
@@ -393,7 +396,7 @@ public class OptimizerGroupController {
     // check if the new rules is conflict with others
     String oldRules = optimizerManager.getResourceGroup(name).getOptimizeGroupRule();
     String newRules = newGroup.getOptimizeGroupRule();
-    if (!Objects.equal(oldRules, newRules)) {
+    if (newRules != null && !Objects.equal(oldRules, newRules)) {
       // only check the rule updated
       List<List<String>> intersectionMsg = groupRuleOverlap(newRules, name);
       if (intersectionMsg.size() > 0) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -19,6 +19,7 @@
 package org.apache.amoro.server.dashboard.controller;
 
 import static org.apache.amoro.properties.CatalogMetaProperties.CATALOG_TYPE_HIVE;
+import static org.apache.amoro.table.TableProperties.SELF_OPTIMIZING_GROUP;
 
 import io.javalin.http.Context;
 import org.apache.amoro.Constants;
@@ -155,6 +156,12 @@ public class TableController {
       if (tableRuntimeSummary != null) {
         tableSummary.setHealthScore(tableRuntimeSummary.getHealthScore());
       }
+      // show the optimizeGroup in tableRuntime.
+      serverTableMeta
+          .getProperties()
+          .put(
+              SELF_OPTIMIZING_GROUP,
+              tableService.getRuntime(serverTableIdentifier.get().getId()).getOptimizerGroup());
     } else {
       tableSummary.setOptimizingStatus(OptimizingStatus.IDLE.name());
     }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/CatalogMetaMapper.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/CatalogMetaMapper.java
@@ -74,7 +74,7 @@ public interface CatalogMetaMapper {
         column = "catalog_properties",
         typeHandler = Map2StringConverter.class)
   })
-  List<CatalogMeta> getCatalog(@Param("catalogName") String catalogName);
+  CatalogMeta getCatalog(@Param("catalogName") String catalogName);
 
   @Insert(
       "INSERT INTO "

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
@@ -70,7 +70,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableRuntime.java
@@ -41,6 +41,7 @@ import org.apache.amoro.server.table.blocker.TableBlocker;
 import org.apache.amoro.server.utils.IcebergTableUtil;
 import org.apache.amoro.shade.guava32.com.google.common.base.MoreObjects;
 import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
+import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.amoro.table.BaseTable;
 import org.apache.amoro.table.ChangeTable;
 import org.apache.amoro.table.MixedTable;
@@ -49,6 +50,7 @@ import org.apache.iceberg.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
@@ -280,9 +282,16 @@ public class TableRuntime extends StatedPersistentBase {
           () -> {
             TableConfiguration configuration = null;
             try {
-              configuration = tableConfiguration.clone();
-            } catch (Exception e) {
-              LOG.error("Failed to set table to optimizingConfig, group: {}", optimizerGroup);
+              ObjectMapper objectMapper = new ObjectMapper();
+              configuration =
+                  objectMapper.readValue(
+                      objectMapper.writeValueAsBytes(tableConfiguration), TableConfiguration.class);
+            } catch (IOException e) {
+              LOG.error(
+                  "[{}]Failed to update optimizerGroup {}",
+                  this.tableIdentifier.getTableFullName(),
+                  optimizerGroup,
+                  e);
               return this;
             }
             // shutdown the process;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableService.java
@@ -118,7 +118,7 @@ public interface TableService extends CatalogService, TableManager {
 
   <T> void notify(NotifyEvent e, T param);
 
-  static enum NotifyEvent {
+  enum NotifyEvent {
     RESOURCE_GROUP_INSERT,
     RESOURCE_GROUP_UPDATE,
     RESOURCE_GROUP_DELETE

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableService.java
@@ -115,4 +115,12 @@ public interface TableService extends CatalogService, TableManager {
       @Nullable List<Integer> statusCodeFilters,
       int limit,
       int offset);
+
+  <T> void notify(NotifyEvent e, T param);
+
+  static enum NotifyEvent {
+    RESOURCE_GROUP_INSERT,
+    RESOURCE_GROUP_UPDATE,
+    RESOURCE_GROUP_DELETE
+  }
 }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/executor/DanglingDeleteFilesCleaningExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/executor/DanglingDeleteFilesCleaningExecutor.java
@@ -29,7 +29,8 @@ import org.slf4j.LoggerFactory;
 /** Clean table dangling delete files */
 public class DanglingDeleteFilesCleaningExecutor extends BaseTableExecutor {
 
-  private static final Logger LOG = LoggerFactory.getLogger(OrphanFilesCleaningExecutor.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DanglingDeleteFilesCleaningExecutor.class);
 
   private static final long INTERVAL = 24 * 60 * 60 * 1000L;
 

--- a/amoro-common/src/main/java/org/apache/amoro/ServerTableIdentifier.java
+++ b/amoro-common/src/main/java/org/apache/amoro/ServerTableIdentifier.java
@@ -123,6 +123,10 @@ public class ServerTableIdentifier {
     return String.format("%s.%s.%s(tableId=%d)", catalog, database, tableName, id);
   }
 
+  public String getTableFullName() {
+    return String.format("%s.%s.%s", catalog, database, tableName);
+  }
+
   public static ServerTableIdentifier of(TableIdentifier tableIdentifier, TableFormat format) {
     return new ServerTableIdentifier(tableIdentifier, format);
   }

--- a/amoro-common/src/main/java/org/apache/amoro/config/TableConfiguration.java
+++ b/amoro-common/src/main/java/org/apache/amoro/config/TableConfiguration.java
@@ -24,7 +24,7 @@ import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgno
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TableConfiguration {
+public class TableConfiguration implements Cloneable {
   private boolean expireSnapshotEnabled;
   private long snapshotTTLMinutes;
   private int snapshotMinCount;
@@ -37,6 +37,21 @@ public class TableConfiguration {
   private TagConfiguration tagConfiguration;
 
   public TableConfiguration() {}
+
+  @Override
+  public TableConfiguration clone() throws CloneNotSupportedException {
+    return new TableConfiguration()
+        .setExpireSnapshotEnabled(this.expireSnapshotEnabled)
+        .setSnapshotTTLMinutes(this.snapshotTTLMinutes)
+        .setSnapshotMinCount(this.snapshotMinCount)
+        .setChangeDataTTLMinutes(this.changeDataTTLMinutes)
+        .setCleanOrphanEnabled(this.cleanOrphanEnabled)
+        .setOrphanExistingMinutes(this.orphanExistingMinutes)
+        .setDeleteDanglingDeleteFilesEnabled(this.deleteDanglingDeleteFilesEnabled)
+        .setOptimizingConfig(this.optimizingConfig)
+        .setExpiringDataConfig(this.expiringDataConfig)
+        .setTagConfiguration(this.tagConfiguration);
+  }
 
   public boolean isExpireSnapshotEnabled() {
     return expireSnapshotEnabled;

--- a/amoro-common/src/main/java/org/apache/amoro/config/TableConfiguration.java
+++ b/amoro-common/src/main/java/org/apache/amoro/config/TableConfiguration.java
@@ -24,7 +24,7 @@ import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgno
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TableConfiguration implements Cloneable {
+public class TableConfiguration {
   private boolean expireSnapshotEnabled;
   private long snapshotTTLMinutes;
   private int snapshotMinCount;
@@ -37,21 +37,6 @@ public class TableConfiguration implements Cloneable {
   private TagConfiguration tagConfiguration;
 
   public TableConfiguration() {}
-
-  @Override
-  public TableConfiguration clone() throws CloneNotSupportedException {
-    return new TableConfiguration()
-        .setExpireSnapshotEnabled(this.expireSnapshotEnabled)
-        .setSnapshotTTLMinutes(this.snapshotTTLMinutes)
-        .setSnapshotMinCount(this.snapshotMinCount)
-        .setChangeDataTTLMinutes(this.changeDataTTLMinutes)
-        .setCleanOrphanEnabled(this.cleanOrphanEnabled)
-        .setOrphanExistingMinutes(this.orphanExistingMinutes)
-        .setDeleteDanglingDeleteFilesEnabled(this.deleteDanglingDeleteFilesEnabled)
-        .setOptimizingConfig(this.optimizingConfig)
-        .setExpiringDataConfig(this.expiringDataConfig)
-        .setTagConfiguration(this.tagConfiguration);
-  }
 
   public boolean isExpireSnapshotEnabled() {
     return expireSnapshotEnabled;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #1865.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Front-end: 
  - Configure by adding rules in the properties of optimize-group with key 'match.rules'
  
![image](https://github.com/user-attachments/assets/f31d51dc-d159-4350-9017-42d514986205)

- Backend:
  - 1. When creating a group, rule conflict detection will be performed.
And traverse the table corresponding to the catalog default value of the current optimize-group to see if it matches the current rule and assign the value.
  - 2. When updating the optimize-group rules, rule conflict detection will be performed.
	- 1. First, the table under the current rule will be judged. If the rule no longer matches after the rule is changed, the default group of the catalog to which the table belongs will be used.
	- 2. Traverse the table corresponding to the catalog default value of the current optimize-group to see if it matches the current rule and assign the value.
  - 3. when deleting the group
	- 1. Configure the tables under the group to the default group of the catalog to which they belong.
	When the group of the above table is changed, the tableConfigureChange responsibility chain call of the table will be triggered.
  - 4. When synchronizing the external catalog, the group will be automatically matched according to regular rules.
  - 5. TableRuntimeRefreshExecutor no longer pays attention to optimize-group when refreshing.

- Special note
 We support manually adding the table name to the rules of a group, which is equivalent to the original manual configuration of the group. Because in our practice, there are some situations that require manual specification.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
