### PR TITLE
[Improvement]: Improved test testDecryptOption in TestConfigShade by removing redundancy and converting into Parameterized Test

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/config/TestConfigShade.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/config/TestConfigShade.java
@@ -52,10 +52,7 @@ public class TestConfigShade {
       new Base64ConfigShade().getIdentifier();
 
   static Stream<Arguments> encryptedValueProvider() {
-    return Stream.of(
-            Arguments.of(USERNAME, "YWRtaW4="),
-            Arguments.of(PASSWORD, "cGFzc3dvcmQ=")
-    );
+    return Stream.of(Arguments.of(USERNAME, "YWRtaW4="), Arguments.of(PASSWORD, "cGFzc3dvcmQ="));
   }
 
   @ParameterizedTest
@@ -64,7 +61,8 @@ public class TestConfigShade {
     String actualEncoded = getBase64EncodedText(rawValue);
     Assertions.assertEquals(expectedEncoded, actualEncoded);
 
-    String decrypted = ConfigShadeUtils.decryptOption(BASE64_CONFIG_SHADE_IDENTIFIER, actualEncoded);
+    String decrypted =
+        ConfigShadeUtils.decryptOption(BASE64_CONFIG_SHADE_IDENTIFIER, actualEncoded);
     Assertions.assertEquals(rawValue, decrypted);
   }
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/config/TestConfigShade.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/config/TestConfigShade.java
@@ -31,6 +31,9 @@ import org.apache.amoro.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.amoro.utils.JacksonUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.yaml.snakeyaml.Yaml;
 
 import java.net.URL;
@@ -39,6 +42,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class TestConfigShade {
   private static final String USERNAME = "admin";
@@ -47,19 +51,21 @@ public class TestConfigShade {
   private static final String BASE64_CONFIG_SHADE_IDENTIFIER =
       new Base64ConfigShade().getIdentifier();
 
-  @Test
-  public void testDecryptOptions() {
-    String encryptUsername = getBase64EncodedText(USERNAME);
-    String encryptPassword = getBase64EncodedText(PASSWORD);
-    Assertions.assertEquals(encryptUsername, "YWRtaW4=");
-    Assertions.assertEquals(encryptPassword, "cGFzc3dvcmQ=");
+  static Stream<Arguments> encryptedValueProvider() {
+    return Stream.of(
+            Arguments.of(USERNAME, "YWRtaW4="),
+            Arguments.of(PASSWORD, "cGFzc3dvcmQ=")
+    );
+  }
 
-    String decryptUsername =
-        ConfigShadeUtils.decryptOption(BASE64_CONFIG_SHADE_IDENTIFIER, encryptUsername);
-    String decryptPassword =
-        ConfigShadeUtils.decryptOption(BASE64_CONFIG_SHADE_IDENTIFIER, encryptPassword);
-    Assertions.assertEquals(decryptUsername, USERNAME);
-    Assertions.assertEquals(decryptPassword, PASSWORD);
+  @ParameterizedTest
+  @MethodSource("encryptedValueProvider")
+  public void testDecryptOption(String rawValue, String expectedEncoded) {
+    String actualEncoded = getBase64EncodedText(rawValue);
+    Assertions.assertEquals(expectedEncoded, actualEncoded);
+
+    String decrypted = ConfigShadeUtils.decryptOption(BASE64_CONFIG_SHADE_IDENTIFIER, actualEncoded);
+    Assertions.assertEquals(rawValue, decrypted);
   }
 
   private String getBase64EncodedText(String plaintext) {


### PR DESCRIPTION
## Why are the changes needed?
- The underlying test tests the encryption and decryption logic for 2 exact independent flows (Username and Password). Making all the lines repeated twice with different inputs making it harder to maintain and extend.
- When the test fails, JUnit only shows which type of assertion failed, but not which specific input caused the failure.
- Adding new test cases requires copying and pasting new assertion instead of simply adding new data.


## Brief change log
Parameterized test `testDecryptOption `
This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.

Test run report after change:
<img width="370" alt="Screenshot 2025-04-12 at 2 50 14 PM" src="https://github.com/user-attachments/assets/fc7f5c12-5d7d-4e95-a0d1-54952c4aaff9" />



## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
No
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
