### PR TITLE
[AMORO-3330] Reducing redundant 'databaseExists' in 'CommonUnifiedCatalog'

### DIFF
--- a/amoro-common/src/main/java/org/apache/amoro/CommonUnifiedCatalog.java
+++ b/amoro-common/src/main/java/org/apache/amoro/CommonUnifiedCatalog.java
@@ -102,18 +102,11 @@ public class CommonUnifiedCatalog implements UnifiedCatalog {
 
   @Override
   public void createDatabase(String database) {
-    if (databaseExists(database)) {
-      throw new AlreadyExistsException("Database: " + database + " already exists.");
-    }
-
     findFirstFormatCatalog(TableFormat.values()).createDatabase(database);
   }
 
   @Override
   public void dropDatabase(String database) {
-    if (!databaseExists(database)) {
-      throw new NoSuchDatabaseException("Database: " + database + " does not exist.");
-    }
     if (!listTables(database).isEmpty()) {
       throw new IllegalStateException("Database: " + database + " is not empty.");
     }
@@ -148,9 +141,6 @@ public class CommonUnifiedCatalog implements UnifiedCatalog {
 
   @Override
   public List<TableIDWithFormat> listTables(String database) {
-    if (!databaseExists(database)) {
-      throw new NoSuchDatabaseException("Database: " + database + " does not exist.");
-    }
     TableFormat[] formats =
         new TableFormat[] {
           TableFormat.MIXED_HIVE,

--- a/amoro-format-hudi/src/main/java/org/apache/amoro/formats/hudi/HudiHadoopCatalog.java
+++ b/amoro-format-hudi/src/main/java/org/apache/amoro/formats/hudi/HudiHadoopCatalog.java
@@ -21,6 +21,7 @@ package org.apache.amoro.formats.hudi;
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.DatabaseNotEmptyException;
 import org.apache.amoro.FormatCatalog;
+import org.apache.amoro.NoSuchDatabaseException;
 import org.apache.amoro.NoSuchTableException;
 import org.apache.amoro.properties.CatalogMetaProperties;
 import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
@@ -155,7 +156,12 @@ public class HudiHadoopCatalog implements FormatCatalog {
         () -> {
           FileSystem fs = fs();
           Path databasePath = new Path(warehouse, database);
-          FileStatus[] items = fs.listStatus(databasePath);
+          FileStatus[] items;
+          try {
+            items = fs.listStatus(databasePath);
+          } catch (FileNotFoundException e) {
+            throw new NoSuchDatabaseException("Database: " + database + " is not exists", e);
+          }
           if (items == null || items.length == 0) {
             return Lists.newArrayList();
           }

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/mixed/MixedCatalog.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/mixed/MixedCatalog.java
@@ -20,6 +20,7 @@ package org.apache.amoro.formats.mixed;
 
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.FormatCatalog;
+import org.apache.amoro.NoSuchDatabaseException;
 import org.apache.amoro.TableFormat;
 import org.apache.amoro.mixed.MixedFormatCatalog;
 import org.apache.amoro.table.MixedTable;
@@ -76,9 +77,13 @@ public class MixedCatalog implements FormatCatalog {
 
   @Override
   public List<String> listTables(String database) {
-    return catalog.listTables(database).stream()
-        .map(TableIdentifier::getTableName)
-        .collect(Collectors.toList());
+    try {
+      return catalog.listTables(database).stream()
+          .map(TableIdentifier::getTableName)
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new NoSuchDatabaseException("Database: " + database + " is not exists", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3330
## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->
1）the 'databaseExists' call in 'CommonUnifiedCatalog#createDatabase' and 'CommonUnifiedCatalog#dropDatabase' can be suppressed by the subsequent logic, so we delete redundant 'databaseExists' in those functions.
2) the 'databaseExists' in  'CommonUnifiedCatalog#listTables' can not be removed directly, because the 'HudiHadoopCatalog#listTables' and 'MixedCatalog#listTables' methods called in 'FormatCatalog#listTables' do not explicitly throw NoSuchDatabaseException. We add exception handling for NoSuchDatabaseException in these functions to eliminate the redundancy of 'databaseExists' in 'CommonUnifiedCatalog#listTables'.


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
