### PR TITLE
[AMORO-3533] Avoid bulk table removal when synchronizing external catalogs and fetching database table listings fails

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/DefaultCatalogManager.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/DefaultCatalogManager.java
@@ -28,6 +28,7 @@ import org.apache.amoro.properties.CatalogMetaProperties;
 import org.apache.amoro.server.AmoroManagementConf;
 import org.apache.amoro.server.persistence.PersistentBase;
 import org.apache.amoro.server.persistence.mapper.CatalogMetaMapper;
+import org.apache.amoro.shade.guava32.com.google.common.annotations.VisibleForTesting;
 import org.apache.amoro.shade.guava32.com.google.common.cache.CacheBuilder;
 import org.apache.amoro.shade.guava32.com.google.common.cache.CacheLoader;
 import org.apache.amoro.shade.guava32.com.google.common.cache.LoadingCache;
@@ -122,6 +123,11 @@ public class DefaultCatalogManager extends PersistentBase implements CatalogMana
             n -> CatalogBuilder.buildServerCatalog(catalogMeta.get(), serverConfiguration));
     serverCatalog.reload(catalogMeta.get());
     return serverCatalog;
+  }
+
+  @VisibleForTesting
+  public void setServerCatalog(ServerCatalog catalog) {
+    serverCatalogMap.put(catalog.name(), catalog);
   }
 
   @Override

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
@@ -274,17 +274,10 @@ public class DefaultTableService extends PersistentBase implements TableService 
               try {
                 tableIdentifiersFutures.add(
                     CompletableFuture.supplyAsync(
-                            () -> {
-                              try {
-                                return externalCatalog.listTables(database).stream()
+                            () ->
+                                externalCatalog.listTables(database).stream()
                                     .map(TableIdentity::new)
-                                    .collect(Collectors.toSet());
-                              } catch (Exception e) {
-                                LOG.error(
-                                    "TableExplorer list tables in database {} error", database, e);
-                                throw new RuntimeException(e);
-                              }
-                            },
+                                    .collect(Collectors.toSet()),
                             tableExplorerExecutors)
                         .exceptionally(
                             ex -> {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
Currently when synchronizing the external directory and fetching the database table list fails, an empty `HashSet` is returned in `DefaultTableService#exploreExternalCatalog()`, which causes the database to be considered to contain 0 tables and triggers the removal of all its tables.

Close #3533.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Throw an exception instead of returning an empty set when fetching the list of tables for a database fails.

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
