### PR TITLE
[hotfix] Throw the exception when the tableRuntime disposal fails.

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
@@ -113,6 +113,7 @@ public class DefaultTableService extends PersistentBase implements TableService 
                     "Error occurred while removing tableRuntime of table {}",
                     identifier.getId(),
                     e);
+                throw e;
               }
             });
   }
@@ -482,6 +483,7 @@ public class DefaultTableService extends PersistentBase implements TableService 
                               tableIdentifier.getId()); // remove only after successful operation
                         } catch (Exception e) {
                           LOG.error("Error occurred while disposing table {}", tableIdentifier, e);
+                          throw e;
                         }
                       }),
           () ->


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Currently when the disposal of tableRuntime fails, the try-catch method only prints an error log after catching the exception. This does not trigger a rollback of the doAsTransaction method, which in turn allows other methods to execute normally. In  disposeTable(), this may result in the tableRuntime not being removed from memory and persistence, but the tableIdentifier being removed.

Close #3556 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Throw the exception when the tableRuntime disposal fails.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
