### PR TITLE
[AMORO-3624]: In HA mode, the zk client session timeout and connection timeout should be configurable. #3624

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
@@ -215,6 +215,18 @@ public class AmoroManagementConf {
           .defaultValue("")
           .withDescription("The Zookeeper address used for high availability.");
 
+  public static final ConfigOption<Integer> HA_ZOOKEEPER_SESSION_TIMEOUT_MS =
+      ConfigOptions.key("ha.session-timeout-ms")
+          .intType()
+          .defaultValue(30000)
+          .withDescription("The Zookeeper session timeout in milliseconds.");
+
+  public static final ConfigOption<Integer> HA_ZOOKEEPER_CONNECTION_TIMEOUT_MS =
+      ConfigOptions.key("ha.connection-timeout-ms")
+          .intType()
+          .defaultValue(30000)
+          .withDescription("The Zookeeper connection timeout in milliseconds.");
+
   public static final ConfigOption<Integer> TABLE_SERVICE_THRIFT_BIND_PORT =
       ConfigOptions.key("thrift-server.table-service.bind-port")
           .intType()

--- a/amoro-ams/src/main/java/org/apache/amoro/server/HighAvailabilityContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/HighAvailabilityContainer.java
@@ -51,6 +51,10 @@ public class HighAvailabilityContainer implements LeaderLatchListener {
   public HighAvailabilityContainer(Configurations serviceConfig) throws Exception {
     if (serviceConfig.getBoolean(AmoroManagementConf.HA_ENABLE)) {
       String zkServerAddress = serviceConfig.getString(AmoroManagementConf.HA_ZOOKEEPER_ADDRESS);
+      int zkSessionTimeout =
+          serviceConfig.getInteger(AmoroManagementConf.HA_ZOOKEEPER_SESSION_TIMEOUT_MS);
+      int zkConnectionTimeout =
+          serviceConfig.getInteger(AmoroManagementConf.HA_ZOOKEEPER_CONNECTION_TIMEOUT_MS);
       String haClusterName = serviceConfig.getString(AmoroManagementConf.HA_CLUSTER_NAME);
       tableServiceMasterPath = AmsHAProperties.getTableServiceMasterPath(haClusterName);
       optimizingServiceMasterPath = AmsHAProperties.getOptimizingServiceMasterPath(haClusterName);
@@ -58,8 +62,8 @@ public class HighAvailabilityContainer implements LeaderLatchListener {
       this.zkClient =
           CuratorFrameworkFactory.builder()
               .connectString(zkServerAddress)
-              .sessionTimeoutMs(5000)
-              .connectionTimeoutMs(5000)
+              .sessionTimeoutMs(zkSessionTimeout)
+              .connectionTimeoutMs(zkConnectionTimeout)
               .retryPolicy(retryPolicy)
               .build();
       zkClient.start();


### PR DESCRIPTION
[Improvement]: In HA mode, the zk client session timeout and connection timeout should be configurable. #3624

## Why are the changes needed?
In HA mode, the zk client session timeout and connection timeout should be configurable.
The default hard-coded timeout of 5 seconds is too short.Once a fullgc lasts for more than 5 seconds, it is more likely to cause a master change.
![image](https://github.com/user-attachments/assets/3dbaa577-4a2c-4b9f-ac31-5621639800e2)


Close #3624 

## Brief change log
<!--
Make session timeout and connection timeout configurable.
-->

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [*] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no) 
   no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
