### PR TITLE
[AMORO-3367] Avoid throwing StringIndexOutOfBoundsException in flink optimizer executors

### DIFF
--- a/amoro-optimizer/amoro-optimizer-flink/src/main/java/org/apache/amoro/optimizer/flink/FlinkOptimizerExecutor.java
+++ b/amoro-optimizer/amoro-optimizer-flink/src/main/java/org/apache/amoro/optimizer/flink/FlinkOptimizerExecutor.java
@@ -75,8 +75,9 @@ public class FlinkOptimizerExecutor extends OptimizerExecutor {
       if (runtimeContext != null && !runtimeContext.isEmpty()) {
         runtimeContext.forEach((k, v) -> sb.append(k).append("=").append(v).append("\n"));
       }
+      String errorMsg = sb + result.getErrorMessage();
       result.setErrorMessage(
-          (sb + result.getErrorMessage()).substring(0, ERROR_MESSAGE_MAX_LENGTH));
+          errorMsg.substring(0, Math.min(ERROR_MESSAGE_MAX_LENGTH, errorMsg.length())));
     }
     return result;
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3367.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Retry the optimization process when a task fails, and handle unexpected errors that occur while extracting error messages.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
