### PR TITLE
[Improvement] expose 'http-server.rest-auth-type' variable in Helm chart

### DIFF
--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -52,7 +52,7 @@ data:
           bind-port: {{ .Values.server.optimizing.port }}
 
       http-server:
-        rest-auth-type: {{ .Values.amoroConf.ams.restAuthType }}
+        rest-auth-type: {{ .Values.server.rest.restAuthType }}
         bind-port: {{ .Values.server.rest.port }}
 
       refresh-external-catalogs:

--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -52,6 +52,7 @@ data:
           bind-port: {{ .Values.server.optimizing.port }}
 
       http-server:
+        rest-auth-type: {{ .Values.amoroConf.ams.restAuthType }}
         bind-port: {{ .Values.server.rest.port }}
 
       refresh-external-catalogs:

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -142,6 +142,7 @@ amoroConf:
   ams:
     adminUsername: admin
     adminPassword: admin
+    restAuthType: token
 
   ## AMS database properties, default value is derby. For production environment, suggest to use mysql
   ##

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -86,6 +86,7 @@ server:
   rest:
     enabled: true
     port: 1630
+    restAuthType: token
     service:
       ## @param type Can set as "ClusterIP" or "NodePort". If set to "NodePort", @param nodePort below should set a value
       ##
@@ -142,7 +143,6 @@ amoroConf:
   ams:
     adminUsername: admin
     adminPassword: admin
-    restAuthType: token
 
   ## AMS database properties, default value is derby. For production environment, suggest to use mysql
   ##


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #xxx.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- export http-server.rest-auth-type variable in helm chart value.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
