### PR TITLE
[Improvement]: Improved test OptimizingStatusTest.testOptimizingStatusCodeValue to use parameterized unit testing

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/OptimizingStatusTest.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/OptimizingStatusTest.java
@@ -21,19 +21,33 @@ package org.apache.amoro.server.optimizing;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 public class OptimizingStatusTest {
   @Test
-  public void testOptimizingStatusCodeValue() {
+  public void testNumberOfOptimizingStatuses() {
     assertEquals(7, OptimizingStatus.values().length);
+  }
 
-    assertEquals(OptimizingStatus.FULL_OPTIMIZING, OptimizingStatus.ofCode(100));
-    assertEquals(OptimizingStatus.MAJOR_OPTIMIZING, OptimizingStatus.ofCode(200));
-    assertEquals(OptimizingStatus.MINOR_OPTIMIZING, OptimizingStatus.ofCode(300));
-    assertEquals(OptimizingStatus.COMMITTING, OptimizingStatus.ofCode(400));
-    assertEquals(OptimizingStatus.PLANNING, OptimizingStatus.ofCode(500));
-    assertEquals(OptimizingStatus.PENDING, OptimizingStatus.ofCode(600));
-    assertEquals(OptimizingStatus.IDLE, OptimizingStatus.ofCode(700));
+  static Stream<Arguments> codeToStatusProvider() {
+    return Stream.of(
+        Arguments.of(100, OptimizingStatus.FULL_OPTIMIZING),
+        Arguments.of(200, OptimizingStatus.MAJOR_OPTIMIZING),
+        Arguments.of(300, OptimizingStatus.MINOR_OPTIMIZING),
+        Arguments.of(400, OptimizingStatus.COMMITTING),
+        Arguments.of(500, OptimizingStatus.PLANNING),
+        Arguments.of(600, OptimizingStatus.PENDING),
+        Arguments.of(700, OptimizingStatus.IDLE));
+  }
+
+  @ParameterizedTest
+  @MethodSource("codeToStatusProvider")
+  public void testOptimizingStatusCodeValue(int code, OptimizingStatus expectedStatus) {
+    assertEquals(expectedStatus, OptimizingStatus.ofCode(code));
   }
 
   @Test


### PR DESCRIPTION
## Why are the changes needed?
- The same method call are repeated multiple times with different inputs in the test `testOptimizingStatusCodeValue` making it harder to maintain and extend.
- When the test fails, JUnit only shows which type of assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting new assertion instead of simply adding new data.
- The test also had a completely independent testing logic related to the Number Of Optimizing Statuses.


## Brief change log
Split the original test into 2 tests: `testNumberOfOptimizingStatuses` and a Parameterized test `testOptimizingStatusCodeValue `
This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

Test run report after change:
<img width="418" alt="Screenshot 2025-04-12 at 2 12 22 PM" src="https://github.com/user-attachments/assets/639570fa-dbd8-4e3a-94b5-4cefa3cbd58c" />



## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
