### PR TITLE
[Hotfix] Improve the default configuration for AMS internal service and Kubernetes deployment

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
@@ -146,7 +146,7 @@ public class AmoroManagementConf {
   public static final ConfigOption<Boolean> SYNC_HIVE_TABLES_ENABLED =
       ConfigOptions.key("sync-hive-tables.enabled")
           .booleanType()
-          .defaultValue(true)
+          .defaultValue(false)
           .withDescription("Enable synchronizing Hive tables.");
 
   public static final ConfigOption<Integer> SYNC_HIVE_TABLES_THREAD_COUNT =
@@ -428,7 +428,7 @@ public class AmoroManagementConf {
   public static final ConfigOption<Boolean> DATA_EXPIRATION_ENABLED =
       ConfigOptions.key("data-expiration.enabled")
           .booleanType()
-          .defaultValue(false)
+          .defaultValue(true)
           .withDescription("Enable data expiration");
 
   public static final ConfigOption<Integer> DATA_EXPIRATION_THREAD_COUNT =

--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -94,9 +94,26 @@ data:
         enabled: true
         thread-count: 10
 
-      sync-hive-tables:
+      clean-dangling-delete-files:
         enabled: true
         thread-count: 10
+
+      sync-hive-tables:
+        enabled: false
+        thread-count: 10
+
+      data-expiration:
+        enabled: true
+        thread-count: 10
+        interval: 1d
+      
+      auto-create-tags:
+        enabled: true
+        thread-count: 3
+        interval: 1min # 60000
+          
+      table-manifest-io:
+        thread-count: 20
 
       database:
         type: {{ .Values.amoroConf.database.type }}
@@ -109,7 +126,14 @@ data:
       terminal:
         backend: {{ .Values.amoroConf.terminal.backend }}
         {{- if eq .Values.amoroConf.terminal.backend "local" }}
-        local.spark.sql.iceberg.handle-timestamp-without-timezone: {{ .Values.amoroConf.terminal.icebergHandleTimestampWithoutTimezone }}
+        result:
+          limit: 1000
+        stop-on-error: false
+        session:
+          timeout: 30min
+        local:
+          using-session-catalog-for-hive: false        
+          spark.sql.iceberg.handle-timestamp-without-timezone: {{ .Values.amoroConf.terminal.icebergHandleTimestampWithoutTimezone }}
         {{- end }}
         {{- if hasKey .Values.amoroConf.terminal "kyuubiLdapEnabled" }}
         kyuubi.ldap.enabled: {{ .Values.amoroConf.terminal.kyuubiLdapEnabled}}

--- a/charts/amoro/tests/amoro-configmap_test.yaml
+++ b/charts/amoro/tests/amoro-configmap_test.yaml
@@ -60,7 +60,7 @@ tests:
           path: data["config.yaml"]
           pattern:
             |
-            local.spark.sql.iceberg.handle-timestamp-without-timezone: true
+            spark.sql.iceberg.handle-timestamp-without-timezone: true
   - it: Amoro configMap should show kyuubi url if terminal.backend is set to kyuubi
     set:
       amoroConf:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
In #3097, we only modified the configuration file template `amoro-ams/dist/src/main/amoro-bin/conf/config.yaml` in the general deployment, but did not modify the relevant default parameters in the configuration file for kubernetes deployments. Further, we did not modify the default values of the internal parameters `ams.sync-hive-tables.enabled` and `ams.data-expiration.enabled`, which may lead to invalidation of the defaults in case of no user configuration in the `config.yaml`.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Improve the default configuration file of helm charts: `charts/amoro/templates/amoro-configmap.yaml`.
- Modify the default values of the internal management configurations in class `AmoroManagementConf`.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
