### PR TITLE
[AMORO-3477] Add double quotes to the flink config values when generating the flink optimizer startup command

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/FlinkOptimizerContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/FlinkOptimizerContainer.java
@@ -669,11 +669,11 @@ public class FlinkOptimizerContainer extends AbstractResourceContainer {
      * transformed into Flink options. 1. optimizing-group properties 2. optimizing-container
      * properties
      *
-     * @return flink options, format is `-Dkey1=value1 -Dkey2=value2`
+     * @return flink options, format is `-Dkey1="value1" -Dkey2="value2"`
      */
     public String toCliOptions() {
       return flinkOptions.entrySet().stream()
-          .map(entry -> "-D" + entry.getKey() + "=" + entry.getValue())
+          .map(entry -> "-D" + entry.getKey() + "=\"" + entry.getValue() + "\"")
           .collect(Collectors.joining(" "));
     }
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestFlinkOptimizerContainer.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestFlinkOptimizerContainer.java
@@ -18,8 +18,15 @@
 
 package org.apache.amoro.server.manager;
 
+import static org.apache.amoro.server.manager.FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY;
+import static org.apache.amoro.server.manager.FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY;
+
 import org.apache.amoro.OptimizerProperties;
+import org.apache.amoro.resource.Resource;
+import org.apache.amoro.resource.ResourceGroup;
+import org.apache.amoro.resource.ResourceType;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
+import org.apache.amoro.utils.MemorySize;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -88,12 +95,8 @@ public class TestFlinkOptimizerContainer {
             .toString(),
         "config.yaml");
     Map<String, String> flinkConfig = container.loadFlinkConfigForYAML(newFlinkConfResourceUrl);
-    Assert.assertEquals(
-        flinkConfig.get(FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY),
-        "1728m");
-    Assert.assertEquals(
-        flinkConfig.get(FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY),
-        "1600m");
+    Assert.assertEquals(flinkConfig.get(TASK_MANAGER_TOTAL_PROCESS_MEMORY), "1728m");
+    Assert.assertEquals(flinkConfig.get(JOB_MANAGER_TOTAL_PROCESS_MEMORY), "1600m");
   }
 
   @Test
@@ -114,28 +117,24 @@ public class TestFlinkOptimizerContainer {
             .build();
     String flinkOptions = conf.toCliOptions();
     Assert.assertEquals(3, flinkOptions.split(" ").length);
-    Assert.assertTrue(flinkOptions.contains("-Dkey1=value1"));
-    Assert.assertTrue(flinkOptions.contains("-Dkey2=value4"));
-    Assert.assertTrue(flinkOptions.contains("-Dkey5=value5"));
+    Assert.assertTrue(flinkOptions.contains("-Dkey1=\"value1\""));
+    Assert.assertTrue(flinkOptions.contains("-Dkey2=\"value4\""));
+    Assert.assertTrue(flinkOptions.contains("-Dkey5=\"value5\""));
   }
 
   @Test
   public void testGetMemorySizeValue() {
     HashMap<String, String> prop = new HashMap<>();
-    prop.put(FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY, "100");
-    prop.put(FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY, "100");
+    prop.put(TASK_MANAGER_TOTAL_PROCESS_MEMORY, "100");
+    prop.put(JOB_MANAGER_TOTAL_PROCESS_MEMORY, "100");
 
     FlinkOptimizerContainer.FlinkConf conf =
         FlinkOptimizerContainer.FlinkConf.buildFor(prop, Maps.newHashMap()).build();
 
     Assert.assertEquals(
-        0,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY));
+        0, container.getMemorySizeValue(prop, conf, TASK_MANAGER_TOTAL_PROCESS_MEMORY));
     Assert.assertEquals(
-        0,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY));
+        0, container.getMemorySizeValue(prop, conf, JOB_MANAGER_TOTAL_PROCESS_MEMORY));
 
     Map<String, String> containerProperties = Maps.newHashMap();
     containerProperties.put("flink-conf.jobmanager.memory.process.size", "200 M");
@@ -143,50 +142,84 @@ public class TestFlinkOptimizerContainer {
     conf = FlinkOptimizerContainer.FlinkConf.buildFor(prop, containerProperties).build();
     prop.clear();
     Assert.assertEquals(
-        0,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY));
+        0, container.getMemorySizeValue(prop, conf, TASK_MANAGER_TOTAL_PROCESS_MEMORY));
     Assert.assertEquals(
-        200L,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY));
+        200L, container.getMemorySizeValue(prop, conf, JOB_MANAGER_TOTAL_PROCESS_MEMORY));
 
     prop.clear();
     containerProperties = Maps.newHashMap();
     conf = FlinkOptimizerContainer.FlinkConf.buildFor(prop, containerProperties).build();
 
-    prop.put(FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY, "300 M");
-    prop.put(FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY, "300");
+    prop.put(TASK_MANAGER_TOTAL_PROCESS_MEMORY, "300 M");
+    prop.put(JOB_MANAGER_TOTAL_PROCESS_MEMORY, "300");
     Assert.assertEquals(
-        300L,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY));
+        300L, container.getMemorySizeValue(prop, conf, TASK_MANAGER_TOTAL_PROCESS_MEMORY));
     Assert.assertEquals(
-        0,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY));
+        0, container.getMemorySizeValue(prop, conf, JOB_MANAGER_TOTAL_PROCESS_MEMORY));
 
     conf = FlinkOptimizerContainer.FlinkConf.buildFor(Maps.newHashMap(), Maps.newHashMap()).build();
     prop.clear();
     Assert.assertEquals(
-        0L,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY));
+        0L, container.getMemorySizeValue(prop, conf, TASK_MANAGER_TOTAL_PROCESS_MEMORY));
     Assert.assertEquals(
-        0L,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY));
+        0L, container.getMemorySizeValue(prop, conf, JOB_MANAGER_TOTAL_PROCESS_MEMORY));
 
-    prop.put(FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY, "400 MB");
-    prop.put(FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY, "400 MB");
+    prop.put(JOB_MANAGER_TOTAL_PROCESS_MEMORY, "400 MB");
+    prop.put(TASK_MANAGER_TOTAL_PROCESS_MEMORY, "400 MB");
     conf = FlinkOptimizerContainer.FlinkConf.buildFor(prop, Maps.newHashMap()).build();
     Assert.assertEquals(
-        400L,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.TASK_MANAGER_TOTAL_PROCESS_MEMORY));
+        400L, container.getMemorySizeValue(prop, conf, TASK_MANAGER_TOTAL_PROCESS_MEMORY));
     Assert.assertEquals(
-        400L,
-        container.getMemorySizeValue(
-            prop, conf, FlinkOptimizerContainer.FlinkConfKeys.JOB_MANAGER_TOTAL_PROCESS_MEMORY));
+        400L, container.getMemorySizeValue(prop, conf, JOB_MANAGER_TOTAL_PROCESS_MEMORY));
+  }
+
+  @Test
+  public void testBuildFlinkOptionsWithSpaces() {
+    Map<String, String> containerProperties = Maps.newHashMap(this.containerProperties);
+    containerProperties.put("flink-conf.key1", "value1");
+    containerProperties.put(
+        "flink-conf.taskmanager.memory.process.size", MemorySize.parse("10240mb").toString());
+    containerProperties.put("jobmanager.memory", "value3"); // non "flink-conf." property
+
+    // Create some optimizing group properties
+    Map<String, String> groupProperties = new HashMap<>();
+    groupProperties.put("flink-conf.key1", "value1 with spaces");
+    groupProperties.put(
+        "flink-conf.jobmanager.memory.process.size", MemorySize.parse("1G").toString());
+
+    FlinkOptimizerContainer.FlinkConf conf =
+        FlinkOptimizerContainer.FlinkConf.buildFor(Maps.newHashMap(), containerProperties)
+            .withGroupProperties(groupProperties)
+            .build();
+    String flinkOptions = conf.toCliOptions();
+    Assert.assertTrue(flinkOptions.contains("-Dkey1=\"value1 with spaces\""));
+    Assert.assertTrue(flinkOptions.contains("-Dtaskmanager.memory.process.size=\"10 gb\""));
+    Assert.assertTrue(flinkOptions.contains("-Djobmanager.memory.process.size=\"1 gb\""));
+  }
+
+  @Test
+  public void testBuildFlinkOptimizerStartupArgsString() {
+    Map<String, String> containerProperties = Maps.newHashMap(this.containerProperties);
+    containerProperties.put("jobmanager.memory.process.size", "100MB");
+    containerProperties.put("taskmanager.memory.process.size", "10240 MB");
+    containerProperties.put("flink-conf.key1", "value1");
+    containerProperties.put("key2", "value2");
+
+    ResourceGroup resourceGroup =
+        new ResourceGroup.Builder("default", "flinkContainer")
+            .addProperties(containerProperties)
+            .build();
+    Resource resource =
+        new Resource.Builder(
+                resourceGroup.getContainer(), resourceGroup.getName(), ResourceType.OPTIMIZER)
+            .setProperties(resourceGroup.getProperties())
+            .setThreadCount(2)
+            .build();
+    container.init("test", containerProperties);
+    String startUpArgs = container.buildOptimizerStartupArgsString(resource);
+
+    Assert.assertTrue(startUpArgs.contains("-Dkey1=\"value1\""));
+    Assert.assertTrue(startUpArgs.contains("-Djobmanager.memory.process.size=\"100 mb\""));
+    Assert.assertTrue(startUpArgs.contains("-Dtaskmanager.memory.process.size=\"10 gb\""));
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
Currently, when generating startup commands for the flink optimizer, no double quotes`""` are added to the `flink-conf` parameter values. However, when the user-defined `flink-conf` parameter value contains spaces, this can cause the `${value}` in the `"-D${key}=${value}"` in the final generated startup command to contain spaces and the creation of the optimizer will fail.

For example, when i start a flink optimizer with the following configurations: jobmanager.memory.process.size=1000mb and taskmanager.memory.process.size=2gb, we can only see the following logs, with no ERROR message.

```
2025-03-17 19:29:29,838 INFO [JettyServerThreadPool-175] [org.apache.amoro.server.manager.FlinkOptimizerContainer] [] - Starting flink optimizer using command : export 
HADOOP_USER_NAME=hadoop && export HADOOP_CONF_DIR=/usr/local/hadoop3/etc/hadoop/ && export FLINK_CONF_DIR=/usr/local/flink/conf/ && export JVM_ARGS=-Djava.security.krb5
.conf=/etc/krb5.conf && /usr/local/flink/bin/flink run --target=yarn-per-job -Dyarn.per-job-cluster.include-user-jar=FIRST -Dtaskmanager.memory.process.size=2 gb -Dyarn
.application.name=Amoro-flink-optimizer-flinkgroup-7tq9maje3c8pr8116u1h7scors -Djobmanager.memory.process.size=1000 mb -c org.apache.amoro.optimizer.flink.FlinkOptimize
r /data02/amoro-0.8-SNAPSHOT/plugin/optimizer/flink/optimizer-job.jar  -a thrift://127.0.0.1:1261 -p 1 -g flinkgroup -id 7tq9maje3c8pr8116u1h7scors
2025-03-17 19:29:31,898 INFO [JettyServerThreadPool-175] [org.apache.amoro.server.manager.FlinkOptimizerContainer] [] - 2025-03-17 19:29:31,898 INFO  org.apache.flink.y
arn.cli.FlinkYarnSessionCli                [] - Found Yarn properties file under /tmp/.yarn-properties-root.
2025-03-17 19:29:31,899 INFO [JettyServerThreadPool-175] [org.apache.amoro.server.manager.FlinkOptimizerContainer] [] - 2025-03-17 19:29:31,898 INFO  org.apache.flink.y
arn.cli.FlinkYarnSessionCli                [] - Found Yarn properties file under /tmp/.yarn-properties-root.
2025-03-17 19:29:32,075 INFO [JettyServerThreadPool-175] [org.apache.amoro.server.manager.FlinkOptimizerContainer] [] - 2025-03-17 19:29:32,075 INFO  org.apache.hadoop.
security.UserGroupInformation              [] - Login successful for user hdfs/nm-bigdata-168030124.ctc.local@BIGDATA.CHINATELECOM.CN using keytab file hdfs.keytab. Key
tab auto renewal enabled : false
2025-03-17 19:29:32,204 INFO [JettyServerThreadPool-175] [org.apache.amoro.server.manager.FlinkOptimizerContainer] [] - Could not get job jar and dependencies from JAR 
file: JAR file does not exist: gb
2025-03-17 19:29:32,204 INFO [JettyServerThreadPool-175] [org.apache.amoro.server.manager.FlinkOptimizerContainer] [] -
2025-03-17 19:29:32,204 INFO [JettyServerThreadPool-175] [org.apache.amoro.server.manager.FlinkOptimizerContainer] [] - Use the help option (-h or --help) to get help o
n the command.

```
Close #3477.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Add double quotes `""` the flink-conf parameter values when transforming the Flink options into cli options. The format is `-Dkey1="value1" -Dkey2="value2"`

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
