### PR TITLE
[AMORO-3393]: A stateless catalog manager implement

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
@@ -51,8 +51,8 @@ public class AmoroManagementConf {
           .defaultValue("admin")
           .withDescription("The administrator password");
 
-  public static final ConfigOption<Duration> CACHE_CATALOG_META_DURATION =
-      ConfigOptions.key("cache.catalog-meta.duration")
+  public static final ConfigOption<Duration> CATALOG_META_CACHE_EXPIRATION_INTERVAL =
+      ConfigOptions.key("catalog-meta-cache.expiration-interval")
           .durationType()
           .defaultValue(Duration.ofSeconds(60))
           .withDescription("TTL for catalog metadata.");

--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
@@ -51,6 +51,12 @@ public class AmoroManagementConf {
           .defaultValue("admin")
           .withDescription("The administrator password");
 
+  public static final ConfigOption<Duration> CACHE_CATALOG_META_DURATION =
+      ConfigOptions.key("cache.catalog-meta.duration")
+          .durationType()
+          .defaultValue(Duration.ofSeconds(60))
+          .withDescription("TTL for catalog metadata.");
+
   public static final ConfigOption<Integer> TABLE_MANIFEST_IO_THREAD_COUNT =
       ConfigOptions.key("table-manifest-io.thread-count")
           .intType()

--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
@@ -151,7 +151,7 @@ public class AmoroServiceContainer {
 
     catalogManager = new DefaultCatalogManager(serviceConfig);
     tableService = new DefaultTableService(serviceConfig, catalogManager);
-    optimizingService = new DefaultOptimizingService(serviceConfig, tableService);
+    optimizingService = new DefaultOptimizingService(serviceConfig, catalogManager, tableService);
 
     LOG.info("Setting up AMS table executors...");
     AsyncTableExecutors.getInstance().setup(tableService, serviceConfig);
@@ -168,7 +168,7 @@ public class AmoroServiceContainer {
     addHandlerChain(AsyncTableExecutors.getInstance().getTagsAutoCreatingExecutor());
     tableService.initialize();
     LOG.info("AMS table service have been initialized");
-    terminalManager = new TerminalManager(serviceConfig, tableService);
+    terminalManager = new TerminalManager(serviceConfig, catalogManager, tableService);
 
     initThriftService();
     startThriftService();

--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
@@ -28,6 +28,8 @@ import org.apache.amoro.api.OptimizingService;
 import org.apache.amoro.config.ConfigHelpers;
 import org.apache.amoro.config.Configurations;
 import org.apache.amoro.exception.AmoroRuntimeException;
+import org.apache.amoro.server.catalog.CatalogManager;
+import org.apache.amoro.server.catalog.DefaultCatalogManager;
 import org.apache.amoro.server.dashboard.DashboardServer;
 import org.apache.amoro.server.dashboard.JavalinJsonMapper;
 import org.apache.amoro.server.dashboard.response.ErrorResponse;
@@ -92,6 +94,7 @@ public class AmoroServiceContainer {
 
   private final HighAvailabilityContainer haContainer;
   private DataSource dataSource;
+  private CatalogManager catalogManager;
   private DefaultTableService tableService;
   private DefaultOptimizingService optimizingService;
   private TerminalManager terminalManager;
@@ -146,7 +149,8 @@ public class AmoroServiceContainer {
     EventsManager.getInstance();
     MetricManager.getInstance();
 
-    tableService = new DefaultTableService(serviceConfig);
+    catalogManager = new DefaultCatalogManager(serviceConfig);
+    tableService = new DefaultTableService(serviceConfig, catalogManager);
     optimizingService = new DefaultOptimizingService(serviceConfig, tableService);
 
     LOG.info("Setting up AMS table executors...");
@@ -240,8 +244,9 @@ public class AmoroServiceContainer {
 
   private void initHttpService() {
     DashboardServer dashboardServer =
-        new DashboardServer(serviceConfig, tableService, optimizingService, terminalManager);
-    RestCatalogService restCatalogService = new RestCatalogService(tableService);
+        new DashboardServer(
+            serviceConfig, catalogManager, tableService, optimizingService, terminalManager);
+    RestCatalogService restCatalogService = new RestCatalogService(catalogManager, tableService);
 
     httpServer =
         Javalin.create(
@@ -333,7 +338,7 @@ public class AmoroServiceContainer {
         new AmoroTableMetastore.Processor<>(
             ThriftServiceProxy.createProxy(
                 AmoroTableMetastore.Iface.class,
-                new TableManagementService(tableService),
+                new TableManagementService(catalogManager, tableService),
                 AmoroRuntimeException::normalizeCompatibly));
     tableManagementServer =
         createThriftServer(
@@ -534,6 +539,11 @@ public class AmoroServiceContainer {
   @VisibleForTesting
   public TableService getTableService() {
     return this.tableService;
+  }
+
+  @VisibleForTesting
+  public CatalogManager getCatalogManager() {
+    return this.catalogManager;
   }
 
   @VisibleForTesting

--- a/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
@@ -39,6 +39,7 @@ import org.apache.amoro.TableFormat;
 import org.apache.amoro.events.IcebergReportEvent;
 import org.apache.amoro.exception.ObjectNotExistsException;
 import org.apache.amoro.properties.CatalogMetaProperties;
+import org.apache.amoro.server.catalog.CatalogManager;
 import org.apache.amoro.server.catalog.InternalCatalog;
 import org.apache.amoro.server.catalog.ServerCatalog;
 import org.apache.amoro.server.manager.EventsManager;
@@ -106,9 +107,11 @@ public class RestCatalogService extends PersistentBase {
 
   private final JavalinJackson jsonMapper;
 
+  private final CatalogManager catalogManager;
   private final TableService tableService;
 
-  public RestCatalogService(TableService tableService) {
+  public RestCatalogService(CatalogManager catalogManager, TableService tableService) {
+    this.catalogManager = catalogManager;
     this.tableService = tableService;
     ObjectMapper objectMapper = jsonMapper();
     this.jsonMapper = new JavalinJackson(objectMapper);
@@ -432,7 +435,7 @@ public class RestCatalogService extends PersistentBase {
 
   private InternalCatalog getCatalog(String catalog) {
     Preconditions.checkNotNull(catalog, "lack required path variables: catalog");
-    ServerCatalog internalCatalog = tableService.getServerCatalog(catalog);
+    ServerCatalog internalCatalog = catalogManager.getServerCatalog(catalog);
     Preconditions.checkArgument(
         internalCatalog instanceof InternalCatalog, "The catalog is not an iceberg rest catalog");
     Set<TableFormat> tableFormats = CatalogUtil.tableFormats(internalCatalog.getMetadata());

--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/CatalogManager.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/CatalogManager.java
@@ -22,8 +22,8 @@ import org.apache.amoro.api.CatalogMeta;
 
 import java.util.List;
 
-/** The CatalogService interface defines the operations that can be performed on catalogs. */
-public interface CatalogService {
+/** The CatalogManager interface defines the operations that can be performed on catalogs. */
+public interface CatalogManager {
   /**
    * Returns a list of CatalogMeta objects.
    *
@@ -61,6 +61,13 @@ public interface CatalogService {
    * @return the InternalCatalog object matching the catalogName, or null if no catalog exists
    */
   InternalCatalog getInternalCatalog(String catalogName);
+
+  /**
+   * Retrieves all ExternalCatalogs.
+   *
+   * @return a list of ExternalCatalogs
+   */
+  List<ExternalCatalog> getExternalCatalogs();
 
   /**
    * Creates a catalog based on the provided catalog meta information. The catalog name is obtained

--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/DefaultCatalogManager.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/DefaultCatalogManager.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.catalog;
+
+import org.apache.amoro.api.CatalogMeta;
+import org.apache.amoro.config.Configurations;
+import org.apache.amoro.exception.AlreadyExistsException;
+import org.apache.amoro.exception.IllegalMetadataException;
+import org.apache.amoro.exception.ObjectNotExistsException;
+import org.apache.amoro.server.persistence.PersistentBase;
+import org.apache.amoro.server.persistence.mapper.CatalogMetaMapper;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DefaultCatalogManager extends PersistentBase implements CatalogManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultCatalogManager.class);
+  protected final Configurations serverConfiguration;
+
+  private final Map<String, ServerCatalog> serverCatalogMap = Maps.newConcurrentMap();
+
+  public DefaultCatalogManager(Configurations serverConfiguration) {
+    this.serverConfiguration = serverConfiguration;
+    listCatalogMetas()
+        .forEach(
+            c -> {
+              ServerCatalog serverCatalog =
+                  CatalogBuilder.buildServerCatalog(c, serverConfiguration);
+              serverCatalogMap.put(c.getCatalogName(), serverCatalog);
+            });
+    LOG.info("DefaultCatalogManager initialized, total catalogs: {}", serverCatalogMap.size());
+  }
+
+  @Override
+  public List<CatalogMeta> listCatalogMetas() {
+    return getAs(CatalogMetaMapper.class, CatalogMetaMapper::getCatalogs);
+  }
+
+  @Override
+  public CatalogMeta getCatalogMeta(String catalogName) {
+    return getAs(
+        CatalogMetaMapper.class, catalogMetaMapper -> catalogMetaMapper.getCatalog(catalogName));
+  }
+
+  @Override
+  public boolean catalogExist(String catalogName) {
+    return getCatalogMeta(catalogName) != null;
+  }
+
+  @Override
+  public ServerCatalog getServerCatalog(String catalogName) {
+    CatalogMeta catalogMeta = getCatalogMeta(catalogName);
+    if (catalogMeta == null) {
+      // remove if catalog is deleted
+      disposeCatalog(catalogName);
+      return null;
+    }
+    ServerCatalog serverCatalog =
+        serverCatalogMap.computeIfAbsent(
+            catalogName, n -> CatalogBuilder.buildServerCatalog(catalogMeta, serverConfiguration));
+    serverCatalog.reload();
+    return serverCatalog;
+  }
+
+  @Override
+  public InternalCatalog getInternalCatalog(String catalogName) {
+    ServerCatalog serverCatalog = getServerCatalog(catalogName);
+    if (serverCatalog == null) {
+      throw new ObjectNotExistsException("Catalog " + catalogName);
+    }
+    if (serverCatalog.isInternal()) {
+      return (InternalCatalog) serverCatalog;
+    }
+    throw new ObjectNotExistsException("Catalog " + catalogName + " is not internal catalog");
+  }
+
+  @Override
+  public List<ExternalCatalog> getExternalCatalogs() {
+    return listCatalogMetas().stream()
+        .map(c -> getServerCatalog(c.getCatalogName()))
+        .filter(c -> !c.isInternal())
+        .map(c -> (ExternalCatalog) c)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void createCatalog(CatalogMeta catalogMeta) {
+    if (catalogExist(catalogMeta.getCatalogName())) {
+      throw new AlreadyExistsException("Catalog " + catalogMeta.getCatalogName());
+    }
+    // Build to make sure the catalog is valid
+    ServerCatalog catalog = CatalogBuilder.buildServerCatalog(catalogMeta, serverConfiguration);
+    doAs(CatalogMetaMapper.class, mapper -> mapper.insertCatalog(catalog.getMetadata()));
+    disposeCatalog(catalogMeta.getCatalogName());
+    serverCatalogMap.put(catalogMeta.getCatalogName(), catalog);
+    LOG.info(
+        "Create catalog {}, type:{}", catalogMeta.getCatalogName(), catalogMeta.getCatalogType());
+  }
+
+  @Override
+  public void dropCatalog(String catalogName) {
+    doAs(CatalogMetaMapper.class, mapper -> mapper.deleteCatalog(catalogName));
+    disposeCatalog(catalogName);
+  }
+
+  @Override
+  public void updateCatalog(CatalogMeta catalogMeta) {
+    ServerCatalog catalog = getServerCatalog(catalogMeta.getCatalogName());
+    validateCatalogUpdate(catalog.getMetadata(), catalogMeta);
+    catalog.updateMetadata(catalogMeta);
+    LOG.info("Update catalog metadata: {}", catalogMeta.getCatalogName());
+  }
+
+  private void validateCatalogUpdate(CatalogMeta oldMeta, CatalogMeta newMeta) {
+    if (!oldMeta.getCatalogType().equals(newMeta.getCatalogType())) {
+      throw new IllegalMetadataException("Cannot update catalog type");
+    }
+  }
+
+  private void disposeCatalog(String name) {
+    serverCatalogMap.computeIfPresent(
+        name,
+        (n, c) -> {
+          LOG.info("Dispose catalog: {}", n);
+          c.dispose();
+          return null;
+        });
+  }
+}

--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/DefaultCatalogManager.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/DefaultCatalogManager.java
@@ -52,7 +52,8 @@ public class DefaultCatalogManager extends PersistentBase implements CatalogMana
 
   public DefaultCatalogManager(Configurations serverConfiguration) {
     this.serverConfiguration = serverConfiguration;
-    Duration cacheTtl = serverConfiguration.get(AmoroManagementConf.CACHE_CATALOG_META_DURATION);
+    Duration cacheTtl =
+        serverConfiguration.get(AmoroManagementConf.CATALOG_META_CACHE_EXPIRATION_INTERVAL);
     metaCache =
         CacheBuilder.newBuilder()
             .maximumSize(100)
@@ -80,8 +81,7 @@ public class DefaultCatalogManager extends PersistentBase implements CatalogMana
 
   @Override
   public List<CatalogMeta> listCatalogMetas() {
-    return getAs(CatalogMetaMapper.class, CatalogMetaMapper::getCatalogs)
-        .stream()
+    return getAs(CatalogMetaMapper.class, CatalogMetaMapper::getCatalogs).stream()
         .peek(c -> metaCache.put(c.getCatalogName(), Optional.of(c)))
         .collect(Collectors.toList());
   }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/InternalCatalog.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/InternalCatalog.java
@@ -45,6 +45,11 @@ public abstract class InternalCatalog extends ServerCatalog {
   }
 
   @Override
+  public boolean isInternal() {
+    return true;
+  }
+
+  @Override
   public List<String> listDatabases() {
     return getAs(
         TableMetaMapper.class, mapper -> mapper.selectDatabases(getMetadata().getCatalogName()));

--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/ServerCatalog.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/ServerCatalog.java
@@ -21,7 +21,6 @@ package org.apache.amoro.server.catalog;
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.TableIDWithFormat;
 import org.apache.amoro.api.CatalogMeta;
-import org.apache.amoro.exception.IllegalMetadataException;
 import org.apache.amoro.server.persistence.PersistentBase;
 import org.apache.amoro.server.persistence.mapper.CatalogMetaMapper;
 import org.apache.amoro.table.TableMetaStore;
@@ -81,14 +80,7 @@ public abstract class ServerCatalog extends PersistentBase {
   public abstract AmoroTable<?> loadTable(String database, String tableName);
 
   public void dispose() {
-    doAsTransaction(
-        () ->
-            doAsExisted(
-                CatalogMetaMapper.class,
-                mapper -> mapper.deleteCatalog(name()),
-                () ->
-                    new IllegalMetadataException(
-                        "Catalog " + name() + " has more than one database or table")));
+    // do resource clean up
   }
 
   public boolean isInternal() {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/ServerCatalog.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/ServerCatalog.java
@@ -59,6 +59,10 @@ public abstract class ServerCatalog extends PersistentBase {
     if (meta == null) {
       throw new IllegalStateException("Catalog " + metadata.getCatalogName() + " is dropped.");
     }
+    this.reload(meta);
+  }
+
+  public void reload(CatalogMeta meta) {
     if (this.metadata.equals(meta)) {
       return;
     }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
@@ -109,7 +109,8 @@ public class DashboardServer {
     this.optimizerController = new OptimizerController(optimizerManager);
     this.platformFileInfoController = new PlatformFileInfoController(platformFileManager);
     this.settingController = new SettingController(serviceConfig, optimizerManager);
-    ServerTableDescriptor tableDescriptor = new ServerTableDescriptor(tableService, serviceConfig);
+    ServerTableDescriptor tableDescriptor =
+        new ServerTableDescriptor(catalogManager, tableService, serviceConfig);
     this.tableController =
         new TableController(catalogManager, tableService, tableDescriptor, serviceConfig);
     this.terminalController = new TerminalController(terminalManager);

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
@@ -37,6 +37,7 @@ import org.apache.amoro.exception.SignatureCheckException;
 import org.apache.amoro.server.AmoroManagementConf;
 import org.apache.amoro.server.DefaultOptimizingService;
 import org.apache.amoro.server.RestCatalogService;
+import org.apache.amoro.server.catalog.CatalogManager;
 import org.apache.amoro.server.dashboard.controller.CatalogController;
 import org.apache.amoro.server.dashboard.controller.HealthCheckController;
 import org.apache.amoro.server.dashboard.controller.LoginController;
@@ -96,11 +97,12 @@ public class DashboardServer {
 
   public DashboardServer(
       Configurations serviceConfig,
+      CatalogManager catalogManager,
       TableService tableService,
       DefaultOptimizingService optimizerManager,
       TerminalManager terminalManager) {
     PlatformFileManager platformFileManager = new PlatformFileManager();
-    this.catalogController = new CatalogController(tableService, platformFileManager);
+    this.catalogController = new CatalogController(catalogManager, platformFileManager);
     this.healthCheckController = new HealthCheckController();
     this.loginController = new LoginController(serviceConfig);
     this.optimizerGroupController = new OptimizerGroupController(tableService, optimizerManager);
@@ -108,7 +110,8 @@ public class DashboardServer {
     this.platformFileInfoController = new PlatformFileInfoController(platformFileManager);
     this.settingController = new SettingController(serviceConfig, optimizerManager);
     ServerTableDescriptor tableDescriptor = new ServerTableDescriptor(tableService, serviceConfig);
-    this.tableController = new TableController(tableService, tableDescriptor, serviceConfig);
+    this.tableController =
+        new TableController(catalogManager, tableService, tableDescriptor, serviceConfig);
     this.terminalController = new TerminalController(terminalManager);
     this.versionController = new VersionController();
     this.overviewController = new OverviewController();

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/ServerTableDescriptor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/ServerTableDescriptor.java
@@ -23,6 +23,7 @@ import org.apache.amoro.TableFormat;
 import org.apache.amoro.api.TableIdentifier;
 import org.apache.amoro.config.Configurations;
 import org.apache.amoro.process.ProcessStatus;
+import org.apache.amoro.server.catalog.CatalogManager;
 import org.apache.amoro.server.catalog.ServerCatalog;
 import org.apache.amoro.server.persistence.PersistentBase;
 import org.apache.amoro.server.table.TableService;
@@ -50,10 +51,13 @@ public class ServerTableDescriptor extends PersistentBase {
 
   private final Map<TableFormat, FormatTableDescriptor> formatDescriptorMap = new HashMap<>();
 
+  private final CatalogManager catalogManager;
   private final TableService tableService;
 
-  public ServerTableDescriptor(TableService tableService, Configurations serviceConfig) {
+  public ServerTableDescriptor(
+      CatalogManager catalogManager, TableService tableService, Configurations serviceConfig) {
     this.tableService = tableService;
+    this.catalogManager = catalogManager;
 
     // All table formats will jointly reuse the work thread pool named iceberg-worker-pool-%d
     ExecutorService executorService = ThreadPools.getWorkerPool();
@@ -146,7 +150,7 @@ public class ServerTableDescriptor extends PersistentBase {
   }
 
   private AmoroTable<?> loadTable(TableIdentifier identifier) {
-    ServerCatalog catalog = tableService.getServerCatalog(identifier.getCatalog());
+    ServerCatalog catalog = catalogManager.getServerCatalog(identifier.getCatalog());
     return catalog.loadTable(identifier.getDatabase(), identifier.getTableName());
   }
 }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/CatalogMetaMapper.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/CatalogMetaMapper.java
@@ -74,7 +74,7 @@ public interface CatalogMetaMapper {
         column = "catalog_properties",
         typeHandler = Map2StringConverter.class)
   })
-  List<CatalogMeta> getCatalog(@Param("catalogName") String catalogName);
+  CatalogMeta getCatalog(@Param("catalogName") String catalogName);
 
   @Insert(
       "INSERT INTO "

--- a/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/CatalogMetaMapper.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/CatalogMetaMapper.java
@@ -111,6 +111,9 @@ public interface CatalogMetaMapper {
   @Select("SELECT table_count FROM " + TABLE_NAME + " WHERE catalog_name = #{catalogName}")
   Integer selectTableCount(@Param("catalogName") String catalogName);
 
+  @Select("SELECT database_count FROM " + TABLE_NAME + " WHERE catalog_name = #{catalogName}")
+  Integer selectDatabaseCount(@Param("catalogName") String catalogName);
+
   @Update(
       "UPDATE "
           + TABLE_NAME

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
@@ -22,7 +22,6 @@ import com.github.pagehelper.Page;
 import com.github.pagehelper.PageHelper;
 import com.github.pagehelper.PageInfo;
 import org.apache.amoro.AmoroTable;
-import org.apache.amoro.NoSuchTableException;
 import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.TableFormat;
 import org.apache.amoro.TableIDWithFormat;
@@ -38,7 +37,7 @@ import org.apache.amoro.exception.IllegalMetadataException;
 import org.apache.amoro.exception.ObjectNotExistsException;
 import org.apache.amoro.exception.PersistenceException;
 import org.apache.amoro.server.AmoroManagementConf;
-import org.apache.amoro.server.catalog.CatalogBuilder;
+import org.apache.amoro.server.catalog.CatalogManager;
 import org.apache.amoro.server.catalog.ExternalCatalog;
 import org.apache.amoro.server.catalog.InternalCatalog;
 import org.apache.amoro.server.catalog.ServerCatalog;
@@ -46,7 +45,6 @@ import org.apache.amoro.server.manager.MetricManager;
 import org.apache.amoro.server.optimizing.OptimizingStatus;
 import org.apache.amoro.server.persistence.StatedPersistentBase;
 import org.apache.amoro.server.persistence.TableRuntimeMeta;
-import org.apache.amoro.server.persistence.mapper.CatalogMetaMapper;
 import org.apache.amoro.server.persistence.mapper.TableBlockerMapper;
 import org.apache.amoro.server.persistence.mapper.TableMetaMapper;
 import org.apache.amoro.server.table.blocker.TableBlocker;
@@ -90,8 +88,6 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
   private static final int TABLE_BLOCKER_RETRY = 3;
   private final long externalCatalogRefreshingInterval;
   private final long blockerTimeout;
-  private final Map<String, InternalCatalog> internalCatalogMap = new ConcurrentHashMap<>();
-  private final Map<String, ExternalCatalog> externalCatalogMap = new ConcurrentHashMap<>();
 
   private final Map<Long, TableRuntime> tableRuntimeMap = new ConcurrentHashMap<>();
 
@@ -103,94 +99,16 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
               .build());
   private final CompletableFuture<Boolean> initialized = new CompletableFuture<>();
   private final Configurations serverConfiguration;
+  private final CatalogManager catalogManager;
   private RuntimeHandlerChain headHandler;
   private ExecutorService tableExplorerExecutors;
 
-  public DefaultTableService(Configurations configuration) {
+  public DefaultTableService(Configurations configuration, CatalogManager catalogManager) {
+    this.catalogManager = catalogManager;
     this.externalCatalogRefreshingInterval =
         configuration.getLong(AmoroManagementConf.REFRESH_EXTERNAL_CATALOGS_INTERVAL);
     this.blockerTimeout = configuration.getLong(AmoroManagementConf.BLOCKER_TIMEOUT);
     this.serverConfiguration = configuration;
-  }
-
-  @Override
-  public List<CatalogMeta> listCatalogMetas() {
-    checkStarted();
-    List<CatalogMeta> catalogs =
-        internalCatalogMap.values().stream()
-            .map(ServerCatalog::getMetadata)
-            .collect(Collectors.toList());
-    catalogs.addAll(
-        externalCatalogMap.values().stream()
-            .map(ServerCatalog::getMetadata)
-            .collect(Collectors.toList()));
-    return catalogs;
-  }
-
-  @Override
-  public CatalogMeta getCatalogMeta(String catalogName) {
-    checkStarted();
-    ServerCatalog catalog = getServerCatalog(catalogName);
-    return catalog.getMetadata();
-  }
-
-  @Override
-  public boolean catalogExist(String catalogName) {
-    checkStarted();
-    return internalCatalogMap.containsKey(catalogName)
-        || externalCatalogMap.containsKey(catalogName);
-  }
-
-  @Override
-  public ServerCatalog getServerCatalog(String catalogName) {
-    ServerCatalog catalog =
-        Optional.ofNullable((ServerCatalog) internalCatalogMap.get(catalogName))
-            .orElse(externalCatalogMap.get(catalogName));
-    return Optional.ofNullable(catalog)
-        .orElseThrow(() -> new ObjectNotExistsException("Catalog " + catalogName));
-  }
-
-  @Override
-  public void createCatalog(CatalogMeta catalogMeta) {
-    checkStarted();
-    if (catalogExist(catalogMeta.getCatalogName())) {
-      throw new AlreadyExistsException("Catalog " + catalogMeta.getCatalogName());
-    }
-    doAsTransaction(
-        () -> doAs(CatalogMetaMapper.class, mapper -> mapper.insertCatalog(catalogMeta)),
-        () -> initServerCatalog(catalogMeta));
-  }
-
-  private void initServerCatalog(CatalogMeta catalogMeta) {
-    ServerCatalog catalog = CatalogBuilder.buildServerCatalog(catalogMeta, serverConfiguration);
-    if (catalog instanceof InternalCatalog) {
-      internalCatalogMap.put(catalogMeta.getCatalogName(), (InternalCatalog) catalog);
-    } else {
-      externalCatalogMap.put(catalogMeta.getCatalogName(), (ExternalCatalog) catalog);
-    }
-  }
-
-  @Override
-  public void dropCatalog(String catalogName) {
-    checkStarted();
-    ServerCatalog serverCatalog = getServerCatalog(catalogName);
-    if (serverCatalog == null) {
-      throw new ObjectNotExistsException("Catalog " + catalogName);
-    }
-
-    // TableRuntime cleanup is responsibility by exploreExternalCatalog method
-    serverCatalog.dispose();
-    internalCatalogMap.remove(catalogName);
-    externalCatalogMap.remove(catalogName);
-  }
-
-  @Override
-  public void updateCatalog(CatalogMeta catalogMeta) {
-    checkStarted();
-    ServerCatalog catalog = getServerCatalog(catalogMeta.getCatalogName());
-    validateCatalogUpdate(catalog.getMetadata(), catalogMeta);
-    doAs(CatalogMetaMapper.class, mapper -> mapper.updateCatalog(catalogMeta));
-    catalog.updateMetadata(catalogMeta);
   }
 
   @Override
@@ -206,7 +124,8 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
       throw new IllegalMetadataException("database is blank");
     }
 
-    InternalCatalog internalCatalog = getInternalCatalog(tableIdentifier.getCatalog());
+    InternalCatalog internalCatalog =
+        catalogManager.getInternalCatalog(tableIdentifier.getCatalog());
     String database = tableIdentifier.getDatabase();
     String table = tableIdentifier.getTableName();
     if (!internalCatalog.tableExists(database, table)) {
@@ -227,7 +146,7 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
   @Override
   public void createTable(String catalogName, TableMetadata tableMetadata) {
     checkStarted();
-    InternalCatalog catalog = getInternalCatalog(catalogName);
+    InternalCatalog catalog = catalogManager.getInternalCatalog(catalogName);
     String database = tableMetadata.getTableIdentifier().getDatabase();
     String table = tableMetadata.getTableIdentifier().getTableName();
     if (catalog.tableExists(database, table)) {
@@ -248,7 +167,8 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
   @Override
   public AmoroTable<?> loadTable(ServerTableIdentifier tableIdentifier) {
     checkStarted();
-    return getServerCatalog(tableIdentifier.getCatalog())
+    return catalogManager
+        .getServerCatalog(tableIdentifier.getCatalog())
         .loadTable(tableIdentifier.getDatabase(), tableIdentifier.getTableName());
   }
 
@@ -372,11 +292,6 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
     }
   }
 
-  public InternalCatalog getInternalCatalog(String catalogName) {
-    return Optional.ofNullable(internalCatalogMap.get(catalogName))
-        .orElseThrow(() -> new ObjectNotExistsException("Catalog " + catalogName));
-  }
-
   @Override
   public void addHandlerChain(RuntimeHandlerChain handler) {
     checkNotStarted();
@@ -404,8 +319,6 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
   @Override
   public void initialize() {
     checkNotStarted();
-    List<CatalogMeta> catalogMetas = getAs(CatalogMetaMapper.class, CatalogMetaMapper::getCatalogs);
-    catalogMetas.forEach(this::initServerCatalog);
 
     List<TableRuntimeMeta> tableRuntimeMetaList =
         getAs(TableMetaMapper.class, TableMetaMapper::selectTableRuntimeMetas);
@@ -461,26 +374,6 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
             mapper.selectTableIdentifier(id.getCatalog(), id.getDatabase(), id.getTableName()));
   }
 
-  private ServerTableIdentifier getOrSyncServerTableIdentifier(TableIdentifier id) {
-    ServerTableIdentifier serverTableIdentifier = getServerTableIdentifier(id);
-    if (serverTableIdentifier != null) {
-      return serverTableIdentifier;
-    }
-    ServerCatalog serverCatalog = getServerCatalog(id.getCatalog());
-    if (serverCatalog instanceof InternalCatalog) {
-      return null;
-    }
-    try {
-      AmoroTable<?> table = serverCatalog.loadTable(id.database, id.getTableName());
-      TableIdentity identity =
-          new TableIdentity(id.getDatabase(), id.getTableName(), table.format());
-      syncTable((ExternalCatalog) serverCatalog, identity);
-      return getServerTableIdentifier(id);
-    } catch (NoSuchTableException e) {
-      return null;
-    }
-  }
-
   @Override
   public TableRuntime getRuntime(Long tableId) {
     checkStarted();
@@ -509,8 +402,11 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
       throw new IllegalStateException("TableService is not initialized");
     }
     long start = System.currentTimeMillis();
-    LOG.info("Syncing external catalogs: {}", String.join(",", externalCatalogMap.keySet()));
-    for (ExternalCatalog externalCatalog : externalCatalogMap.values()) {
+    List<ExternalCatalog> externalCatalogs = catalogManager.getExternalCatalogs();
+    List<String> externalCatalogNames =
+        externalCatalogs.stream().map(ExternalCatalog::name).collect(Collectors.toList());
+    LOG.info("Syncing external catalogs: {}", String.join(",", externalCatalogNames));
+    for (ExternalCatalog externalCatalog : externalCatalogs) {
       try {
         final List<CompletableFuture<Set<TableIdentity>>> tableIdentifiersFutures =
             Lists.newArrayList();
@@ -618,7 +514,9 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
     // It is permissible to have some erroneous states in the middle, as long as the final data is
     // consistent.
     Set<String> catalogNames =
-        listCatalogMetas().stream().map(CatalogMeta::getCatalogName).collect(Collectors.toSet());
+        catalogManager.listCatalogMetas().stream()
+            .map(CatalogMeta::getCatalogName)
+            .collect(Collectors.toSet());
     for (TableRuntime tableRuntime : tableRuntimeMap.values()) {
       if (!catalogNames.contains(tableRuntime.getTableIdentifier().getCatalog())) {
         disposeTable(tableRuntime.getTableIdentifier());

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableService.java
@@ -22,7 +22,6 @@ import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.api.BlockableOperation;
 import org.apache.amoro.api.Blocker;
 import org.apache.amoro.api.TableIdentifier;
-import org.apache.amoro.server.catalog.CatalogService;
 import org.apache.amoro.server.persistence.TableRuntimeMeta;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -31,7 +30,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
-public interface TableService extends CatalogService, TableManager {
+public interface TableService extends TableManager {
 
   void initialize();
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/terminal/TerminalManager.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/terminal/TerminalManager.java
@@ -25,6 +25,7 @@ import org.apache.amoro.config.ConfigOptions;
 import org.apache.amoro.config.Configurations;
 import org.apache.amoro.properties.CatalogMetaProperties;
 import org.apache.amoro.server.AmoroManagementConf;
+import org.apache.amoro.server.catalog.CatalogManager;
 import org.apache.amoro.server.catalog.CatalogType;
 import org.apache.amoro.server.dashboard.model.LatestSessionInfo;
 import org.apache.amoro.server.dashboard.model.LogInfo;
@@ -59,6 +60,7 @@ public class TerminalManager {
 
   private final Configurations serviceConfig;
   private final AtomicLong threadPoolCount = new AtomicLong();
+  private final CatalogManager catalogManager;
   private final TableService tableService;
   private final TerminalSessionFactory sessionFactory;
   private final int resultLimits;
@@ -80,8 +82,10 @@ public class TerminalManager {
           new LinkedBlockingQueue<>(),
           r -> new Thread(null, r, "terminal-execute-" + threadPoolCount.incrementAndGet()));
 
-  public TerminalManager(Configurations conf, TableService tableService) {
+  public TerminalManager(
+      Configurations conf, CatalogManager catalogManager, TableService tableService) {
     this.serviceConfig = conf;
+    this.catalogManager = catalogManager;
     this.tableService = tableService;
     this.resultLimits = conf.getInteger(AmoroManagementConf.TERMINAL_RESULT_LIMIT);
     this.stopOnError = conf.getBoolean(AmoroManagementConf.TERMINAL_STOP_ON_ERROR);
@@ -101,7 +105,7 @@ public class TerminalManager {
    * @return - sessionId, session refer to a sql execution context
    */
   public String executeScript(String terminalId, String catalog, String script) {
-    CatalogMeta catalogMeta = tableService.getCatalogMeta(catalog);
+    CatalogMeta catalogMeta = catalogManager.getCatalogMeta(catalog);
     TableMetaStore metaStore = getCatalogTableMetaStore(catalogMeta);
     String sessionId = getSessionId(terminalId, metaStore, catalog);
     String connectorType = catalogConnectorType(catalogMeta);

--- a/amoro-ams/src/test/java/org/apache/amoro/server/RestCatalogServiceTestBase.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/RestCatalogServiceTestBase.java
@@ -23,6 +23,7 @@ import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.TableFormat;
 import org.apache.amoro.api.CatalogMeta;
 import org.apache.amoro.properties.CatalogMetaProperties;
+import org.apache.amoro.server.catalog.CatalogManager;
 import org.apache.amoro.server.catalog.InternalCatalog;
 import org.apache.amoro.server.table.TableMetadata;
 import org.apache.amoro.server.table.TableRuntime;
@@ -75,6 +76,7 @@ public abstract class RestCatalogServiceTestBase {
 
   protected abstract String catalogName();
 
+  protected CatalogManager catalogManager;
   protected TableService tableService;
   protected InternalCatalog serverCatalog;
 
@@ -82,8 +84,9 @@ public abstract class RestCatalogServiceTestBase {
 
   @BeforeEach
   public void before() {
+    catalogManager = ams.serviceContainer().getCatalogManager();
     tableService = ams.serviceContainer().getTableService();
-    serverCatalog = (InternalCatalog) tableService.getServerCatalog(catalogName());
+    serverCatalog = catalogManager.getInternalCatalog(catalogName());
     location =
         serverCatalog.getMetadata().getCatalogProperties().get(CatalogMetaProperties.KEY_WAREHOUSE)
             + "/"
@@ -114,7 +117,7 @@ public abstract class RestCatalogServiceTestBase {
   }
 
   protected TableMetadata getTableMetadata(TableIdentifier identifier) {
-    InternalCatalog internalCatalog = tableService.getInternalCatalog(identifier.getCatalog());
+    InternalCatalog internalCatalog = catalogManager.getInternalCatalog(identifier.getCatalog());
     return internalCatalog.loadTableMetadata(identifier.getDatabase(), identifier.getTableName());
   }
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
@@ -75,7 +75,7 @@ public class TestInternalIcebergCatalogService extends RestCatalogServiceTestBas
       CatalogMeta oldMeta = meta.deepCopy();
       meta.putToCatalogProperties("cache-enabled", "false");
       meta.putToCatalogProperties("cache.expiration-interval-ms", "10000");
-      serverCatalog.updateMetadata(meta);
+      catalogManager.updateCatalog(meta);
       String warehouseInAMS = meta.getCatalogProperties().get(CatalogMetaProperties.KEY_WAREHOUSE);
 
       Map<String, String> clientSideConfiguration = Maps.newHashMap();
@@ -91,7 +91,7 @@ public class TestInternalIcebergCatalogService extends RestCatalogServiceTestBas
       } catch (IOException e) {
         throw new RuntimeException(e);
       } finally {
-        serverCatalog.updateMetadata(oldMeta);
+        catalogManager.updateCatalog(oldMeta);
       }
     }
   }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/catalog/TableCatalogTestBase.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/catalog/TableCatalogTestBase.java
@@ -52,13 +52,13 @@ public class TableCatalogTestBase extends TableServiceTestBase {
     amoroCatalogTestHelper.initWarehouse(path);
     amoroCatalogTestHelper.initHiveConf(TEST_HMS.getHiveConf());
     this.amoroCatalog = amoroCatalogTestHelper.amoroCatalog();
-    tableService().createCatalog(amoroCatalogTestHelper.getCatalogMeta());
+    CATALOG_MANAGER.createCatalog(amoroCatalogTestHelper.getCatalogMeta());
     this.originalCatalog = amoroCatalogTestHelper.originalCatalog();
   }
 
   @After
   public void clean() {
-    tableService().dropCatalog(amoroCatalogTestHelper.catalogName());
+    CATALOG_MANAGER.dropCatalog(amoroCatalogTestHelper.catalogName());
     amoroCatalogTestHelper.clean();
   }
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/catalog/TestServerCatalog.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/catalog/TestServerCatalog.java
@@ -103,7 +103,7 @@ public class TestServerCatalog extends TableCatalogTestBase {
     metadata
         .getCatalogProperties()
         .put(CatalogMetaProperties.KEY_TABLE_FILTER, dbWithFilter + "." + tableWithFilter1);
-    getServerCatalog().updateMetadata(metadata);
+    CATALOG_MANAGER.updateCatalog(metadata);
     Assert.assertEquals(1, getServerCatalog().listTables(dbWithFilter).size());
     Assert.assertEquals(
         tableWithFilter1,
@@ -113,20 +113,20 @@ public class TestServerCatalog extends TableCatalogTestBase {
     metadata
         .getCatalogProperties()
         .put(CatalogMetaProperties.KEY_TABLE_FILTER, dbWithFilter + "\\." + ".+");
-    getServerCatalog().updateMetadata(metadata2);
+    CATALOG_MANAGER.updateCatalog(metadata2);
     Assert.assertEquals(2, getServerCatalog().listTables(dbWithFilter).size());
 
     CatalogMeta metadata3 = getServerCatalog().getMetadata();
     metadata
         .getCatalogProperties()
         .put(CatalogMetaProperties.KEY_TABLE_FILTER, testDatabaseName + "\\." + ".+");
-    getServerCatalog().updateMetadata(metadata3);
+    CATALOG_MANAGER.updateCatalog(metadata3);
     Assert.assertEquals(1, getServerCatalog().listTables(testDatabaseName).size());
     Assert.assertTrue(getServerCatalog().listTables(dbWithFilter).isEmpty());
 
     CatalogMeta metadata4 = getServerCatalog().getMetadata();
     metadata.getCatalogProperties().remove(CatalogMetaProperties.KEY_TABLE_FILTER);
-    getServerCatalog().updateMetadata(metadata4);
+    CATALOG_MANAGER.updateCatalog(metadata4);
   }
 
   @Test

--- a/amoro-ams/src/test/java/org/apache/amoro/server/catalog/TestServerCatalog.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/catalog/TestServerCatalog.java
@@ -135,6 +135,6 @@ public class TestServerCatalog extends TableCatalogTestBase {
   }
 
   private ServerCatalog getServerCatalog() {
-    return tableService().getServerCatalog(getAmoroCatalogTestHelper().catalogName());
+    return CATALOG_MANAGER.getServerCatalog(getAmoroCatalogTestHelper().catalogName());
   }
 }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestIcebergHadoopOptimizing.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestIcebergHadoopOptimizing.java
@@ -407,7 +407,7 @@ public class TestIcebergHadoopOptimizing extends AbstractOptimizingTest {
 
   private Table createIcebergTable(String catalog, PartitionSpec spec, int formatVersion) {
     ServerCatalog serverCatalog =
-        amsEnv.serviceContainer().getTableService().getServerCatalog(catalog);
+        amsEnv.serviceContainer().getCatalogManager().getServerCatalog(catalog);
     if (serverCatalog instanceof InternalCatalog) {
       this.serverCatalog = (InternalCatalog) serverCatalog;
       if (!this.serverCatalog.databaseExists(DATABASE)) {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/AMSTableTestBase.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/AMSTableTestBase.java
@@ -96,7 +96,7 @@ public class AMSTableTestBase extends TableServiceTestBase {
         }
       }
 
-      tableService().createCatalog(catalogMeta);
+      CATALOG_MANAGER.createCatalog(catalogMeta);
       try {
         Database database = new Database();
         database.setName(TableTestHelper.TEST_DB_NAME);
@@ -120,7 +120,7 @@ public class AMSTableTestBase extends TableServiceTestBase {
       dropDatabase();
     }
     if (catalogMeta != null) {
-      tableService().dropCatalog(catalogMeta.getCatalogName());
+      CATALOG_MANAGER.dropCatalog(catalogMeta.getCatalogName());
       TEST_HMS.getHiveClient().dropDatabase(TableTestHelper.TEST_DB_NAME, false, true);
     }
   }
@@ -146,7 +146,7 @@ public class AMSTableTestBase extends TableServiceTestBase {
   protected void createDatabase() {
     if (externalCatalog == null) {
       InternalCatalog catalog =
-          tableService().getInternalCatalog(TableTestHelper.TEST_CATALOG_NAME);
+          CATALOG_MANAGER.getInternalCatalog(TableTestHelper.TEST_CATALOG_NAME);
       if (!catalog.listDatabases().contains(TableTestHelper.TEST_DB_NAME)) {
         catalog.createDatabase(TableTestHelper.TEST_DB_NAME);
       }
@@ -161,7 +161,7 @@ public class AMSTableTestBase extends TableServiceTestBase {
   protected void dropDatabase() {
     if (externalCatalog == null) {
       InternalCatalog catalog =
-          tableService().getInternalCatalog(TableTestHelper.TEST_CATALOG_NAME);
+          CATALOG_MANAGER.getInternalCatalog(TableTestHelper.TEST_CATALOG_NAME);
       catalog.dropDatabase(TableTestHelper.TEST_DB_NAME);
     } else {
       externalCatalog.dropDatabase(TableTestHelper.TEST_DB_NAME);

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TableServiceTestBase.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TableServiceTestBase.java
@@ -22,6 +22,7 @@ import org.apache.amoro.config.Configurations;
 import org.apache.amoro.resource.ResourceGroup;
 import org.apache.amoro.server.AmoroManagementConf;
 import org.apache.amoro.server.DefaultOptimizingService;
+import org.apache.amoro.server.catalog.DefaultCatalogManager;
 import org.apache.amoro.server.manager.EventsManager;
 import org.apache.amoro.server.manager.MetricManager;
 import org.junit.AfterClass;
@@ -33,6 +34,7 @@ public abstract class TableServiceTestBase {
 
   @ClassRule public static DerbyPersistence DERBY = new DerbyPersistence();
 
+  protected static DefaultCatalogManager CATALOG_MANAGER = null;
   private static DefaultTableService TABLE_SERVICE = null;
   private static DefaultOptimizingService OPTIMIZING_SERVICE = null;
 
@@ -41,7 +43,8 @@ public abstract class TableServiceTestBase {
     try {
       Configurations configurations = new Configurations();
       configurations.set(AmoroManagementConf.OPTIMIZER_HB_TIMEOUT, 800L);
-      TABLE_SERVICE = new DefaultTableService(new Configurations());
+      CATALOG_MANAGER = new DefaultCatalogManager(configurations);
+      TABLE_SERVICE = new DefaultTableService(new Configurations(), CATALOG_MANAGER);
       OPTIMIZING_SERVICE = new DefaultOptimizingService(configurations, TABLE_SERVICE);
       TABLE_SERVICE.addHandlerChain(OPTIMIZING_SERVICE.getTableRuntimeHandler());
       TABLE_SERVICE.initialize();

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TableServiceTestBase.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TableServiceTestBase.java
@@ -45,7 +45,8 @@ public abstract class TableServiceTestBase {
       configurations.set(AmoroManagementConf.OPTIMIZER_HB_TIMEOUT, 800L);
       CATALOG_MANAGER = new DefaultCatalogManager(configurations);
       TABLE_SERVICE = new DefaultTableService(new Configurations(), CATALOG_MANAGER);
-      OPTIMIZING_SERVICE = new DefaultOptimizingService(configurations, TABLE_SERVICE);
+      OPTIMIZING_SERVICE =
+          new DefaultOptimizingService(configurations, CATALOG_MANAGER, TABLE_SERVICE);
       TABLE_SERVICE.addHandlerChain(OPTIMIZING_SERVICE.getTableRuntimeHandler());
       TABLE_SERVICE.initialize();
       try {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestCatalogService.java
@@ -60,18 +60,18 @@ public class TestCatalogService extends TableServiceTestBase {
   public void testCreateAndDropCatalog() {
     CatalogMeta catalogMeta = catalogTestHelper.buildCatalogMeta("/tmp");
     // test create catalog
-    tableService().createCatalog(catalogMeta);
+    CATALOG_MANAGER.createCatalog(catalogMeta);
 
     // test create duplicate catalog
     Assert.assertThrows(
-        AlreadyExistsException.class, () -> tableService().createCatalog(catalogMeta));
+        AlreadyExistsException.class, () -> CATALOG_MANAGER.createCatalog(catalogMeta));
 
     // test get catalog
-    CatalogMeta readCatalogMeta = tableService().getCatalogMeta(catalogMeta.getCatalogName());
+    CatalogMeta readCatalogMeta = CATALOG_MANAGER.getCatalogMeta(catalogMeta.getCatalogName());
     Assert.assertEquals(catalogMeta, readCatalogMeta);
 
     // test get catalog list
-    List<CatalogMeta> catalogMetas = tableService().listCatalogMetas();
+    List<CatalogMeta> catalogMetas = CATALOG_MANAGER.listCatalogMetas();
     Assert.assertEquals(1, catalogMetas.size());
     Assert.assertEquals(
         catalogMeta,
@@ -81,57 +81,57 @@ public class TestCatalogService extends TableServiceTestBase {
             .orElseThrow(() -> new IllegalStateException("Cannot find expect catalog")));
 
     // test catalogExist
-    Assert.assertTrue(tableService().catalogExist(catalogMeta.getCatalogName()));
+    Assert.assertTrue(CATALOG_MANAGER.catalogExist(catalogMeta.getCatalogName()));
 
     // test drop catalog
-    tableService().dropCatalog(catalogMeta.getCatalogName());
+    CATALOG_MANAGER.dropCatalog(catalogMeta.getCatalogName());
 
     // test drop not existed catalog
     Assert.assertThrows(
         ObjectNotExistsException.class,
-        () -> tableService().getCatalogMeta(catalogMeta.getCatalogName()));
+        () -> CATALOG_MANAGER.getCatalogMeta(catalogMeta.getCatalogName()));
 
-    Assert.assertFalse(tableService().catalogExist(catalogMeta.getCatalogName()));
+    Assert.assertFalse(CATALOG_MANAGER.catalogExist(catalogMeta.getCatalogName()));
   }
 
   @Test
   public void testUpdateCatalog() {
     CatalogMeta catalogMeta = catalogTestHelper.buildCatalogMeta("/tmp");
-    tableService().createCatalog(catalogMeta);
+    CATALOG_MANAGER.createCatalog(catalogMeta);
 
     CatalogMeta updateCatalogMeta = new CatalogMeta(catalogMeta);
     updateCatalogMeta.getCatalogProperties().put("k2", "V2");
     updateCatalogMeta.getCatalogProperties().put("k3", "v3");
-    tableService().updateCatalog(updateCatalogMeta);
-    CatalogMeta getCatalogMeta = tableService().getCatalogMeta(catalogMeta.getCatalogName());
+    CATALOG_MANAGER.updateCatalog(updateCatalogMeta);
+    CatalogMeta getCatalogMeta = CATALOG_MANAGER.getCatalogMeta(catalogMeta.getCatalogName());
     Assert.assertEquals("V2", getCatalogMeta.getCatalogProperties().get("k2"));
     Assert.assertEquals("v3", getCatalogMeta.getCatalogProperties().get("k3"));
     Assert.assertEquals(
-        updateCatalogMeta, tableService().getCatalogMeta(catalogMeta.getCatalogName()));
+        updateCatalogMeta, CATALOG_MANAGER.getCatalogMeta(catalogMeta.getCatalogName()));
 
     // test update catalog type
     final CatalogMeta updateCatalogMeta2 = new CatalogMeta(updateCatalogMeta);
     updateCatalogMeta2.setCatalogType(CatalogMetaProperties.CATALOG_TYPE_CUSTOM);
     Assert.assertThrows(
-        IllegalMetadataException.class, () -> tableService().updateCatalog(updateCatalogMeta2));
+        IllegalMetadataException.class, () -> CATALOG_MANAGER.updateCatalog(updateCatalogMeta2));
 
     // test update unknown catalog
-    tableService().dropCatalog(catalogMeta.getCatalogName());
+    CATALOG_MANAGER.dropCatalog(catalogMeta.getCatalogName());
     Assert.assertThrows(
-        ObjectNotExistsException.class, () -> tableService().updateCatalog(catalogMeta));
+        ObjectNotExistsException.class, () -> CATALOG_MANAGER.updateCatalog(catalogMeta));
   }
 
   @Test
   public void testDropCatalogWithDatabase() {
     Assume.assumeTrue(catalogTestHelper.tableFormat().equals(TableFormat.MIXED_ICEBERG));
     CatalogMeta catalogMeta = catalogTestHelper.buildCatalogMeta("/tmp");
-    tableService().createCatalog(catalogMeta);
-    InternalCatalog catalog = tableService().getInternalCatalog(catalogMeta.getCatalogName());
+    CATALOG_MANAGER.createCatalog(catalogMeta);
+    InternalCatalog catalog = CATALOG_MANAGER.getInternalCatalog(catalogMeta.getCatalogName());
     catalog.createDatabase("test_db");
     Assert.assertThrows(
         IllegalMetadataException.class,
-        () -> tableService().dropCatalog(catalogMeta.getCatalogName()));
+        () -> CATALOG_MANAGER.dropCatalog(catalogMeta.getCatalogName()));
     catalog.dropDatabase("test_db");
-    tableService().dropCatalog(catalogMeta.getCatalogName());
+    CATALOG_MANAGER.dropCatalog(catalogMeta.getCatalogName());
   }
 }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestDatabaseService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestDatabaseService.java
@@ -56,7 +56,7 @@ public class TestDatabaseService extends AMSTableTestBase {
 
   @Test
   public void testCreateAndDropDatabase() {
-    InternalCatalog catalog = tableService().getInternalCatalog(TEST_CATALOG_NAME);
+    InternalCatalog catalog = CATALOG_MANAGER.getInternalCatalog(TEST_CATALOG_NAME);
     // test create database
     catalog.createDatabase(TEST_DB_NAME);
 
@@ -78,7 +78,7 @@ public class TestDatabaseService extends AMSTableTestBase {
   public void testDropDatabaseWithTable() {
     Assume.assumeTrue(catalogTestHelper().tableFormat().equals(TableFormat.MIXED_ICEBERG));
     Assume.assumeTrue(catalogTestHelper().isInternalCatalog());
-    InternalCatalog catalog = tableService().getInternalCatalog(TEST_CATALOG_NAME);
+    InternalCatalog catalog = CATALOG_MANAGER.getInternalCatalog(TEST_CATALOG_NAME);
     catalog.createDatabase(TEST_DB_NAME);
 
     createTable();

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestTableRuntimeHandler.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestTableRuntimeHandler.java
@@ -67,7 +67,7 @@ public class TestTableRuntimeHandler extends AMSTableTestBase {
 
   @Test
   public void testInitialize() throws Exception {
-    tableService = new DefaultTableService(new Configurations());
+    tableService = new DefaultTableService(new Configurations(), CATALOG_MANAGER);
     TestHandler handler = new TestHandler();
     tableService.addHandlerChain(handler);
     tableService.initialize();
@@ -86,7 +86,7 @@ public class TestTableRuntimeHandler extends AMSTableTestBase {
     Assert.assertTrue(handler.isDisposed());
 
     // initialize with a history table
-    tableService = new DefaultTableService(new Configurations());
+    tableService = new DefaultTableService(new Configurations(), CATALOG_MANAGER);
     handler = new TestHandler();
     tableService.addHandlerChain(handler);
     tableService.initialize();

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestTableService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestTableService.java
@@ -74,7 +74,7 @@ public class TestTableService extends AMSTableTestBase {
 
   @Test
   public void testCreateAndDropTable() {
-    ServerCatalog serverCatalog = tableService().getServerCatalog(TEST_CATALOG_NAME);
+    ServerCatalog serverCatalog = CATALOG_MANAGER.getServerCatalog(TEST_CATALOG_NAME);
     InternalCatalog internalCatalog =
         catalogTestHelper().isInternalCatalog() ? (InternalCatalog) serverCatalog : null;
 
@@ -94,7 +94,7 @@ public class TestTableService extends AMSTableTestBase {
 
     // test list tables
     List<TableIDWithFormat> tableIdentifierList =
-        tableService().getServerCatalog(TEST_CATALOG_NAME).listTables(TEST_DB_NAME);
+        CATALOG_MANAGER.getServerCatalog(TEST_CATALOG_NAME).listTables(TEST_DB_NAME);
     Assert.assertEquals(1, tableIdentifierList.size());
     Assert.assertEquals(
         tableMeta().getTableIdentifier(),

--- a/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/src/main/java/org/apache/amoro/spark/SparkUnifiedCatalogBase.java
+++ b/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/src/main/java/org/apache/amoro/spark/SparkUnifiedCatalogBase.java
@@ -173,15 +173,27 @@ public class SparkUnifiedCatalogBase implements TableCatalog, SupportsNamespaces
     throw new UnsupportedOperationException("Cannot apply namespace change");
   }
 
-  @Override
-  public boolean dropNamespace(String[] namespace) {
+  public boolean dropNamespace(String[] namespace, boolean cascade)
+      throws NoSuchNamespaceException {
     String database = namespaceToDatabase(namespace);
+    if (!unifiedCatalog.databaseExists(database)) {
+      throw new NoSuchNamespaceException(namespace);
+    }
     List<TableIDWithFormat> tables = unifiedCatalog.listTables(database);
+    if (!tables.isEmpty() && !cascade) {
+      throw new IllegalStateException("Namespace '" + database + "' is non empty.");
+    }
+
     for (TableIDWithFormat id : tables) {
       unifiedCatalog.dropTable(database, id.getIdentifier().getTableName(), true);
     }
     unifiedCatalog.dropDatabase(database);
     return !unifiedCatalog.databaseExists(database);
+  }
+
+  @Override
+  public boolean dropNamespace(String[] namespace) throws NoSuchNamespaceException {
+    return dropNamespace(namespace, false);
   }
 
   @Override

--- a/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/src/test/java/org/apache/amoro/spark/test/unified/UnifiedCatalogTestSuites.java
+++ b/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/src/test/java/org/apache/amoro/spark/test/unified/UnifiedCatalogTestSuites.java
@@ -91,6 +91,9 @@ public class UnifiedCatalogTestSuites extends SparkTestBase {
     long count = sql(sqlText).count();
     Assertions.assertEquals(expect, count);
 
+    // create and drop namespace
+    testNamespaceWithSql();
+
     // visit sub tables.
     testVisitSubTable(format, sessionCatalog);
 
@@ -106,6 +109,17 @@ public class UnifiedCatalogTestSuites extends SparkTestBase {
 
     sql("DROP TABLE " + target() + " PURGE");
     Assertions.assertFalse(unifiedCatalog().tableExists(target().database, target().table));
+  }
+
+  private void testNamespaceWithSql() {
+    // Use SparkTestBase::sql method to test SparkUnifiedCatalog instead of CommonUnifiedCatalog.
+    String createDatabase = "CREATE DATABASE test_unified_catalog";
+    sql(createDatabase);
+    Assertions.assertTrue(unifiedCatalog().databaseExists("test_unified_catalog"));
+
+    String dropDatabase = "DROP DATABASE test_unified_catalog";
+    sql(dropDatabase);
+    Assertions.assertFalse(unifiedCatalog().databaseExists("test_unified_catalog"));
   }
 
   private String pkDDL(TableFormat format) {

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/java/org/apache/amoro/spark/SparkUnifiedCatalog.java
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/java/org/apache/amoro/spark/SparkUnifiedCatalog.java
@@ -22,7 +22,6 @@ import org.apache.amoro.TableFormat;
 import org.apache.spark.sql.catalyst.analysis.NoSuchFunctionException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
@@ -67,26 +66,6 @@ public class SparkUnifiedCatalog extends SparkUnifiedCatalogBase
       return ((FunctionCatalog) tableCatalog).loadFunction(ident);
     }
     throw new NoSuchFunctionException(ident);
-  }
-
-  /**
-   * Drop a namespace from the catalog with cascade mode, recursively dropping all objects within
-   * the namespace if cascade is true.
-   *
-   * <p>If the catalog implementation does not support this operation, it may throw {@link
-   * UnsupportedOperationException}.
-   *
-   * @param namespace a multi-part namespace
-   * @param cascade When true, deletes all objects under the namespace
-   * @return true if the namespace was dropped
-   * @throws NoSuchNamespaceException If the namespace does not exist (optional)
-   * @throws NonEmptyNamespaceException If the namespace is non-empty and cascade is false
-   * @throws UnsupportedOperationException If drop is not a supported operation
-   */
-  @Override
-  public boolean dropNamespace(String[] namespace, boolean cascade)
-      throws NoSuchNamespaceException, NonEmptyNamespaceException {
-    return false;
   }
 
   /**

--- a/dist/src/main/amoro-bin/conf/config.yaml
+++ b/dist/src/main/amoro-bin/conf/config.yaml
@@ -91,9 +91,8 @@ ams:
   table-manifest-io:
     thread-count: 20
 
-  cache:
-    catalog-meta:
-      duration: 60s
+  catalog-meta-cache:
+    expiration-interval: 60s
 
   database:
     type: derby

--- a/dist/src/main/amoro-bin/conf/config.yaml
+++ b/dist/src/main/amoro-bin/conf/config.yaml
@@ -91,6 +91,10 @@ ams:
   table-manifest-io:
     thread-count: 20
 
+  cache:
+    catalog-meta:
+      duration: 60s
+
   database:
     type: derby
     jdbc-driver-class: org.apache.derby.jdbc.EmbeddedDriver


### PR DESCRIPTION

## Why are the changes needed?

Close #3393.

This is a subtask to implement a stateless RESTController. 

## Brief change log

- Rename the **CatalogService** interface to **CatalogManager**, indicating that the interface provides stateless services.
- Provide a stateless implementation called **DefaultCatalogManager**.
- The **TableService** interface will no longer inherit from **CatalogManager**.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
