### PR TITLE
[AMORO-3228] Remove the format suffix in judgment condition

### DIFF
--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/io/writer/IcebergFanoutPosDeleteWriter.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/io/writer/IcebergFanoutPosDeleteWriter.java
@@ -149,11 +149,7 @@ public class IcebergFanoutPosDeleteWriter<T>
             return;
           }
           posDeletes.sort(Comparator.comparingLong(PosRow::pos));
-          String fileName = TableFileUtil.getFileName(filePath.get().toString());
-          FileFormat fileFormat = FileFormat.fromFileName(fileName);
-          if (fileFormat != null) {
-            fileName = fileName.substring(0, fileName.length() - fileFormat.name().length() - 1);
-          }
+          String fileName = TableFileUtil.getFileNameWithoutExt(filePath.get().toString());
           String fileDir = TableFileUtil.getFileDir(filePath.get().toString());
           String deleteFilePath =
               format.addExtension(

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
@@ -37,14 +37,31 @@ public class TableFileUtil {
   private static final String POS_DELETE_FILE_IDENTIFIER = "delete";
 
   /**
-   * Parse file name form file path
+   * Parse file name from file path.
    *
    * @param filePath file path
-   * @return file name parsed from file path
+   * @return file name parsed from file path, e.g. data-1.parquet.
    */
   public static String getFileName(String filePath) {
     int lastSlash = filePath.lastIndexOf('/');
     return filePath.substring(lastSlash + 1);
+  }
+
+  /**
+   * Parse file name without ext from file path.
+   *
+   * @param filePath file path
+   * @return file name without ext parsed from file path, e.g. data-1.
+   */
+  public static String getFileNameWithoutExt(String filePath) {
+    String fileName = getFileName(filePath);
+
+    FileFormat fileFormat = FileFormat.fromFileName(fileName);
+    if (fileFormat != null) {
+      return fileName.substring(0, fileName.length() - fileFormat.name().length() - 1);
+    }
+
+    return fileName;
   }
 
   /**
@@ -200,12 +217,9 @@ public class TableFileUtil {
   }
 
   public static boolean isOptimizingPosDeleteFile(String dataFilePath, String posDeleteFilePath) {
-    FileFormat fileFormat = FileFormat.fromFileName(dataFilePath);
-    if (fileFormat != null) {
-      dataFilePath =
-          dataFilePath.substring(0, dataFilePath.length() - fileFormat.name().length() - 1);
-    }
-    return getFileName(posDeleteFilePath)
-        .startsWith(String.format("%s-%s", getFileName(dataFilePath), POS_DELETE_FILE_IDENTIFIER));
+    return getFileNameWithoutExt(posDeleteFilePath)
+        .startsWith(
+            String.format(
+                "%s-%s", getFileNameWithoutExt(dataFilePath), POS_DELETE_FILE_IDENTIFIER));
   }
 }

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
@@ -217,7 +217,7 @@ public class TableFileUtil {
   }
 
   public static boolean isOptimizingPosDeleteFile(String dataFilePath, String posDeleteFilePath) {
-    return getFileNameWithoutExt(posDeleteFilePath)
+    return getFileName(posDeleteFilePath)
         .startsWith(
             String.format(
                 "%s-%s", getFileNameWithoutExt(dataFilePath), POS_DELETE_FILE_IDENTIFIER));

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
@@ -20,6 +20,7 @@ package org.apache.amoro.utils;
 
 import org.apache.amoro.io.AuthenticatedFileIO;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -199,6 +200,11 @@ public class TableFileUtil {
   }
 
   public static boolean isOptimizingPosDeleteFile(String dataFilePath, String posDeleteFilePath) {
+    FileFormat fileFormat = FileFormat.fromFileName(dataFilePath);
+    if (fileFormat != null) {
+      dataFilePath =
+          dataFilePath.substring(0, dataFilePath.length() - fileFormat.name().length() - 1);
+    }
     return getFileName(posDeleteFilePath)
         .startsWith(String.format("%s-%s", getFileName(dataFilePath), POS_DELETE_FILE_IDENTIFIER));
   }

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/io/TestIcebergFanoutPosDeleteWriter.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/io/TestIcebergFanoutPosDeleteWriter.java
@@ -127,6 +127,8 @@ public class TestIcebergFanoutPosDeleteWriter extends TableTestBase {
                         dataDir, fileFormat.addExtension("data-1-delete-suffix")))
                 .toString());
     Assert.assertNotNull(deleteFile1);
+    Assert.assertTrue(
+        TableFileUtil.isOptimizingPosDeleteFile(dataFile1Path, deleteFile1.path().toString()));
     Assert.assertEquals(3, deleteFile1.recordCount());
     // Check whether the path-pos pairs are sorted as expected.
     Schema pathPosSchema = DeleteSchemaUtil.pathPosSchema();
@@ -147,6 +149,8 @@ public class TestIcebergFanoutPosDeleteWriter extends TableTestBase {
                         dataDir, fileFormat.addExtension("data-2-delete-suffix")))
                 .toString());
     Assert.assertNotNull(deleteFile2);
+    Assert.assertTrue(
+        TableFileUtil.isOptimizingPosDeleteFile(dataFile2Path, deleteFile2.path().toString()));
     Assert.assertEquals(
         new Path(
                 TableFileUtil.getNewFilePath(


### PR DESCRIPTION
## Why are the changes needed?

Relate for #3228 

Unable to judge correctly, need to remove the format suffix.

## Brief change log

| - |example|
|:--:|:--:|
|dataFilePath|./data/data-1.parquet| 
|posDeleteFilePath | ./data/data-1-delete-suffix.parquet|

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
