### PR TITLE
[AMORO-3587] Modify the default value of hive catalog clients to 20

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/catalog/CatalogBuilder.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/catalog/CatalogBuilder.java
@@ -23,6 +23,8 @@ import static org.apache.amoro.properties.CatalogMetaProperties.CATALOG_TYPE_CUS
 import static org.apache.amoro.properties.CatalogMetaProperties.CATALOG_TYPE_GLUE;
 import static org.apache.amoro.properties.CatalogMetaProperties.CATALOG_TYPE_HADOOP;
 import static org.apache.amoro.properties.CatalogMetaProperties.CATALOG_TYPE_HIVE;
+import static org.apache.amoro.properties.CatalogMetaProperties.CLIENT_POOL_SIZE;
+import static org.apache.amoro.properties.CatalogMetaProperties.CLIENT_POOL_SIZE_DEFAULT;
 
 import org.apache.amoro.TableFormat;
 import org.apache.amoro.api.CatalogMeta;
@@ -88,6 +90,9 @@ public class CatalogBuilder {
       case CATALOG_TYPE_HIVE:
         String amsUri = getAmsURI(serverConfiguration);
         catalogMeta.getCatalogProperties().put(CatalogMetaProperties.AMS_URI, amsUri);
+        catalogMeta
+            .getCatalogProperties()
+            .put(CLIENT_POOL_SIZE, String.valueOf(CLIENT_POOL_SIZE_DEFAULT));
         return new ExternalCatalog(catalogMeta);
       case CATALOG_TYPE_AMS:
         return new InternalCatalogImpl(catalogMeta, serverConfiguration);

--- a/amoro-common/src/main/java/org/apache/amoro/properties/CatalogMetaProperties.java
+++ b/amoro-common/src/main/java/org/apache/amoro/properties/CatalogMetaProperties.java
@@ -64,7 +64,7 @@ public class CatalogMetaProperties {
   public static final String TABLE_FORMATS = "table-formats";
 
   public static final String CLIENT_POOL_SIZE = "clients";
-  public static final int CLIENT_POOL_SIZE_DEFAULT = 2;
+  public static final int CLIENT_POOL_SIZE_DEFAULT = 20;
 
   public static final String CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS =
       "client.pool.cache.eviction-interval-ms";

--- a/docs/admin-guides/managing-catalogs.md
+++ b/docs/admin-guides/managing-catalogs.md
@@ -69,6 +69,7 @@ You can create a catalog in the AMS frontend:
 Common properties include:
 - warehouse: Warehouse **must be configured** for ams/hadoop/glue catalog, as it determines where our database and table files should be placed
 - catalog-impl: when the metastore is **Custom**, an additional catalog-impl must be defined, and the user must put the jar package for the custom catalog implementation into the **{AMORO_HOME}/lib** directory, **and the service must be restarted to take effect**
+- clients: Hive Catalog connection pool size for accessing HiveMetaStore, default configuration is 20, requires restarting Amoro to take effect.
 - database-filter: Configure a regular expression to filter databases in the catalog. If not set then all databases will be displayed in table menu.
 - table-filter: Configure a regular expression to filter tables in the catalog. The matching will be done in the format of `database.table`. For example, if it is set to `(A\.a)|(B\.b)`, it will ignore all tables except for table `a` in database `A` and table `b` in database `B`
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3587.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Fixed the default value of clients to 20 and set the clients parameter when creating an external Hive metastore catalog.
- Added description of the clients parameter in the docs/admin-guides/managing-catalogs.md document

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
