### PR TITLE
[AMORO-3488] Display the file count and file size directly in the table list even when the optimization status is idle

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/utils/OptimizingUtil.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/utils/OptimizingUtil.java
@@ -79,6 +79,8 @@ public class OptimizingUtil {
       optimizeFileInfo = collectOptimizingFileInfo(summary);
     } else if (optimizingStatus == OptimizingStatus.PENDING) {
       optimizeFileInfo = collectPendingFileInfo(optimizingTableRuntime.getPendingInput());
+    } else if (optimizingStatus == OptimizingStatus.IDLE) {
+      optimizeFileInfo = collectFileInfo(optimizingTableRuntime.getTableSummary());
     } else {
       optimizeFileInfo = null;
     }
@@ -136,6 +138,16 @@ public class OptimizingUtil {
                 metricsSummary.getPositionalDeleteSize(), metricsSummary.getPositionDeleteSize()),
             metricsSummary.getPosDeleteFileCnt())
         .addFiles(metricsSummary.getRewriteDataSize(), metricsSummary.getRewriteDataFileCnt())
+        .build();
+  }
+
+  private static FilesStatistics collectFileInfo(
+      AbstractOptimizingEvaluator.PendingInput tableSummary) {
+    if (tableSummary == null) {
+      return null;
+    }
+    return FilesStatistics.builder()
+        .addFiles(tableSummary.getTotalFileSize(), tableSummary.getTotalFileCount())
         .build();
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3488.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->
When the table's optimization status is idle, the file count and file size are shown as zero. To view these details, you need to click on the table name to access the details page. However, it would be more meaningful to display the file count and file size directly in the table list, even when the optimization status is idle.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

Before applying patch
![image](https://github.com/user-attachments/assets/22d501cd-35cb-4345-81c9-b03bb7ecdf83)

After applying patch
![image](https://github.com/user-attachments/assets/2309f3ce-4d29-40e6-a026-9b92b5c1077b)


- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
