### PR TITLE
Revert "[AMORO-3352]Add mysql-connector-j dependency by maven profile“

### DIFF
--- a/amoro-ams/pom.xml
+++ b/amoro-ams/pom.xml
@@ -201,6 +201,12 @@
         </dependency>
 
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
         </dependency>
@@ -398,13 +404,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <version>${mysql-connector-j.version}</version>
-            <scope>${mysql-j-dependency-scope}</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-data</artifactId>
             <version>${iceberg.version}</version>
@@ -452,7 +451,8 @@
             <version>1.19.6</version>
             <scope>test</scope>
         </dependency>
-        
+
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -151,12 +151,10 @@
         <guava.version>32.1.1-jre</guava.version>
         <hudi.version>0.14.1</hudi.version>
         <pagehelper.version>6.1.0</pagehelper.version>
-        <mysql-connector-j.version>9.1.0</mysql-connector-j.version>
 
         <rocksdb-dependency-scope>compile</rocksdb-dependency-scope>
         <lucene-dependency-scope>compile</lucene-dependency-scope>
         <aliyun-sdk-dependency-scope>provided</aliyun-sdk-dependency-scope>
-        <mysql-j-dependency-scope>provided</mysql-j-dependency-scope>
     </properties>
 
     <dependencies>
@@ -626,6 +624,12 @@
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>${derby-jdbc.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql-jdbc.version}</version>
             </dependency>
 
             <dependency>
@@ -1371,12 +1375,6 @@
             <id>aliyun-oss-sdk</id>
             <properties>
                 <aliyun-sdk-dependency-scope>compile</aliyun-sdk-dependency-scope>
-            </properties>
-        </profile>
-        <profile>
-            <id>mysql-j</id>
-            <properties>
-                <mysql-j-dependency-scope>compile</mysql-j-dependency-scope>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
This reverts commit 4be9821704521f8c8a2c9db7e305bae55d1fdccd.

The license of MySQL is incompatible with the Apache License. Please see https://github.com/apache/amoro/issues/3352 for more information

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3352 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- `git revert 4be9821704521f8c8a2c9db7e305bae55d1fdccd`

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
