### PR TITLE
[Improvement]: Refactored 4 tests in MemorySizeTest to use parameterized unit testing

### DIFF
--- a/amoro-common/src/test/java/org/apache/amoro/utils/MemorySizeTest.java
+++ b/amoro-common/src/test/java/org/apache/amoro/utils/MemorySizeTest.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;

--- a/amoro-common/src/test/java/org/apache/amoro/utils/MemorySizeTest.java
+++ b/amoro-common/src/test/java/org/apache/amoro/utils/MemorySizeTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
@@ -80,44 +81,56 @@ public class MemorySizeTest {
     assertEquals(1234, MemorySize.parseBytes("1234 bytes"));
   }
 
-  @Test
-  public void testParseKibiBytes() {
-    assertEquals(667766, MemorySize.parse("667766k").getKibiBytes());
-    assertEquals(667766, MemorySize.parse("667766 k").getKibiBytes());
-    assertEquals(667766, MemorySize.parse("667766kb").getKibiBytes());
-    assertEquals(667766, MemorySize.parse("667766 kb").getKibiBytes());
-    assertEquals(667766, MemorySize.parse("667766kibibytes").getKibiBytes());
-    assertEquals(667766, MemorySize.parse("667766 kibibytes").getKibiBytes());
+  @ParameterizedTest
+  @CsvSource({
+    "667766k, 667766",
+    "667766 k, 667766",
+    "667766kb, 667766",
+    "667766 kb, 667766",
+    "667766kibibytes, 667766",
+    "667766 kibibytes, 667766"
+  })
+  public void testParseKibiBytes(String input, int expected) {
+    assertEquals(expected, MemorySize.parse(input).getKibiBytes());
   }
 
-  @Test
-  public void testParseMebiBytes() {
-    assertEquals(7657623, MemorySize.parse("7657623m").getMebiBytes());
-    assertEquals(7657623, MemorySize.parse("7657623 m").getMebiBytes());
-    assertEquals(7657623, MemorySize.parse("7657623mb").getMebiBytes());
-    assertEquals(7657623, MemorySize.parse("7657623 mb").getMebiBytes());
-    assertEquals(7657623, MemorySize.parse("7657623mebibytes").getMebiBytes());
-    assertEquals(7657623, MemorySize.parse("7657623 mebibytes").getMebiBytes());
+  @ParameterizedTest
+  @CsvSource({
+    "7657623m, 7657623",
+    "7657623 m, 7657623",
+    "7657623mb, 7657623",
+    "7657623 mb, 7657623",
+    "7657623mebibytes, 7657623",
+    "7657623 mebibytes, 7657623"
+  })
+  public void testParseMebiBytes(String input, int expected) {
+    assertEquals(expected, MemorySize.parse(input).getMebiBytes());
   }
 
-  @Test
-  public void testParseGibiBytes() {
-    assertEquals(987654, MemorySize.parse("987654g").getGibiBytes());
-    assertEquals(987654, MemorySize.parse("987654 g").getGibiBytes());
-    assertEquals(987654, MemorySize.parse("987654gb").getGibiBytes());
-    assertEquals(987654, MemorySize.parse("987654 gb").getGibiBytes());
-    assertEquals(987654, MemorySize.parse("987654gibibytes").getGibiBytes());
-    assertEquals(987654, MemorySize.parse("987654 gibibytes").getGibiBytes());
+  @ParameterizedTest
+  @CsvSource({
+    "987654g, 987654",
+    "987654 g, 987654",
+    "987654gb, 987654",
+    "987654 gb, 987654",
+    "987654gibibytes, 987654",
+    "987654 gibibytes, 987654"
+  })
+  public void testParseGibiBytes(String input, int expected) {
+    assertEquals(expected, MemorySize.parse(input).getGibiBytes());
   }
 
-  @Test
-  public void testParseTebiBytes() {
-    assertEquals(1234567, MemorySize.parse("1234567t").getTebiBytes());
-    assertEquals(1234567, MemorySize.parse("1234567 t").getTebiBytes());
-    assertEquals(1234567, MemorySize.parse("1234567tb").getTebiBytes());
-    assertEquals(1234567, MemorySize.parse("1234567 tb").getTebiBytes());
-    assertEquals(1234567, MemorySize.parse("1234567tebibytes").getTebiBytes());
-    assertEquals(1234567, MemorySize.parse("1234567 tebibytes").getTebiBytes());
+  @ParameterizedTest
+  @CsvSource({
+    "1234567t, 1234567",
+    "1234567 t, 1234567",
+    "1234567tb, 1234567",
+    "1234567 tb, 1234567",
+    "1234567tebibytes, 1234567",
+    "1234567 tebibytes, 1234567"
+  })
+  public void testParseTebiBytes(String input, int expected) {
+    assertEquals(expected, MemorySize.parse(input).getTebiBytes());
   }
 
   @Test


### PR DESCRIPTION
Aim:

Improve the test code by avoiding code duplication, improving maintainability, and enhancing readability. By converting the test into a parameterized unit test, we reduce boilerplate code, make it easier to extend by simply adding new input values, and improve debugging by clearly identifying which test case fails instead of searching through individual assertions.

## Why are the changes needed?
- The same method call to `getKibiBytes`, `getMebiBytes`, `getGibiBytes`, & `getTebiBytes`  are repeated multiple times with different inputs in the tests `testParseKibiBytes`, `testParseMebiBytes`, `testParseGibiBytes`, & `testParseTebiBytes` respectively making them harder to maintain and extend.
- When any of these test fails, JUnit only shows which type of assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting new assertion instead of simply adding new data.

## Brief change log
Parameterized `testParseKibiBytes`, `testParseMebiBytes`, `testParseGibiBytes`, & `testParseTebiBytes`
This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

Test reports after changes: 
<img width="375" alt="Screenshot 2025-03-04 at 7 29 59 PM" src="https://github.com/user-attachments/assets/1713c46d-1b2e-484d-9046-57348f759d5d" />
<img width="319" alt="Screenshot 2025-03-04 at 7 30 05 PM" src="https://github.com/user-attachments/assets/c737b83e-9a0e-4222-907a-b2cccbe4b64f" />

 

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
