### PR TITLE
[hotfix] Update time and storage units in template configuration files

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestAmoroManagementConf.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestAmoroManagementConf.java
@@ -28,6 +28,7 @@ import org.apache.amoro.shade.guava32.com.google.common.io.Resources;
 import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.amoro.utils.JacksonUtil;
+import org.apache.amoro.utils.MemorySize;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.Yaml;
@@ -65,7 +66,7 @@ public class TestAmoroManagementConf {
           .put(AmoroManagementConf.TERMINAL_SESSION_TIMEOUT.key(), "min")
           .build();
 
-  private static final ConfigOption<String>[] STORAGE_RELATED_CONFIG_OPTIONS =
+  private static final ConfigOption<MemorySize>[] STORAGE_RELATED_CONFIG_OPTIONS =
       new ConfigOption[] {AmoroManagementConf.THRIFT_MAX_MESSAGE_SIZE};
 
   @Test
@@ -186,7 +187,7 @@ public class TestAmoroManagementConf {
 
   private void assertStorageRelatedConfigs(
       Configurations serviceConfig, Configurations expectedConfig) {
-    for (ConfigOption<String> configOption : STORAGE_RELATED_CONFIG_OPTIONS) {
+    for (ConfigOption<MemorySize> configOption : STORAGE_RELATED_CONFIG_OPTIONS) {
       Assertions.assertEquals(
           expectedConfig.get(configOption),
           serviceConfig.get(AmoroManagementConf.THRIFT_MAX_MESSAGE_SIZE));

--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -53,7 +53,7 @@ data:
     {{- end }}
     
       thrift-server:
-        max-message-size: 104857600 # 100MB
+        max-message-size: 100MB # 104857600
         selector-thread-count: 2
         selector-queue-size: 4
         table-service:
@@ -67,11 +67,11 @@ data:
         bind-port: {{ .Values.server.rest.port }}
 
       refresh-external-catalogs:
-        interval: 180000 # 3min
+        interval: 3min # 180000
 
       refresh-tables:
         thread-count: 10
-        interval: 60000 # 1min
+        interval: 1min # 60000
 
       self-optimizing:
         commit-thread-count: 10
@@ -79,11 +79,11 @@ data:
         runtime-data-expire-interval-hours: 1
 
       optimizer:
-        heart-beat-timeout: 60000 # 1min
-        task-ack-timeout: 30000 # 30s
+        heart-beat-timeout: 1min # 60000
+        task-ack-timeout: 30s # 30000
 
       blocker:
-        timeout: 60000 # 1min
+        timeout: 1min # 60000
 
       # optional features
       expire-snapshots:

--- a/dist/src/main/amoro-bin/conf/config.yaml
+++ b/dist/src/main/amoro-bin/conf/config.yaml
@@ -22,7 +22,7 @@ ams:
   server-expose-host: "127.0.0.1"
 
   thrift-server:
-    max-message-size: 104857600 # 100MB
+    max-message-size: 100MB # 104857600
     selector-thread-count: 2
     selector-queue-size: 4
     table-service:
@@ -37,13 +37,13 @@ ams:
     rest-auth-type: token
 
   refresh-external-catalogs:
-    interval: 180000 # 3min
+    interval: 3min # 180000
     thread-count: 10
     queue-size: 1000000
 
   refresh-tables:
     thread-count: 10
-    interval: 60000 # 1min
+    interval: 1min # 60000
     max-pending-partition-count: 100 # default 100
 
   self-optimizing:
@@ -52,13 +52,13 @@ ams:
     runtime-data-expire-interval-hours: 1
 
   optimizer:
-    heart-beat-timeout: 60000 # 1min
-    task-ack-timeout: 30000 # 30s
-    polling-timeout: 3000 # 3s
+    heart-beat-timeout: 1min # 60000
+    task-ack-timeout: 30s # 30000
+    polling-timeout: 3s # 3000
     max-planning-parallelism: 1 # default 1
 
   blocker:
-    timeout: 60000 # 1min
+    timeout: 1min # 60000
 
   # optional features
   expire-snapshots:
@@ -86,7 +86,7 @@ ams:
   auto-create-tags:
     enabled: true
     thread-count: 3
-    interval: 60000 # 1min
+    interval: 1min # 60000
 
   table-manifest-io:
     thread-count: 20
@@ -141,7 +141,7 @@ ams:
       limit: 1000
     stop-on-error: false
     session:
-      timeout: 30
+      timeout: 30min # 1800000
     local:
       using-session-catalog-for-hive: false
       spark.sql.iceberg.handle-timestamp-without-timezone: false


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
Based on the optimizations in #3418 and #3423, the ams configuration file now supports parsing time and storage units, and we need to update the template file to prompt the user for the latest usage.

Close #xxx.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Upgrade `dist/src/main/amoro-bin/conf/config.yaml` to the new version example.
- Upgrade `charts/amoro/templates/common/amoro-configmap.yaml` to the new version example.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
