### PR TITLE
[AMORO-3252] Fix primary key duplicate exception when concurrently inserting table optimization process entries into database

### DIFF
--- a/amoro-ams/src/main/resources/derby/ams-derby-init.sql
+++ b/amoro-ams/src/main/resources/derby/ams-derby-init.sql
@@ -140,7 +140,7 @@ CREATE TABLE table_optimizing_process (
     summary             CLOB(64m),
     from_sequence       CLOB(64m),
     to_sequence         CLOB(64m),
-    CONSTRAINT table_optimizing_process_pk PRIMARY KEY (process_id)
+    CONSTRAINT table_optimizing_process_pk PRIMARY KEY (process_id, table_id)
 );
 
 CREATE TABLE task_runtime (
@@ -160,7 +160,7 @@ CREATE TABLE task_runtime (
     rewrite_output  BLOB,
     metrics_summary CLOB,
     properties      CLOB,
-    CONSTRAINT task_runtime_pk PRIMARY KEY (process_id, task_id)
+    CONSTRAINT task_runtime_pk PRIMARY KEY (process_id, task_id, table_id)
 );
 
 CREATE TABLE optimizing_task_quota (
@@ -171,7 +171,7 @@ CREATE TABLE optimizing_task_quota (
     start_time      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     end_time        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     fail_reason     VARCHAR(4096),
-    CONSTRAINT optimizing_task_quota_pk PRIMARY KEY (process_id, task_id, retry_num)
+    CONSTRAINT optimizing_task_quota_pk PRIMARY KEY (process_id, task_id, retry_num, table_id)
 );
 
 CREATE TABLE api_tokens (

--- a/amoro-ams/src/main/resources/mysql/ams-mysql-init.sql
+++ b/amoro-ams/src/main/resources/mysql/ams-mysql-init.sql
@@ -153,7 +153,7 @@ CREATE TABLE `table_optimizing_process`
     `summary`                       mediumtext COMMENT 'Max change transaction id of these tasks',
     `from_sequence`                 mediumtext COMMENT 'from or min sequence of each partition',
     `to_sequence`                   mediumtext COMMENT 'to or max sequence of each partition',
-    PRIMARY KEY (`process_id`),
+    PRIMARY KEY (`process_id`, `table_id`),
     KEY  `table_index` (`table_id`, `plan_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'History of optimizing after each commit';
 
@@ -175,7 +175,7 @@ CREATE TABLE `task_runtime`
     `rewrite_output`            longblob DEFAULT NULL COMMENT 'rewrite files output',
     `metrics_summary`           text COMMENT 'metrics summary',
     `properties`                mediumtext COMMENT 'task properties',
-    PRIMARY KEY (`process_id`, `task_id`),
+    PRIMARY KEY (`process_id`, `task_id`, `table_id`),
     KEY  `table_index` (`table_id`, `process_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'Optimize task basic information';
 
@@ -188,7 +188,7 @@ CREATE TABLE `optimizing_task_quota`
     `start_time`                timestamp default CURRENT_TIMESTAMP COMMENT 'Time when task start waiting to execute',
     `end_time`                  timestamp default CURRENT_TIMESTAMP COMMENT 'Time when task finished',
     `fail_reason`               varchar(4096) DEFAULT NULL COMMENT 'Error message after task failed',
-    PRIMARY KEY (`process_id`, `task_id`, `retry_num`),
+    PRIMARY KEY (`process_id`, `task_id`, `retry_num`, `table_id`),
     KEY  `table_index` (`table_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'Optimize task basic information';
 

--- a/amoro-ams/src/main/resources/mysql/upgrade.sql
+++ b/amoro-ams/src/main/resources/mysql/upgrade.sql
@@ -75,3 +75,16 @@ update resource_group set properties = JSON_SET(properties, '$."flink-conf.taskm
 -- update resource memory unit
 update resource set properties = JSON_SET(properties, '$."flink-conf.jobmanager.memory.process.size"', CONCAT(JSON_UNQUOTE(JSON_EXTRACT(properties, '$."flink-conf.jobmanager.memory.process.size"')), 'MB')) WHERE JSON_UNQUOTE(JSON_EXTRACT(properties, '$."flink-conf.jobmanager.memory.process.size"')) REGEXP '^[0-9]+$';
 update resource set properties = JSON_SET(properties, '$."flink-conf.taskmanager.memory.process.size"', CONCAT(JSON_UNQUOTE(JSON_EXTRACT(properties, '$."flink-conf.taskmanager.memory.process.size"')), 'MB')) WHERE JSON_UNQUOTE(JSON_EXTRACT(properties, '$."flink-conf.taskmanager.memory.process.size"')) REGEXP '^[0-9]+$';
+
+-- Drop the existing primary key of table_optimizing_process
+ALTER TABLE `table_optimizing_process` DROP PRIMARY KEY;
+-- Add the new primary key including table_id
+ALTER TABLE `table_optimizing_process` ADD PRIMARY KEY (`process_id`, `table_id`);
+-- Drop the existing primary key of task_runtime
+ALTER TABLE `task_runtime` DROP PRIMARY KEY;
+-- Add the new primary key including table_id
+ALTER TABLE `task_runtime` ADD PRIMARY KEY (`process_id`, `task_id`, `table_id`);
+-- Drop the existing primary key of optimizing_task_quota
+ALTER TABLE `optimizing_task_quota` DROP PRIMARY KEY;
+-- Add the new primary key including table_id
+ALTER TABLE `optimizing_task_quota` ADD PRIMARY KEY (`process_id`, `task_id`, `retry_num`, `table_id`);

--- a/amoro-ams/src/main/resources/postgres/ams-postgres-init.sql
+++ b/amoro-ams/src/main/resources/postgres/ams-postgres-init.sql
@@ -233,7 +233,7 @@ CREATE TABLE table_optimizing_process
     summary TEXT,
     from_sequence TEXT,
     to_sequence TEXT,
-    PRIMARY KEY (process_id)
+    PRIMARY KEY (process_id, table_id)
 );
 CREATE INDEX process_index ON table_optimizing_process (table_id, plan_time);
 
@@ -273,7 +273,7 @@ CREATE TABLE task_runtime
     rewrite_output BYTEA,
     metrics_summary TEXT,
     properties TEXT,
-    PRIMARY KEY (process_id, task_id)
+    PRIMARY KEY (process_id, task_id, table_id)
 );
 CREATE INDEX task_runtime_index ON table_optimizing_process (table_id, process_id);
 
@@ -304,7 +304,7 @@ CREATE TABLE optimizing_task_quota
     start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     end_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     fail_reason VARCHAR(4096),
-    PRIMARY KEY (process_id, task_id, retry_num)
+    PRIMARY KEY (process_id, task_id, retry_num, table_id)
 );
 CREATE INDEX quota_index ON table_optimizing_process (table_id);
 

--- a/amoro-ams/src/main/resources/postgres/upgrade.sql
+++ b/amoro-ams/src/main/resources/postgres/upgrade.sql
@@ -120,3 +120,16 @@ SET properties = jsonb_set(
         ('"' || (properties::jsonb->>'flink-conf.taskmanager.memory.process.size') || 'MB"')::jsonb
     )
 WHERE (properties::jsonb->>'flink-conf.taskmanager.memory.process.size') ~ '^[0-9]+$';
+
+-- Drop the existing primary key of table_optimizing_process
+ALTER TABLE table_optimizing_process DROP CONSTRAINT table_optimizing_process_pkey;
+-- Add the new primary key including table_id
+ALTER TABLE table_optimizing_process ADD PRIMARY KEY (process_id, table_id);
+-- Drop the existing primary key of task_runtime
+ALTER TABLE task_runtime DROP CONSTRAINT task_runtime_pkey;
+-- Add the new primary key including table_id
+ALTER TABLE task_runtime ADD PRIMARY KEY (process_id, task_id, table_id);
+-- Drop the existing primary key of optimizing_task_quota
+ALTER TABLE optimizing_task_quota DROP CONSTRAINT optimizing_task_quota_pkey;
+-- Add the new primary key including table_id
+ALTER TABLE optimizing_task_quota ADD PRIMARY KEY (process_id, task_id, retry_num, table_id);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
Currently the primary keys of the tables `table_optimizing_process`, `task_runtime`, and `optimizing_task_quota` contain only `process_id` and not `table_id`, where `process_id` is created by the current timestamp, e.g. 1744702084683. When multiple tables are optimized concurrently, it is easy to have the same `process_id` at the same trigger time, resulting in a primary key duplication exception `org.apache.ibatis.exceptions.PersistenceException` during persistence.

Close #3252.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-  Add table_id to the primary keys of  `table_optimizing_process`, `task_runtime`, and `optimizing_task_quota` respectively.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
