### PR TITLE
[AMORO-3549] Fix AMS helm chart cannot set log4j2 because of wrong indentation

### DIFF
--- a/charts/amoro/templates/_pod.tpl
+++ b/charts/amoro/templates/_pod.tpl
@@ -54,7 +54,7 @@
   readOnly: true
   subPath: "config.yaml"
 {{- if or .Values.amoroConf.log4j2 }}
-{{- /* log4j2.yaml from config-map*/ -}}
+{{/* log4j2.yaml from config-map*/}}
 - name: conf
   mountPath: {{ include "amoro.home" . }}/conf/log4j2.xml
   readOnly: true

--- a/charts/amoro/tests/amoro-deployment_test.yaml
+++ b/charts/amoro/tests/amoro-deployment_test.yaml
@@ -365,3 +365,11 @@ tests:
                         operator: In
                         values:
                           - ssd
+  - it: Amoro Deployment should allow setting custom log4j2 config
+    template: amoro-deployment.yaml
+    set:
+      amoroConf:
+        log4j2: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Configuration status=\"WARN\"></Configuration>" # minimal log4j2 config
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "amoro-ams")].volumeMounts[?(@.subPath == "log4j2.xml")]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Currently, when setting amoroConf.log4j2 to non-null value in values.yaml, the generated helm chart has an indentation error that makes it invalid yaml. The error looks like the following in amoro-deployment.yaml.
```
		Error: yaml: line 93: block sequence entries are not allowed in this context
```

Close #3549 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- This commit fixes an erroneous helm comment which swallows unnecessary newline.


## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
