### PR TITLE
[hotfix] got 404 when access hive-upgrade page #3487

### DIFF
--- a/amoro-web/src/router/index.ts
+++ b/amoro-web/src/router/index.ts
@@ -17,7 +17,7 @@
   */
 
 import type { RouteRecordRaw } from 'vue-router'
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory  } from 'vue-router'
 const SwaggerUI = () => import('@/components/SwaggerUI.vue')
 const Home = () => import('@/views/Home.vue')
 const Page404 = () => import('@/views/404.vue')
@@ -119,7 +119,7 @@ const routes: Array<RouteRecordRaw> = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHashHistory(),
   routes,
 })
 


### PR DESCRIPTION

## Why are the changes needed?

Close #3487 

## Brief change log

1. Updated API paths: Changed API request paths to start with a leading / (e.g., api/ams/v1/ to /api/ams/v1/) to ensure consistency and adhere to standardized path conventions.
2. Functions affected: getUpgradeStatus, getHiveTableDetail, upgradeHiveTable, getUpgradeProperties.


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
