### PR TITLE
[AMORO-3308][Bugfix]: get signature check error when upload catalog config files

### DIFF
--- a/amoro-web/src/views/catalogs/Detail.vue
+++ b/amoro-web/src/views/catalogs/Detail.vue
@@ -93,6 +93,11 @@ const isEdit = computed(() => {
 const uploadUrl = computed(() => {
   return '/api/ams/v1/files'
 })
+const uploadHeaders = computed(() => {
+  return {
+    'X-Request-Source': 'Web'
+  };
+});
 const isNewCatalog = computed(() => {
   const catalog = (route.query?.catalogname || '').toString()
   return decodeURIComponent(catalog) === 'new catalog'
@@ -680,6 +685,7 @@ onMounted(() => {
               <a-upload
                 v-if="isEdit" v-model:file-list="config.fileList" name="file" accept=".xml"
                 :show-upload-list="false" :action="uploadUrl" :disabled="config.uploadLoading"
+                :headers="uploadHeaders"
                 @change="(args: UploadChangeParam<UploadFile<any>>) => uploadFile(args, config, 'STORAGE')"
               >
                 <a-button type="primary" ghost :loading="config.uploadLoading" class="g-mr-12">
@@ -729,6 +735,7 @@ onMounted(() => {
                 v-if="isEdit" v-model:file-list="config.fileList" name="file"
                 :accept="config.key === 'auth.kerberos.keytab' ? '.keytab' : '.conf'" :show-upload-list="false"
                 :action="uploadUrl" :disabled="config.uploadLoading"
+                :headers="uploadHeaders"
                 @change="(args: UploadChangeParam<UploadFile<any>>) => uploadFile(args, config)"
               >
                 <a-button type="primary" ghost :loading="config.uploadLoading" class="g-mr-12">


### PR DESCRIPTION
## Why are the changes needed?

Close #3308.

## Brief change log

The upload method was implemented additionally and did not use the default config. This bugfix adds the header 'X-Request-Source': 'Web' to the upload method.

## How was this patch tested?

![image](https://github.com/user-attachments/assets/10b6fbbc-29d6-4572-a249-7c9491a41211)
