### PR TITLE
[Improvement] Increase the default database connection pool max wait time

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
@@ -339,7 +339,7 @@ public class AmoroManagementConf {
   public static final ConfigOption<Long> DB_CONNECT_MAX_WAIT_MILLIS =
       ConfigOptions.key("database.connection-pool-max-wait-millis")
           .longType()
-          .defaultValue(1000L)
+          .defaultValue(30000L)
           .withDescription("Max wait time before getting a connection timeout.");
 
   public static final ConfigOption<Long> OPTIMIZER_HB_TIMEOUT =

--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -93,7 +93,7 @@ data:
         url: {{ .Values.amoroConf.database.url }}
         connection-pool-max-total: 20
         connection-pool-max-idle: 16
-        connection-pool-max-wait-millis: 1000
+        connection-pool-max-wait-millis: 30000
 
       terminal:
         backend: {{ .Values.amoroConf.terminal.backend }}

--- a/dist/src/main/amoro-bin/conf/config.yaml
+++ b/dist/src/main/amoro-bin/conf/config.yaml
@@ -100,7 +100,7 @@ ams:
     url: jdbc:derby:/tmp/amoro/derby;create=true
     connection-pool-max-total: 20
     connection-pool-max-idle: 16
-    connection-pool-max-wait-millis: 1000
+    connection-pool-max-wait-millis: 30000
 
 #  MySQL database configuration.
 #  database:
@@ -112,7 +112,7 @@ ams:
 #    auto-create-tables: true
 #    connection-pool-max-total: 20
 #    connection-pool-max-idle: 16
-#    connection-pool-max-wait-millis: 1000
+#    connection-pool-max-wait-millis: 30000
 
 #  Postgres database configuration.
 #  database:
@@ -124,7 +124,7 @@ ams:
 #    auto-create-tables: true
 #    connection-pool-max-total: 20
 #    connection-pool-max-idle: 16
-#    connection-pool-max-wait-millis: 1000
+#    connection-pool-max-wait-millis: 30000
 
   terminal:
     backend: local


### PR DESCRIPTION
… time (#3419)

## Why are the changes needed?

The default database connection pool max wait time is 1000ms for now.
This is quite small and the wait timeout exception is easy to occur when the database system is a bit busy.
Resolve #3419 .

## Brief change log

Change the default value of DB_CONNECT_MAX_WAIT_MILLIS to 30000 in AmoroManagementConf.java(amo-ams).
Change the default value of connection-pool-max-wait-millis to 30000 in amoro-configmap.yaml(charts) and config.yaml(dist).
The reason for choosing 30000 instead of 5000 is that the default connectionTimeout value of HikariCP is 30000 milliseconds (the default value of max-wait-millis of DBCP2 is -1), and the default values ​​of mainstream database connection pools are almost 30000ms or larger.

## Documentation

Does this pull request introduce a new feature?
No

