### PR TITLE
[Improvement]:  Refactored MemorySizeTest.testUnitConversion to Parameterized Test

### DIFF
--- a/amoro-common/src/test/java/org/apache/amoro/utils/MemorySizeTest.java
+++ b/amoro-common/src/test/java/org/apache/amoro/utils/MemorySizeTest.java
@@ -26,46 +26,32 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 /** Tests for the {@link MemorySize} class. */
 public class MemorySizeTest {
 
-  @Test
-  public void testUnitConversion() {
-    final MemorySize zero = MemorySize.ZERO;
-    assertEquals(0, zero.getBytes());
-    assertEquals(0, zero.getKibiBytes());
-    assertEquals(0, zero.getMebiBytes());
-    assertEquals(0, zero.getGibiBytes());
-    assertEquals(0, zero.getTebiBytes());
+  static Stream<Object[]> memorySizeProvider() {
+    return Stream.of(
+            new Object[]{MemorySize.ZERO, 0, 0, 0, 0, 0},
+            new Object[]{new MemorySize(955), 955, 0, 0, 0, 0},
+            new Object[]{new MemorySize(18500), 18500, 18, 0, 0, 0},
+            new Object[]{new MemorySize(15 * 1024 * 1024), 15_728_640, 15_360, 15, 0, 0},
+            new Object[]{new MemorySize(2L * 1024 * 1024 * 1024 * 1024 + 10), 2199023255562L, 2147483648L, 2097152, 2048, 2}
+    );
+  }
 
-    final MemorySize bytes = new MemorySize(955);
-    assertEquals(955, bytes.getBytes());
-    assertEquals(0, bytes.getKibiBytes());
-    assertEquals(0, bytes.getMebiBytes());
-    assertEquals(0, bytes.getGibiBytes());
-    assertEquals(0, bytes.getTebiBytes());
-
-    final MemorySize kilos = new MemorySize(18500);
-    assertEquals(18500, kilos.getBytes());
-    assertEquals(18, kilos.getKibiBytes());
-    assertEquals(0, kilos.getMebiBytes());
-    assertEquals(0, kilos.getGibiBytes());
-    assertEquals(0, kilos.getTebiBytes());
-
-    final MemorySize megas = new MemorySize(15 * 1024 * 1024);
-    assertEquals(15_728_640, megas.getBytes());
-    assertEquals(15_360, megas.getKibiBytes());
-    assertEquals(15, megas.getMebiBytes());
-    assertEquals(0, megas.getGibiBytes());
-    assertEquals(0, megas.getTebiBytes());
-
-    final MemorySize teras = new MemorySize(2L * 1024 * 1024 * 1024 * 1024 + 10);
-    assertEquals(2199023255562L, teras.getBytes());
-    assertEquals(2147483648L, teras.getKibiBytes());
-    assertEquals(2097152, teras.getMebiBytes());
-    assertEquals(2048, teras.getGibiBytes());
-    assertEquals(2, teras.getTebiBytes());
+  @ParameterizedTest
+  @MethodSource("memorySizeProvider")
+  void testUnitConversion(MemorySize memorySize, long expectedBytes, long expectedKibiBytes, long expectedMebiBytes, long expectedGibiBytes, long expectedTebiBytes) {
+    assertEquals(expectedBytes, memorySize.getBytes());
+    assertEquals(expectedKibiBytes, memorySize.getKibiBytes());
+    assertEquals(expectedMebiBytes, memorySize.getMebiBytes());
+    assertEquals(expectedGibiBytes, memorySize.getGibiBytes());
+    assertEquals(expectedTebiBytes, memorySize.getTebiBytes());
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
## Why are the changes needed?

- In the test testUnitConversion the same order of method calls (getBytes, getKibiBytes, getMebiBytes,  . . . ) are repeated multiple times with different inputs, making the test harder to maintain and extend.
- Multiple such clusters of the above method calls are cluttered together in one test, blurring the exact scope of this test.
- When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting the whole block instead of simply adding new data.

## Brief change log
Parameterized testUnitConversion
This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

Test Run report before changes: 
<img width="382" alt="Screenshot 2025-02-28 at 1 45 20 PM" src="https://github.com/user-attachments/assets/1a816673-68b6-458d-a075-f28d4e52d72a" />

Test Run report after changes: 
<img width="610" alt="Screenshot 2025-02-28 at 1 45 50 PM" src="https://github.com/user-attachments/assets/4ffe3412-f89e-4f66-af81-0b8f0be84754" />

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
