### PR TITLE
[AMORO-3616][Improvement] Correct the spelling errors in doc of Managing Optimizers page

### DIFF
--- a/docs/admin-guides/managing-optimizers.md
+++ b/docs/admin-guides/managing-optimizers.md
@@ -56,7 +56,7 @@ containers:
 The format for optimizing URI is `thrift://{host}:{port}?parameter1=value2&parameter2=value2`.
 The supported parameters include:
 
-| Parameter Name | efault Value      | Description                                                |
+| Parameter Name | Default Value     | Description                                                |
 |----------------|-------------------|------------------------------------------------------------|
 | autoReconnect  | true              | If reconnect the server when the connection is broken      |
 | maxReconnects  | 5                 | Retry times when reconnecting                              |


### PR DESCRIPTION
## Why are the changes needed?
Close [#3616](https://github.com/apache/amoro/issues/3616)

## Brief change log

Fix the spelling errors in doc of Managing Optimizers page.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no) 
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
