### PR TITLE
[AMORO-2519] Improve the display of Duration in the page of Optimizing>Tables to make it more user-friendly

### DIFF
--- a/amoro-web/src/views/optimize/components/List.vue
+++ b/amoro-web/src/views/optimize/components/List.vue
@@ -105,7 +105,7 @@ async function getTableList() {
       return {
         ...p,
         quotaOccupationDesc: p.quotaOccupation - 0.0005 > 0 ? `${(p.quotaOccupation * 100).toFixed(1)}%` : '0',
-        durationDesc: p.duration ? formatMS2Time(p.duration) : '-',
+        durationDesc: p.duration ? formatMS2DisplayTime(p.duration) : '-',
         fileSizeDesc: bytesToSize(p.fileSize),
       }
     })
@@ -229,7 +229,7 @@ onMounted(async () => {
         </template>
         <template v-if="column.dataIndex === 'duration'">
           <span :title="record.durationDesc">
-            {{ formatMS2DisplayTime(record.duration || 0) }}
+            {{ formatMS2Time(record.duration || 0) }}
           </span>
         </template>
         <template v-if="column.dataIndex === 'quotaOccupation'">


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
Currently, the display of Duration in the page of Optimizing>Tables is different from that on Optimizing process detail page. Also the display format is not as readable and friendly as the results displayed in the hover box.

Close #2519.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Swap what is displayed in the table and the hover box

Before:
<img width="2286" height="669" alt="Image" src="https://github.com/user-attachments/assets/27b13106-f647-48ad-ab53-0f212aaed336" />

After:
<img width="2320" height="585" alt="Image" src="https://github.com/user-attachments/assets/ff3fea0b-0e27-40a0-83b3-6a74be434e14" />

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
