### PR TITLE
[AMORO-3389][improvement]support add comment to mixed_hive table

### DIFF
--- a/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/catalog/MixedHiveTables.java
+++ b/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/catalog/MixedHiveTables.java
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 public class MixedHiveTables {
 
@@ -510,6 +511,11 @@ public class MixedHiveTables {
       TableMeta meta, Schema schema, PartitionSpec partitionSpec) {
     final long currentTimeMillis = System.currentTimeMillis();
 
+    // set table comment here!
+    Map<String, String> parameters = new HashMap<>();
+    Optional<String> comment = Optional.ofNullable(meta.getProperties().get("comment"));
+    comment.ifPresent(val -> parameters.put("comment", val));
+
     org.apache.hadoop.hive.metastore.api.Table newTable =
         new org.apache.hadoop.hive.metastore.api.Table(
             meta.getTableIdentifier().getTableName(),
@@ -521,7 +527,7 @@ public class MixedHiveTables {
             Integer.MAX_VALUE,
             null,
             HiveSchemaUtil.hivePartitionFields(schema, partitionSpec),
-            new HashMap<>(),
+            parameters,
             null,
             null,
             TableType.EXTERNAL_TABLE.toString());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

**format**: mixed_hive
**engine**: spark
**improvement**: the comment does not be passed to hive table when create a mixed_hive table.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-  pass `comment`  when call hms api to create a hive table

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
