### PR TITLE
[AMORO-3414] Fix syntax errors in postgresql scripts

### DIFF
--- a/amoro-ams/src/main/resources/postgres/ams-postgres-init.sql
+++ b/amoro-ams/src/main/resources/postgres/ams-postgres-init.sql
@@ -205,8 +205,7 @@ COMMENT ON COLUMN table_runtime.last_optimized_change_snapshotId IS 'Last optimi
 COMMENT ON COLUMN table_runtime.last_major_optimizing_time IS 'Latest Major Optimize time for all partitions';
 COMMENT ON COLUMN table_runtime.last_minor_optimizing_time IS 'Latest Minor Optimize time for all partitions';
 COMMENT ON COLUMN table_runtime.last_full_optimizing_time IS 'Latest Full Optimize time for all partitions';
-COMMENT ON COLUMN table_runtime.optimizing_status_code IS 'Table optimize status code: 100(FULL_OPTIMIZING),' ||
-        ' 200(MAJOR_OPTIMIZING), 300(MINOR_OPTIMIZING), 400(COMMITTING), 500(PLANING), 600(PENDING), 700(IDLE)';
+COMMENT ON COLUMN table_runtime.optimizing_status_code IS 'Table optimize status code: 100(FULL_OPTIMIZING), 200(MAJOR_OPTIMIZING), 300(MINOR_OPTIMIZING), 400(COMMITTING), 500(PLANING), 600(PENDING), 700(IDLE)';
 COMMENT ON COLUMN table_runtime.optimizing_status_start_time IS 'Table optimize status start time';
 COMMENT ON COLUMN table_runtime.optimizing_process_id IS 'Optimizing procedure UUID';
 COMMENT ON COLUMN table_runtime.optimizer_group IS 'Optimizer group';

--- a/amoro-ams/src/main/resources/postgres/upgrade.sql
+++ b/amoro-ams/src/main/resources/postgres/upgrade.sql
@@ -86,36 +86,37 @@ COMMENT ON COLUMN http_session.max_interval IS 'Max internal';
 COMMENT ON COLUMN http_session.data_store IS 'Session data store';
 COMMENT ON TABLE http_session IS 'Http session store';
 
-    -- update resource group memory unit
+-- update resource group memory unit
 UPDATE resource_group
 SET properties = jsonb_set(
-        properties,
-        '{flink-conf,jobmanager,memory,process,size}',
-        (properties->>'flink-conf.jobmanager.memory.process.size') || 'MB'
+        properties::jsonb,
+        '{flink-conf.jobmanager.memory.process.size}',
+        ('"' || (properties::jsonb->>'flink-conf.jobmanager.memory.process.size') || 'MB"')::jsonb
     )
-WHERE (properties->>'flink-conf.jobmanager.memory.process.size') ~ '^[0-9]+$';
+WHERE (properties::jsonb->>'flink-conf.jobmanager.memory.process.size') ~ '^[0-9]+$';
+
 
 UPDATE resource_group
 SET properties = jsonb_set(
-        properties,
-        '{flink-conf,taskmanager,memory,process,size}',
-        (properties->>'flink-conf.taskmanager.memory.process.size') || 'MB'
+        properties::jsonb,
+        '{flink-conf.taskmanager.memory.process.size}',
+        ('"' || (properties::jsonb->>'flink-conf.taskmanager.memory.process.size') || 'MB"')::jsonb
     )
-WHERE (properties->>'flink-conf.taskmanager.memory.process.size') ~ '^[0-9]+$';
+WHERE (properties::jsonb->>'flink-conf.taskmanager.memory.process.size') ~ '^[0-9]+$';
 
 -- update resource memory unit
 UPDATE resource
 SET properties = jsonb_set(
-        properties,
-        '{flink-conf,jobmanager,memory,process,size}',
-        (properties->>'flink-conf.jobmanager.memory.process.size') || 'MB'
+        properties::jsonb,
+        '{flink-conf.jobmanager.memory.process.size}',
+        ('"' || (properties::jsonb->>'flink-conf.jobmanager.memory.process.size') || 'MB"')::jsonb
     )
-WHERE (properties->>'flink-conf.jobmanager.memory.process.size') ~ '^[0-9]+$';
+WHERE (properties::jsonb->>'flink-conf.jobmanager.memory.process.size') ~ '^[0-9]+$';
 
 UPDATE resource
 SET properties = jsonb_set(
-        properties,
-        '{flink-conf,taskmanager,memory,process,size}',
-        (properties->>'flink-conf.taskmanager.memory.process.size') || 'MB'
+        properties::jsonb,
+        '{flink-conf.taskmanager.memory.process.size}',
+        ('"' || (properties::jsonb->>'flink-conf.taskmanager.memory.process.size') || 'MB"')::jsonb
     )
-WHERE (properties->>'flink-conf.taskmanager.memory.process.size') ~ '^[0-9]+$';
+WHERE (properties::jsonb->>'flink-conf.taskmanager.memory.process.size') ~ '^[0-9]+$';


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
There are syntax errors in the postgresql script:
1. In `ams-postgres-init.sql`, strings in the `COMMENT ON` statement do not support direct concatenation via `||`.
2. In `upgrade.sql`, the `jsonb_set` function is used with mismatched parameter types and incorrect path arguments.

Close #3414.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Fix the above syntax errors in the scripts `ams-postgres-init.sql` and `upgrade.sql` 

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
