### PR TITLE
[AMORO-3559] Extract abstract class for table metrics

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/AbstractTableMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/AbstractTableMetrics.java
@@ -28,12 +28,12 @@ import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 
 import java.util.List;
 
-public abstract class TableMetrics {
+public abstract class AbstractTableMetrics {
   protected final ServerTableIdentifier identifier;
   protected final List<MetricKey> registeredMetricKeys = Lists.newArrayList();
   protected MetricRegistry globalRegistry;
 
-  protected TableMetrics(ServerTableIdentifier identifier) {
+  protected AbstractTableMetrics(ServerTableIdentifier identifier) {
     this.identifier = identifier;
   }
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableMetrics.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.table;
+
+import org.apache.amoro.ServerTableIdentifier;
+import org.apache.amoro.metrics.Metric;
+import org.apache.amoro.metrics.MetricDefine;
+import org.apache.amoro.metrics.MetricKey;
+import org.apache.amoro.server.metrics.MetricRegistry;
+import org.apache.amoro.shade.guava32.com.google.common.collect.ImmutableMap;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
+
+import java.util.List;
+
+public abstract class TableMetrics {
+  protected final ServerTableIdentifier identifier;
+  protected final List<MetricKey> registeredMetricKeys = Lists.newArrayList();
+  protected MetricRegistry globalRegistry;
+
+  protected TableMetrics(ServerTableIdentifier identifier) {
+    this.identifier = identifier;
+  }
+
+  protected void registerMetric(MetricRegistry registry, MetricDefine define, Metric metric) {
+    MetricKey key =
+        registry.register(
+            define,
+            ImmutableMap.of(
+                "catalog",
+                identifier.getCatalog(),
+                "database",
+                identifier.getDatabase(),
+                "table",
+                identifier.getTableName()),
+            metric);
+    registeredMetricKeys.add(key);
+  }
+
+  public void register(MetricRegistry registry) {
+    if (globalRegistry == null) {
+      registerMetrics(registry);
+      globalRegistry = registry;
+    }
+  }
+
+  public void unregister() {
+    if (globalRegistry != null) {
+      registeredMetricKeys.forEach(globalRegistry::unregister);
+      registeredMetricKeys.clear();
+      globalRegistry = null;
+    }
+  }
+
+  protected abstract void registerMetrics(MetricRegistry registry);
+}

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
@@ -24,24 +24,18 @@ import static org.apache.amoro.metrics.MetricDefine.defineGauge;
 import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.metrics.Counter;
 import org.apache.amoro.metrics.Gauge;
-import org.apache.amoro.metrics.Metric;
 import org.apache.amoro.metrics.MetricDefine;
-import org.apache.amoro.metrics.MetricKey;
 import org.apache.amoro.optimizing.OptimizingType;
 import org.apache.amoro.server.AmoroServiceConstants;
 import org.apache.amoro.server.metrics.MetricRegistry;
 import org.apache.amoro.server.optimizing.OptimizingStatus;
 import org.apache.amoro.server.optimizing.maintainer.IcebergTableMaintainer;
-import org.apache.amoro.shade.guava32.com.google.common.collect.ImmutableMap;
-import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 import org.apache.amoro.shade.guava32.com.google.common.primitives.Longs;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 
-import java.util.List;
-
 /** Table self optimizing metrics */
-public class TableOptimizingMetrics {
+public class TableOptimizingMetrics extends TableMetrics {
   /** Table is no need optimizing. */
   public static final String STATUS_IDLE = "idle";
 
@@ -208,36 +202,18 @@ public class TableOptimizingMetrics {
   private final Counter fullTotalCount = new Counter();
   private final Counter fullFailedCount = new Counter();
 
-  private final ServerTableIdentifier identifier;
-
   private OptimizingStatus optimizingStatus = OptimizingStatus.IDLE;
   private long statusSetTimestamp = System.currentTimeMillis();
   private long lastMinorTime, lastMajorTime, lastFullTime;
   private long lastNonMaintainedTime = AmoroServiceConstants.INVALID_TIME;
   private long lastOptimizingTime = AmoroServiceConstants.INVALID_TIME;
-  private final List<MetricKey> registeredMetricKeys = Lists.newArrayList();
-  private MetricRegistry globalRegistry;
 
   public TableOptimizingMetrics(ServerTableIdentifier identifier) {
-    this.identifier = identifier;
+    super(identifier);
   }
 
-  private void registerMetric(MetricRegistry registry, MetricDefine define, Metric metric) {
-    MetricKey key =
-        registry.register(
-            define,
-            ImmutableMap.of(
-                "catalog",
-                identifier.getCatalog(),
-                "database",
-                identifier.getDatabase(),
-                "table",
-                identifier.getTableName()),
-            metric);
-    registeredMetricKeys.add(key);
-  }
-
-  public void register(MetricRegistry registry) {
+  @Override
+  public void registerMetrics(MetricRegistry registry) {
     if (globalRegistry == null) {
       // register status duration metrics
       registerMetric(
@@ -298,14 +274,6 @@ public class TableOptimizingMetrics {
       registerMetric(registry, TABLE_OPTIMIZING_LAG_DURATION, new OptimizingLagDurationGauge());
 
       globalRegistry = registry;
-    }
-  }
-
-  public void unregister() {
-    if (globalRegistry != null) {
-      registeredMetricKeys.forEach(globalRegistry::unregister);
-      registeredMetricKeys.clear();
-      globalRegistry = null;
     }
   }
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 
 /** Table self optimizing metrics */
-public class TableOptimizingMetrics extends TableMetrics {
+public class TableOptimizingMetrics extends AbstractTableMetrics {
   /** Table is no need optimizing. */
   public static final String STATUS_IDLE = "idle";
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOrphanFilesCleaningMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOrphanFilesCleaningMetrics.java
@@ -22,28 +22,19 @@ import static org.apache.amoro.metrics.MetricDefine.defineCounter;
 
 import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.metrics.Counter;
-import org.apache.amoro.metrics.Metric;
 import org.apache.amoro.metrics.MetricDefine;
-import org.apache.amoro.metrics.MetricKey;
 import org.apache.amoro.server.metrics.MetricRegistry;
-import org.apache.amoro.shade.guava32.com.google.common.collect.ImmutableMap;
-import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
-
-import java.util.List;
 
 /** Table Orphan Files Cleaning metrics. */
-public class TableOrphanFilesCleaningMetrics {
-
+public class TableOrphanFilesCleaningMetrics extends TableMetrics {
   private final Counter orphanDataFilesCount = new Counter();
   private final Counter expectedOrphanDataFilesCount = new Counter();
 
   private final Counter orphanMetadataFilesCount = new Counter();
   private final Counter expectedOrphanMetadataFilesCount = new Counter();
 
-  private final ServerTableIdentifier identifier;
-
   public TableOrphanFilesCleaningMetrics(ServerTableIdentifier identifier) {
-    this.identifier = identifier;
+    super(identifier);
   }
 
   public static final MetricDefine TABLE_ORPHAN_CONTENT_FILE_CLEANING_COUNT =
@@ -72,25 +63,8 @@ public class TableOrphanFilesCleaningMetrics {
           .withTags("catalog", "database", "table")
           .build();
 
-  private final List<MetricKey> registeredMetricKeys = Lists.newArrayList();
-  private MetricRegistry globalRegistry;
-
-  private void registerMetric(MetricRegistry registry, MetricDefine define, Metric metric) {
-    MetricKey key =
-        registry.register(
-            define,
-            ImmutableMap.of(
-                "catalog",
-                identifier.getCatalog(),
-                "database",
-                identifier.getDatabase(),
-                "table",
-                identifier.getTableName()),
-            metric);
-    registeredMetricKeys.add(key);
-  }
-
-  public void register(MetricRegistry registry) {
+  @Override
+  public void registerMetrics(MetricRegistry registry) {
     if (globalRegistry == null) {
       registerMetric(registry, TABLE_ORPHAN_CONTENT_FILE_CLEANING_COUNT, orphanDataFilesCount);
       registerMetric(registry, TABLE_ORPHAN_METADATA_FILE_CLEANING_COUNT, orphanMetadataFilesCount);
@@ -114,13 +88,5 @@ public class TableOrphanFilesCleaningMetrics {
   public void completeOrphanMetadataFiles(int expected, int cleaned) {
     expectedOrphanMetadataFilesCount.inc(expected);
     orphanMetadataFilesCount.inc(cleaned);
-  }
-
-  public void unregister() {
-    if (globalRegistry != null) {
-      registeredMetricKeys.forEach(globalRegistry::unregister);
-      registeredMetricKeys.clear();
-      globalRegistry = null;
-    }
   }
 }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOrphanFilesCleaningMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOrphanFilesCleaningMetrics.java
@@ -26,7 +26,7 @@ import org.apache.amoro.metrics.MetricDefine;
 import org.apache.amoro.server.metrics.MetricRegistry;
 
 /** Table Orphan Files Cleaning metrics. */
-public class TableOrphanFilesCleaningMetrics extends TableMetrics {
+public class TableOrphanFilesCleaningMetrics extends AbstractTableMetrics {
   private final Counter orphanDataFilesCount = new Counter();
   private final Counter expectedOrphanDataFilesCount = new Counter();
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableSummaryMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableSummaryMetrics.java
@@ -30,7 +30,7 @@ import org.apache.amoro.table.MixedTable;
 import org.apache.amoro.table.UnkeyedTable;
 
 /** Table Summary metrics. */
-public class TableSummaryMetrics extends TableMetrics {
+public class TableSummaryMetrics extends AbstractTableMetrics {
 
   // table summary files number metrics
   public static final MetricDefine TABLE_SUMMARY_TOTAL_FILES =

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableSummaryMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableSummaryMetrics.java
@@ -22,20 +22,15 @@ import static org.apache.amoro.metrics.MetricDefine.defineGauge;
 
 import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.metrics.Gauge;
-import org.apache.amoro.metrics.Metric;
 import org.apache.amoro.metrics.MetricDefine;
-import org.apache.amoro.metrics.MetricKey;
 import org.apache.amoro.optimizing.plan.AbstractOptimizingEvaluator;
 import org.apache.amoro.server.metrics.MetricRegistry;
-import org.apache.amoro.shade.guava32.com.google.common.collect.ImmutableMap;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 import org.apache.amoro.table.MixedTable;
 import org.apache.amoro.table.UnkeyedTable;
 
-import java.util.List;
-
 /** Table Summary metrics. */
-public class TableSummaryMetrics {
+public class TableSummaryMetrics extends TableMetrics {
 
   // table summary files number metrics
   public static final MetricDefine TABLE_SUMMARY_TOTAL_FILES =
@@ -132,34 +127,17 @@ public class TableSummaryMetrics {
           .withTags("catalog", "database", "table")
           .build();
 
-  private final ServerTableIdentifier identifier;
-  private final List<MetricKey> registeredMetricKeys = Lists.newArrayList();
   private AbstractOptimizingEvaluator.PendingInput tableSummary =
       new AbstractOptimizingEvaluator.PendingInput();
-  private MetricRegistry globalRegistry;
 
   private long snapshots = 0L;
 
   public TableSummaryMetrics(ServerTableIdentifier identifier) {
-    this.identifier = identifier;
+    super(identifier);
   }
 
-  private void registerMetric(MetricRegistry registry, MetricDefine define, Metric metric) {
-    MetricKey key =
-        registry.register(
-            define,
-            ImmutableMap.of(
-                "catalog",
-                identifier.getCatalog(),
-                "database",
-                identifier.getDatabase(),
-                "table",
-                identifier.getTableName()),
-            metric);
-    registeredMetricKeys.add(key);
-  }
-
-  public void register(MetricRegistry registry) {
+  @Override
+  public void registerMetrics(MetricRegistry registry) {
     if (globalRegistry == null) {
       // register files number metrics
       registerMetric(
@@ -229,14 +207,6 @@ public class TableSummaryMetrics {
       registerMetric(registry, TABLE_SUMMARY_SNAPSHOTS, (Gauge<Long>) () -> snapshots);
 
       globalRegistry = registry;
-    }
-  }
-
-  public void unregister() {
-    if (globalRegistry != null) {
-      registeredMetricKeys.forEach(globalRegistry::unregister);
-      registeredMetricKeys.clear();
-      globalRegistry = null;
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
In the current implementation, each specific metric class (i.e. “TableOptimizingMetrics”, “TableOrphanFilesCleaningMetrics”, “TableSummaryMetrics") all contain similar logic and duplicate code for registering and unregistering metrics. This duplication makes the metrics more difficult to maintain and extend. To improve code maintainability and reduce redundancy, we introduce a generic abstract class `TableMetrics`.

Close #3559.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Create `TableMetrics` abstract class
- Update `TableOptimizingMetrics`, `TableOrphanFilesCleaningMetrics`, and `TableSummaryMetrics` to extend `TableMetrics`.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
