### PR TITLE
[Hotfix] Fix HudiTableDesctiptor error

### DIFF
--- a/amoro-format-hudi/src/main/resources/META-INF/services/org.apache.amoro.table.descriptor.FormatTableDescriptor
+++ b/amoro-format-hudi/src/main/resources/META-INF/services/org.apache.amoro.table.descriptor.FormatTableDescriptor
@@ -15,4 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.apache.amoro.formats.paimon.PaimonTableDescriptor
+org.apache.amoro.formats.hudi.HudiTableDescriptor


### PR DESCRIPTION
## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

In the resources under the Amoro-format-hudi module, should fill in org.apache.amoro.formats.hudi.HudiTableDescriptor instead of paimon

Close #xxx.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no) NO
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
