### PR TITLE
[Improvement]: Parameterized Test testOptimizingStatusDisplayValue test in OptimizingStatusTest

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/OptimizingStatusTest.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/OptimizingStatusTest.java
@@ -21,6 +21,11 @@ package org.apache.amoro.server.optimizing;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 public class OptimizingStatusTest {
   @Test
@@ -36,16 +41,21 @@ public class OptimizingStatusTest {
     assertEquals(OptimizingStatus.IDLE, OptimizingStatus.ofCode(700));
   }
 
-  @Test
-  public void testOptimizingStatusDisplayValue() {
-    assertEquals(7, OptimizingStatus.values().length);
+  static Stream<Arguments> displayValueToStatusProvider() {
+    return Stream.of(
+        Arguments.of("full", OptimizingStatus.FULL_OPTIMIZING),
+        Arguments.of("major", OptimizingStatus.MAJOR_OPTIMIZING),
+        Arguments.of("minor", OptimizingStatus.MINOR_OPTIMIZING),
+        Arguments.of("committing", OptimizingStatus.COMMITTING),
+        Arguments.of("planning", OptimizingStatus.PLANNING),
+        Arguments.of("pending", OptimizingStatus.PENDING),
+        Arguments.of("idle", OptimizingStatus.IDLE));
+  }
 
-    assertEquals(OptimizingStatus.FULL_OPTIMIZING, OptimizingStatus.ofDisplayValue("full"));
-    assertEquals(OptimizingStatus.MAJOR_OPTIMIZING, OptimizingStatus.ofDisplayValue("major"));
-    assertEquals(OptimizingStatus.MINOR_OPTIMIZING, OptimizingStatus.ofDisplayValue("minor"));
-    assertEquals(OptimizingStatus.COMMITTING, OptimizingStatus.ofDisplayValue("committing"));
-    assertEquals(OptimizingStatus.PLANNING, OptimizingStatus.ofDisplayValue("planning"));
-    assertEquals(OptimizingStatus.PENDING, OptimizingStatus.ofDisplayValue("pending"));
-    assertEquals(OptimizingStatus.IDLE, OptimizingStatus.ofDisplayValue("idle"));
+  @ParameterizedTest
+  @MethodSource("displayValueToStatusProvider")
+  public void testOptimizingStatusDisplayValue(
+      String displayValue, OptimizingStatus expectedStatus) {
+    assertEquals(expectedStatus, OptimizingStatus.ofDisplayValue(displayValue));
   }
 }


### PR DESCRIPTION
## Why are the changes needed?
- The same method call are repeated multiple times with different inputs in the test `testOptimizingStatusDisplayValue` making it harder to maintain and extend.
- When the test fails, JUnit only shows which type of assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting new assertion instead of simply adding new data.
- The test also had a redundant check of the Number Of Optimizing Statuses.


## Brief change log
Parameterized test `testOptimizingStatusCodeValue` and removed the redundant check.
This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

Test run report after change:
<img width="460" alt="Screenshot 2025-04-12 at 2 20 36 PM" src="https://github.com/user-attachments/assets/81cccfb9-3417-4d40-8c3c-94e5eac26f92" />



## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
