### PR TITLE
[Improvement]: Improved test testGetUriPath in TestFileUtil by retrofitting to parameterized test

### DIFF
--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestFileUtil.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestFileUtil.java
@@ -29,6 +29,8 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -63,14 +65,18 @@ public class TestFileUtil {
         fileDir);
   }
 
-  @Test
-  public void testGetUriPath() {
-    Assert.assertEquals("/a/b/c", TableFileUtil.getUriPath("hdfs://xxxxx/a/b/c"));
-    Assert.assertEquals("/a/b/c", TableFileUtil.getUriPath("hdfs://localhost:8888/a/b/c"));
-    Assert.assertEquals("/a/b/c", TableFileUtil.getUriPath("file://xxxxx/a/b/c"));
-    Assert.assertEquals("/a/b/c", TableFileUtil.getUriPath("/a/b/c"));
-    Assert.assertEquals("/a/b/c", TableFileUtil.getUriPath("hdfs:/a/b/c"));
-    Assert.assertEquals("a/b/c", TableFileUtil.getUriPath("a/b/c"));
+  @ParameterizedTest
+  @CsvSource(
+      value = {
+        "/a/b/c, hdfs://xxxxx/a/b/c",
+        "/a/b/c, hdfs://localhost:8888/a/b/c",
+        "/a/b/c, file://xxxxx/a/b/c",
+        "/a/b/c, /a/b/c",
+        "/a/b/c, hdfs:/a/b/c",
+        "a/b/c, a/b/c"
+      })
+  public void testGetUriPath_1to6(String param1, String param2) {
+    Assert.assertEquals(param1, TableFileUtil.getUriPath(param2));
   }
 
   private static final TemporaryFolder temp = new TemporaryFolder();

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestFileUtil.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestFileUtil.java
@@ -75,8 +75,8 @@ public class TestFileUtil {
         "/a/b/c, hdfs:/a/b/c",
         "a/b/c, a/b/c"
       })
-  public void testGetUriPath(String param1, String param2) {
-    Assert.assertEquals(param1, TableFileUtil.getUriPath(param2));
+  public void testGetUriPath(String expected, String path) {
+    Assert.assertEquals(expected, TableFileUtil.getUriPath(path));
   }
 
   private static final TemporaryFolder temp = new TemporaryFolder();

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestFileUtil.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestFileUtil.java
@@ -75,7 +75,7 @@ public class TestFileUtil {
         "/a/b/c, hdfs:/a/b/c",
         "a/b/c, a/b/c"
       })
-  public void testGetUriPath_1to6(String param1, String param2) {
+  public void testGetUriPath(String param1, String param2) {
     Assert.assertEquals(param1, TableFileUtil.getUriPath(param2));
   }
 


### PR DESCRIPTION
## Why are the changes needed?
- The same method call are repeated multiple times with different inputs in the test `testGetUriPath` making it harder to maintain and extend.
- When the test fails, JUnit only shows which type of assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting new assertion instead of simply adding new data.


## Brief change log
Parameterized test `testGetUriPath`. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

Test run report after change:
<img width="344" alt="Screenshot 2025-03-04 at 9 51 16 PM" src="https://github.com/user-attachments/assets/e5c22149-0fd1-4ffd-9b6f-4349ad921614" />


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
