### PR TITLE
[AMORO-3638] Add support for task retries when task execution times out

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
@@ -383,8 +383,8 @@ public class AmoroManagementConf {
   public static final ConfigOption<Duration> OPTIMIZER_TASK_EXECUTE_TIMEOUT =
       ConfigOptions.key("optimizer.task-execute-timeout")
           .durationType()
-          .defaultValue(Duration.ofHours(5))
-          .withDescription("Timeout duration for task execution, default to 5 hours.");
+          .defaultValue(Duration.ofHours(1))
+          .withDescription("Timeout duration for task execution, default to 1 hour.");
 
   public static final ConfigOption<Integer> OPTIMIZER_MAX_PLANNING_PARALLELISM =
       ConfigOptions.key("optimizer.max-planning-parallelism")

--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroManagementConf.java
@@ -380,6 +380,12 @@ public class AmoroManagementConf {
           .defaultValue(Duration.ofSeconds(30))
           .withDescription("Timeout duration for task acknowledgment.");
 
+  public static final ConfigOption<Duration> OPTIMIZER_TASK_EXECUTE_TIMEOUT =
+      ConfigOptions.key("optimizer.task-execute-timeout")
+          .durationType()
+          .defaultValue(Duration.ofHours(5))
+          .withDescription("Timeout duration for task execution, default to 5 hours.");
+
   public static final ConfigOption<Integer> OPTIMIZER_MAX_PLANNING_PARALLELISM =
       ConfigOptions.key("optimizer.max-planning-parallelism")
           .intType()

--- a/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/DefaultOptimizingService.java
@@ -59,6 +59,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -518,8 +519,9 @@ public class DefaultOptimizingService extends StatedPersistentBase
       if (task.getStatus() == TaskRuntime.Status.ACKED
           && task.getStartTime() + taskExecuteTimeout < System.currentTimeMillis()) {
         LOG.warn(
-            "Task {} is suspending at ACK status (start time: {}), put it to retry queue, optimizer {}",
+            "Task {} has been suspended in ACK state for {} (start time: {}), put it to retry queue, optimizer {}. (Note: The task may have finished executing, but ams did not receive the COMPLETE message from the optimizer.)",
             task.getTaskId(),
+            Duration.ofMillis(taskExecuteTimeout),
             task.getStartTime(),
             task.getResourceDesc());
       } else {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -508,6 +508,10 @@ public class OptimizingQueue extends PersistentBase {
                 taskRuntime.getFailReason());
             retryTask(taskRuntime);
           } else {
+            LOG.info(
+                "Task {} has reached the max execute retry count. Process {} failed.",
+                taskRuntime.getTaskId(),
+                processId);
             this.failedReason = taskRuntime.getFailReason();
             this.status = ProcessStatus.FAILED;
             this.endTime = taskRuntime.getEndTime();

--- a/amoro-ams/src/test/java/org/apache/amoro/server/AMSServiceTestBase.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/AMSServiceTestBase.java
@@ -38,6 +38,8 @@ public abstract class AMSServiceTestBase extends AMSManagerTestBase {
     try {
       Configurations configurations = new Configurations();
       configurations.set(AmoroManagementConf.OPTIMIZER_HB_TIMEOUT, Duration.ofMillis(800L));
+      configurations.set(
+          AmoroManagementConf.OPTIMIZER_TASK_EXECUTE_TIMEOUT, Duration.ofMillis(30000L));
       TABLE_SERVICE = new DefaultTableService(new Configurations(), CATALOG_MANAGER);
       OPTIMIZING_SERVICE =
           new DefaultOptimizingService(

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultOptimizingService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultOptimizingService.java
@@ -312,6 +312,36 @@ public class TestDefaultOptimizingService extends AMSTableTestBase {
   }
 
   @Test
+  public void testExecuteTaskTimeOutAndRetry() throws InterruptedException {
+    OptimizingTask task = optimizingService().pollTask(token, THREAD_ID);
+    Assertions.assertNotNull(task);
+
+    optimizingService().ackTask(token, THREAD_ID, task.getTaskId());
+
+    TaskRuntime taskRuntime =
+        optimizingService().listTasks(defaultResourceGroup().getName()).get(0);
+    assertTaskStatus(TaskRuntime.Status.ACKED);
+
+    // In this test, OPTIMIZER_TASK_EXECUTE_TIMEOUT is set to 30 seconds, so after waiting 45
+    // seconds the task will be considered suspended and retried
+    Thread.sleep(45000);
+
+    assertTaskStatus(TaskRuntime.Status.PLANNED);
+    OptimizingTask task2 = optimizingService().pollTask(token, THREAD_ID);
+    Assertions.assertNotNull(task2);
+    Assertions.assertEquals(task2.getTaskId(), task.getTaskId());
+    TableOptimizing.OptimizingInput input =
+        SerializationUtil.simpleDeserialize(task.getTaskInput());
+    TableOptimizing.OptimizingInput input2 =
+        SerializationUtil.simpleDeserialize(task2.getTaskInput());
+    Assertions.assertEquals(input2.toString(), input.toString());
+
+    optimizingService().ackTask(token, THREAD_ID, task2.getTaskId());
+    optimizingService().completeTask(token, buildOptimizingTaskResult(task2.getTaskId()));
+    assertTaskCompleted(taskRuntime);
+  }
+
+  @Test
   public void testReloadScheduledTask() {
     // 1.poll task
     OptimizingTask task = optimizingService().pollTask(token, THREAD_ID);

--- a/dist/src/main/amoro-bin/conf/config.yaml
+++ b/dist/src/main/amoro-bin/conf/config.yaml
@@ -55,7 +55,7 @@ ams:
   optimizer:
     heart-beat-timeout: 1min # 60000
     task-ack-timeout: 30s # 30000
-    task-execute-timeout: 5h # 18000000
+    task-execute-timeout: 1h # 3600000
     polling-timeout: 3s # 3000
     max-planning-parallelism: 1 # default 1
 

--- a/dist/src/main/amoro-bin/conf/config.yaml
+++ b/dist/src/main/amoro-bin/conf/config.yaml
@@ -55,6 +55,7 @@ ams:
   optimizer:
     heart-beat-timeout: 1min # 60000
     task-ack-timeout: 30s # 30000
+    task-execute-timeout: 5h # 18000000
     polling-timeout: 3s # 3000
     max-planning-parallelism: 1 # default 1
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
Currently, when the optimizer exits abnormally while executing a task or when there is an exception in the thrift communication between the optimizer and ams, ams fails to update the taskRuntime status, even though the task has already finished executing.  And the optimization process is also stuck in the running phase blocking the subsequent optimization.

Therefore, we need to add a task execution timeout detection in ams to stop and re-run the timeout task in ACK to prevent blocking the subsequent optimization process.

Close #3638.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Add an amoro management configOption `optimizer.task-execute-timeout`
- Detect and retry the timeout taskRuntimes in the `optimizer-keeper-thread`

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
