### PR TITLE
[Hotfix] Spark k8s optimizer release error

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
@@ -117,6 +117,7 @@ public class SparkOptimizerContainer extends AbstractResourceContainer {
       if (deployedOnKubernetes()) {
         SparkOptimizerContainer.SparkConf sparkConf =
             SparkOptimizerContainer.SparkConf.buildFor(loadSparkConfig(), getContainerProperties())
+                .withGroupProperties(resource.getProperties())
                 .build();
         String namespace =
             StringUtils.defaultIfEmpty(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3401.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- When building the Spark config, a step was added to merge the resource group attributes to prevent the configuration of spark.kubernetes.namespace from not taking effect on the resource group.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
