### PR TITLE
[AMORO-3387]fix: create table like using mixed_hive

### DIFF
--- a/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
@@ -33,7 +33,7 @@
     <url>https://amoro.apache.org</url>
 
     <properties>
-        <iceberg.version>1.4.3</iceberg.version>
+<!--        <iceberg.version>1.4.3</iceberg.version>-->
         <spark.version>3.2.4</spark.version>
         <scala.version>2.12.15</scala.version>
     </properties>

--- a/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
@@ -33,7 +33,6 @@
     <url>https://amoro.apache.org</url>
 
     <properties>
-<!--        <iceberg.version>1.4.3</iceberg.version>-->
         <spark.version>3.2.4</spark.version>
         <scala.version>2.12.15</scala.version>
     </properties>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -95,7 +95,7 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
                 mixedSparkTable.table().asKeyedTable().primaryKeySpec().fieldNames()))
           case _ =>
         }
-        targetProperties += ("provider" -> "mixed_hive")
+        targetProperties += ("provider" -> provider.get)
         CreateV2Table(
           targetCatalog,
           targetIdentifier,

--- a/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.2/amoro-mixed-spark-3.2/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -47,12 +47,8 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
 
   private def isCreateMixedFormatTable(catalog: TableCatalog, provider: Option[String]): Boolean = {
     catalog match {
-      case _: MixedFormatSparkCatalog => true
-      case _: MixedFormatSparkSessionCatalog[_] =>
-        provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
-          provider.get.toLowerCase)
-      case _: SparkUnifiedCatalog => true
-      case _: SparkUnifiedSessionCatalog[_] =>
+      case _: MixedFormatSparkCatalog | _: MixedFormatSparkSessionCatalog[_]
+          | _: SparkUnifiedCatalog | _: SparkUnifiedSessionCatalog[_] =>
         provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
           provider.get.toLowerCase)
       case _ => false

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -47,12 +47,8 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
 
   private def isCreateMixedFormatTable(catalog: TableCatalog, provider: Option[String]): Boolean = {
     catalog match {
-      case _: MixedFormatSparkCatalog => true
-      case _: MixedFormatSparkSessionCatalog[_] =>
-        provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
-          provider.get.toLowerCase)
-      case _: SparkUnifiedCatalog => true
-      case _: SparkUnifiedSessionCatalog[_] =>
+      case _: MixedFormatSparkCatalog | _: MixedFormatSparkSessionCatalog[_]
+          | _: SparkUnifiedCatalog | _: SparkUnifiedSessionCatalog[_] =>
         provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
           provider.get.toLowerCase)
       case _ => false
@@ -92,7 +88,7 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
         val (targetCatalog, targetIdentifier) = buildCatalogAndIdentifier(sparkSession, targetTable)
         val table = sourceCatalog.loadTable(sourceIdentifier)
         var targetProperties = properties
-        targetProperties += ("provider" -> "mixed_hive")
+        targetProperties += ("provider" -> provider.getOrElse("mixed_hive"))
         table match {
           case keyedTable: MixedSparkTable =>
             keyedTable.table() match {

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -88,7 +88,7 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
         val (targetCatalog, targetIdentifier) = buildCatalogAndIdentifier(sparkSession, targetTable)
         val table = sourceCatalog.loadTable(sourceIdentifier)
         var targetProperties = properties
-        targetProperties += ("provider" -> provider.getOrElse("mixed_hive"))
+        targetProperties += ("provider" -> provider.get)
         table match {
           case keyedTable: MixedSparkTable =>
             keyedTable.table() match {

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -120,13 +120,7 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
               targetTable.identifier)
             val name = ResolvedDBObjectName(targetCatalog, seq)
             CreateTable(name, table.schema(), table.partitioning(), tableSpec, ifNotExists)
-          case _ =>
-            provider.isDefined match {
-              case true =>
-                throw new UnsupportedOperationException(
-                  s"format ${provider.get} does not support create table like command!!!")
-              case false => plan
-            }
+          case _ => plan
         }
       case _ => plan
     }

--- a/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -47,12 +47,8 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
 
   private def isCreateMixedFormatTable(catalog: TableCatalog, provider: Option[String]): Boolean = {
     catalog match {
-      case _: MixedFormatSparkCatalog => true
-      case _: MixedFormatSparkSessionCatalog[_] =>
-        provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
-          provider.get.toLowerCase)
-      case _: SparkUnifiedCatalog => true
-      case _: SparkUnifiedSessionCatalog[_] =>
+      case _: MixedFormatSparkCatalog | _: MixedFormatSparkSessionCatalog[_]
+          | _: SparkUnifiedCatalog | _: SparkUnifiedSessionCatalog[_] =>
         provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
           provider.get.toLowerCase)
       case _ => false

--- a/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.execution.command.CreateTableLikeCommand
 
-import org.apache.amoro.spark.{MixedFormatSparkCatalog, MixedFormatSparkSessionCatalog}
+import org.apache.amoro.spark.{MixedFormatSparkCatalog, MixedFormatSparkSessionCatalog, SparkUnifiedCatalog, SparkUnifiedSessionCatalog}
 import org.apache.amoro.spark.mixed.MixedSessionCatalogBase
 import org.apache.amoro.spark.sql.MixedFormatExtensionUtils.buildCatalogAndIdentifier
 import org.apache.amoro.spark.sql.catalyst.plans.{AlterMixedFormatTableDropPartition, TruncateMixedFormatTable}
@@ -49,6 +49,10 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
     catalog match {
       case _: MixedFormatSparkCatalog => true
       case _: MixedFormatSparkSessionCatalog[_] =>
+        provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
+          provider.get.toLowerCase)
+      case _: SparkUnifiedCatalog => true
+      case _: SparkUnifiedSessionCatalog[_] =>
         provider.isDefined && MixedSessionCatalogBase.SUPPORTED_PROVIDERS.contains(
           provider.get.toLowerCase)
       case _ => false
@@ -111,7 +115,9 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
           serde = None,
           external = false)
         val identifier =
-          Identifier.of(Array.apply(targetTable.database.get), targetTable.identifier)
+          Identifier.of(
+            Array.apply(targetTable.database.getOrElse(sparkSession.catalog.currentDatabase)),
+            targetTable.identifier)
         val name = ResolvedIdentifier(targetCatalog, identifier)
         CreateTable(name, table.schema(), table.partitioning(), tableSpec, ifNotExists)
       case _ => plan

--- a/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/amoro/spark/sql/catalyst/analysis/RewriteMixedFormatCommand.scala
@@ -90,7 +90,7 @@ case class RewriteMixedFormatCommand(sparkSession: SparkSession) extends Rule[Lo
         val (targetCatalog, targetIdentifier) = buildCatalogAndIdentifier(sparkSession, targetTable)
         val table = sourceCatalog.loadTable(sourceIdentifier)
         var targetProperties = properties
-        targetProperties += ("provider" -> "arctic")
+        targetProperties += ("provider" -> provider.get)
         table match {
           case keyedTable: MixedSparkTable =>
             keyedTable.table() match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
Enviroment:
format: mixed_hive
engine: spark3.3
catalog: `sparkUnifiedSessionCatalog`

bug:
table created by using `create table like  using mixed_hive`  is not a mixed_hive table.

```
spark-sql> create table ctl_demo(id int ,name string, dt string) using mixed_hive partitioned by (dt);
Time taken: 1.137 seconds
spark-sql> show create table ctl_demo;
CREATE TABLE spark_catalog.amoro_v7.ctl_demo (
  id INT,
  name STRING,
  dt STRING)
USING mixed_hive
PARTITIONED BY (dt)
TBLPROPERTIES (
  'base.hive.location-root' = 'hdfs://easyops-cluster/user/warehouse/amoro_v7.db/ctl_demo/hive',
  'base.write.format' = 'parquet',
  'delta.write.format' = 'parquet',
  'flink.max-continuous-empty-commits' = '2147483647',
  'schema.name-mapping.default' = '[ {
  "field-id" : 1,
  "names" : [ "id" ]
}, {
  "field-id" : 2,
  "names" : [ "name" ]
}, {
  "field-id" : 3,
  "names" : [ "dt" ]
} ]',
  'self-optimizing.group' = 'amovo_v7',
  'table.create-timestamp' = '1735817876108',
  'write.metadata.delete-after-commit.enabled' = 'true',
  'write.parquet.compression-codec' = 'zstd')

Time taken: 0.893 seconds, Fetched 1 row(s)
spark-sql> create table ctl_demo_like like ctl_demo using mixed_hive;
Time taken: 0.501 seconds
spark-sql> show create table ctl_demo_like;
CREATE TABLE amoro_v7.ctl_demo_like (
  id INT,
  name STRING,
  dt STRING)
USING mixed_hive
PARTITIONED BY (dt)

Time taken: 0.103 seconds, Fetched 1 row(s)
spark-sql>
```

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-  modify provider to `mixed_hive`
-  support  like sourceTable without databases


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
