### PR TITLE
[AMORO-3682]Fix table creation failure when comment contains `PRIMARY KEY` text

### DIFF
--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/spark/sql/amoro/parser/MixedFormatSqlExtendAstBuilder.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/src/main/scala/org/apache/spark/sql/amoro/parser/MixedFormatSqlExtendAstBuilder.scala
@@ -198,8 +198,10 @@ class MixedFormatSqlExtendAstBuilder()
    * Create a comment string.
    */
   override def visitPrimarySpec(ctx: MixedFormatSqlExtendParser.PrimarySpecContext): Seq[String] =
-    withOrigin(ctx) {
-      visitIdentifierList(ctx.identifierList())
+    Option(ctx).fold(Seq.empty[String]) { validCtx =>
+      withOrigin(validCtx) {
+        visitIdentifierList(validCtx.identifierList())
+      }
     }
 
   override def visitCreateTableClauses(ctx: MixedFormatSqlExtendParser.CreateTableClausesContext)

--- a/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/spark/sql/amoro/parser/MixedFormatSqlExtendAstBuilder.scala
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/main/scala/org/apache/spark/sql/amoro/parser/MixedFormatSqlExtendAstBuilder.scala
@@ -200,8 +200,10 @@ class MixedFormatSqlExtendAstBuilder()
    * Create a comment string.
    */
   override def visitPrimarySpec(ctx: MixedFormatSqlExtendParser.PrimarySpecContext): Seq[String] =
-    withOrigin(ctx) {
-      visitIdentifierList(ctx.identifierList())
+    Option(ctx).fold(Seq.empty[String]) { validCtx =>
+      withOrigin(validCtx) {
+        visitIdentifierList(validCtx.identifierList())
+      }
     }
 
   override def visitCreateTableClauses(ctx: MixedFormatSqlExtendParser.CreateTableClausesContext)

--- a/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/test/java/org/apache/amoro/spark/test/suites/sql/TestCreateTableSQL.java
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/src/test/java/org/apache/amoro/spark/test/suites/sql/TestCreateTableSQL.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -302,6 +303,102 @@ public class TestCreateTableSQL extends MixedTableTestBase {
 
     Asserts.assertType(expectSchema.asStruct(), tbl.schema().asStruct());
     Asserts.assertHashMapContainExpect(expectProperties, tbl.properties());
+    if (TableFormat.MIXED_HIVE.equals(format)) {
+      Table hiveTable = loadHiveTable();
+      Asserts.assertHiveColumns(
+          expectSchema, PartitionSpec.unpartitioned(), hiveTable.getSd().getCols());
+    }
+  }
+
+  public static Stream<Arguments> testPrimaryKeyComment() {
+    String structDDL =
+        "id INT comment 'primary key id',\n"
+            + "data string NOT NULL,\n"
+            + "point struct<x: double NOT NULL, y: double NOT NULL>,\n"
+            + "maps map<string, string>,\n"
+            + "arrays array<string>,\n"
+            + "pt string ";
+    Types.NestedField id =
+        Types.NestedField.optional(1, "id", Types.IntegerType.get(), "primary key id");
+    Types.NestedField data = Types.NestedField.required(2, "data", Types.StringType.get());
+    Types.NestedField point =
+        Types.NestedField.optional(
+            3,
+            "point",
+            Types.StructType.of(
+                Types.NestedField.required(4, "x", Types.DoubleType.get()),
+                Types.NestedField.required(5, "y", Types.DoubleType.get())));
+    Types.NestedField map =
+        Types.NestedField.optional(
+            6,
+            "maps",
+            Types.MapType.ofOptional(7, 8, Types.StringType.get(), Types.StringType.get()));
+    Types.NestedField array =
+        Types.NestedField.optional(
+            9, "arrays", Types.ListType.ofOptional(10, Types.StringType.get()));
+    Types.NestedField pt = Types.NestedField.optional(11, "pt", Types.StringType.get());
+
+    return Stream.of(
+        Arguments.of(
+            TableFormat.MIXED_ICEBERG,
+            structDDL,
+            "TBLPROPERTIES('key'='value1', 'catalog'='INTERNAL')",
+            new Schema(Lists.newArrayList(id, data, point, map, array, pt)),
+            ImmutableMap.of("key", "value1", "catalog", "INTERNAL"),
+            "primary key comment"),
+        Arguments.of(
+            TableFormat.MIXED_ICEBERG,
+            structDDL + ", PRIMARY KEY(id)",
+            "TBLPROPERTIES('key'='value1', 'catalog'='INTERNAL')",
+            new Schema(Lists.newArrayList(id.asRequired(), data, point, map, array, pt)),
+            ImmutableMap.of("key", "value1", "catalog", "INTERNAL"),
+            "primary key comment"),
+        Arguments.of(
+            TableFormat.MIXED_HIVE,
+            structDDL,
+            "tblproperties('key'='value1', 'catalog'='hive')",
+            new Schema(Lists.newArrayList(id, data, point, map, array, pt)),
+            ImmutableMap.of("key", "value1", "catalog", "hive"),
+            "Primary key comment"),
+        Arguments.of(
+            TableFormat.MIXED_HIVE,
+            structDDL + ", PRIMARY KEY(id)",
+            "tblproperties('key'='value1', 'catalog'='hive')",
+            new Schema(Lists.newArrayList(id.asRequired(), data, point, map, array, pt)),
+            ImmutableMap.of("key", "value1", "catalog", "hive"),
+            "Primary key comment"));
+  }
+
+  @DisplayName("Test comment contains primary key")
+  @ParameterizedTest
+  @MethodSource
+  public void testPrimaryKeyComment(
+      TableFormat format,
+      String structDDL,
+      String propertiesDDL,
+      Schema expectSchema,
+      Map<String, String> expectProperties,
+      String tableComment) {
+    spark().conf().set(SparkSQLProperties.USE_TIMESTAMP_WITHOUT_TIME_ZONE_IN_NEW_TABLES, false);
+    String sqlText =
+        "CREATE TABLE "
+            + target()
+            + "("
+            + structDDL
+            + ") using  "
+            + provider(format)
+            + " "
+            + propertiesDDL
+            + " comment '"
+            + tableComment
+            + "'";
+    sql(sqlText);
+
+    MixedTable tbl = loadTable();
+
+    Asserts.assertType(expectSchema.asStruct(), tbl.schema().asStruct());
+    Asserts.assertHashMapContainExpect(expectProperties, tbl.properties());
+    Assert.assertEquals(tableComment, tbl.properties().get("comment"));
     if (TableFormat.MIXED_HIVE.equals(format)) {
       Table hiveTable = loadHiveTable();
       Asserts.assertHiveColumns(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3682 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Ignore primary key spec nullable

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
