### PR TITLE
[improvement] encode for optimizerGroup value

### DIFF
--- a/amoro-web/src/views/optimize/components/List.vue
+++ b/amoro-web/src/views/optimize/components/List.vue
@@ -91,7 +91,7 @@ async function getTableList() {
   try {
     loading.value = true
     const params = {
-      optimizerGroup: optimizerGroup.value || 'all',
+      optimizerGroup: optimizerGroup.value ? encodeURIComponent(optimizerGroup.value) : 'all',
       dbSearchInput: dbSearchInput.value || '',
       tableSearchInput: tableSearchInput.value || '',
       page: pagination.current,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?

when optimizerGroup name has value like '/' , the search url will be  "http://127.0.0.1:1630/api/ams/v1/optimize/optimizerGroups/PROD/test/tables?dbSearchInput=&tableSearchInput=&page=1&pageSize=25". it will 404 for server. we should encode optimizerGroup.

when encode , it will be work well.
![image](https://github.com/user-attachments/assets/1bcb909f-70dd-47bf-934a-d4c31fc96978)


Close #xxx.

## Brief change log


-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no) 
 no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
