### PR TITLE
[Improvement]: Refactored 2 tests in TestTreeNode

### DIFF
--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/TestTreeNode.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/TestTreeNode.java
@@ -21,6 +21,8 @@ package org.apache.amoro;
 import org.apache.amoro.data.DataTreeNode;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestTreeNode {
 
@@ -29,35 +31,17 @@ public class TestTreeNode {
     DataTreeNode.of(0, 0).parent();
   }
 
-  @Test
-  public void testParentNode() {
-    assertParentNode(DataTreeNode.of(0, 0));
-    assertParentNode(DataTreeNode.of(1, 0));
-    assertParentNode(DataTreeNode.of(1, 0));
-    assertParentNode(DataTreeNode.of(3, 3));
-    assertParentNode(DataTreeNode.of(255, 0));
-    assertParentNode(DataTreeNode.of(255, 126));
-    assertParentNode(DataTreeNode.of(255, 245));
-    assertParentNode(DataTreeNode.of(255, 255));
+  @ParameterizedTest
+  @CsvSource({"0, 0", "1, 0", "1, 0", "3, 3", "255, 0", "255, 126", "255, 245", "255, 255"})
+  public void testParentNode(int level, int index) {
+    assertParentNode(DataTreeNode.of(level, index));
   }
 
-  @Test
-  public void testNodeId() {
-    Assert.assertEquals(1, DataTreeNode.of(0, 0).getId());
-    Assert.assertEquals(2, DataTreeNode.of(1, 0).getId());
-    Assert.assertEquals(3, DataTreeNode.of(1, 1).getId());
-    Assert.assertEquals(4, DataTreeNode.of(3, 0).getId());
-    Assert.assertEquals(7, DataTreeNode.of(3, 3).getId());
-    Assert.assertEquals(13, DataTreeNode.of(7, 5).getId());
-    Assert.assertEquals(11, DataTreeNode.of(7, 3).getId());
-
-    Assert.assertEquals(DataTreeNode.of(0, 0), DataTreeNode.ofId(1));
-    Assert.assertEquals(DataTreeNode.of(1, 0), DataTreeNode.ofId(2));
-    Assert.assertEquals(DataTreeNode.of(1, 1), DataTreeNode.ofId(3));
-    Assert.assertEquals(DataTreeNode.of(3, 0), DataTreeNode.ofId(4));
-    Assert.assertEquals(DataTreeNode.of(3, 3), DataTreeNode.ofId(7));
-    Assert.assertEquals(DataTreeNode.of(7, 5), DataTreeNode.ofId(13));
-    Assert.assertEquals(DataTreeNode.of(7, 3), DataTreeNode.ofId(11));
+  @ParameterizedTest
+  @CsvSource({"0, 0, 1", "1, 0, 2", "1, 1, 3", "3, 0, 4", "3, 3, 7", "7, 5, 13", "7, 3, 11"})
+  public void testNodeId(int mask, int index, int expectedId) {
+    Assert.assertEquals(expectedId, DataTreeNode.of(mask, index).getId());
+    Assert.assertEquals(DataTreeNode.of(mask, index), DataTreeNode.ofId(expectedId));
   }
 
   private void assertParentNode(DataTreeNode node) {


### PR DESCRIPTION
Aim:

Improve the test code by avoiding code duplication, improving maintainability, and enhancing readability. By converting the test into a parameterized unit test, we reduce boilerplate code, make it easier to extend by simply adding new input values, and improve debugging by clearly identifying which test case fails instead of searching through individual assertions.

## Why are the changes needed?
- The same method call are repeated multiple times with different inputs in the tests `testParentNode` & `testNodeId` making them harder to maintain and extend.
- When any of these tests fails, JUnit only shows which type of assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting new assertion instead of simply adding new data.

## Brief change log
Parameterized the tests: `testParentNode` & `testNodeId`. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

Test run report after change:
<img width="281" alt="Screenshot 2025-03-04 at 8 40 28 PM" src="https://github.com/user-attachments/assets/0a50cce7-0206-44e9-9895-cb8371b5a36c" />


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
