### PR TITLE
[AMORO-3599] remove com.esotericsoftware.kryo dependencies in flink optimizer package

### DIFF
--- a/amoro-optimizer/amoro-optimizer-flink/pom.xml
+++ b/amoro-optimizer/amoro-optimizer-flink/pom.xml
@@ -46,7 +46,7 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.esotericsoftware.kryo</groupId>
+                    <groupId>com.esotericsoftware</groupId>
                     <artifactId>kryo</artifactId>
                 </exclusion>
             </exclusions>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
The current version of kryo included in amoro is 4.0.3. After 2.24.0, the groupId of kryo dependency has been changed to com.esotericsoftware (e.g. com.esotericsoftware:kryo:4.0.3), which caused the previous exclusion to fail to block kryo: 4.0.3 packaged into the flink optimizer dependency.

![image](https://github.com/user-attachments/assets/4c8caa82-3ea7-4d48-b35e-f44fe26dbfbf)

Close #3599.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Update groupId of kryo dependency `com.esotericsoftware.kryo` to `com.esotericsoftware`

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
