### PR TITLE
[AMORO-3470][Feature]:Support catalog-level default properties storing into underlying tables within a unified catalog

### DIFF
--- a/amoro-common/src/main/java/org/apache/amoro/properties/CatalogMetaProperties.java
+++ b/amoro-common/src/main/java/org/apache/amoro/properties/CatalogMetaProperties.java
@@ -84,9 +84,27 @@ public class CatalogMetaProperties {
   public static final String TABLE_PROPERTIES_PREFIX = "table.";
   public static final String LOG_STORE_PROPERTIES_PREFIX = "log-store.";
   public static final String OPTIMIZE_PROPERTIES_PREFIX = "self-optimizing.";
+  public static final String DEPRECATED_OPTIMIZE_PROPERTIES_PREFIX = "optimize.";
+  public static final String TABLE_EXPIRE_PREFIX = "table-expire.";
+  public static final String ORPHAN_CLEAN_PREFIX = "clean-orphan-file.";
+  public static final String DANGLING_DELETE_FILES_CLEAN_PREFIX = "clean-dangling-delete-files.";
+  public static final String DATA_EXPIRATION_PREFIX = "data-expire.";
+  public static final String TABLE_TRASH_PREFIX = "table-trash.";
+  public static final String AUTO_CREATE_TAG_PREFIX = "tag.auto-create.";
 
   // mixed-format properties
   public static final String MIXED_FORMAT_TABLE_STORE_SEPARATOR =
       "mixed-format.table-store.separator";
   public static final String MIXED_FORMAT_TABLE_STORE_SEPARATOR_DEFAULT = "_";
+
+  // a (semicolon-separated) list of property names(or prefix) that would not write into underlying
+  // tables in addition
+  // to default names(or prefix)
+  public static final String TABLE_NON_PERSISTED_PROPERTIES_ADDITIONAL =
+      "table-properties.non-persisted.additional";
+
+  //  a (semicolon-separated) list of property names(or prefix) excluded from
+  //  default 'merge on loading' properties
+  public static final String TABLE_NON_PERSISTED_PROPERTIES_EXCLUDED =
+      "table-properties.non-persisted.excluded";
 }

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
@@ -21,6 +21,10 @@ package org.apache.amoro.table;
 import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
+import org.apache.amoro.properties.CatalogMetaProperties;
+import org.apache.amoro.properties.HiveTableProperties;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Sets;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -335,4 +339,25 @@ public class TableProperties {
     WRITE_PROTECTED_PROPERTIES.add(WATERMARK_BASE_STORE);
     WRITE_PROTECTED_PROPERTIES.add("flink.max-continuous-empty-commits");
   }
+
+  public static final HashSet<String> DEFAULT_NON_PERSISTED_TABLE_PROPERTIES =
+      Sets.newHashSet(
+          CatalogMetaProperties.OPTIMIZE_PROPERTIES_PREFIX,
+          CatalogMetaProperties.DEPRECATED_OPTIMIZE_PROPERTIES_PREFIX,
+          CatalogMetaProperties.TABLE_EXPIRE_PREFIX,
+          CatalogMetaProperties.ORPHAN_CLEAN_PREFIX,
+          CatalogMetaProperties.DANGLING_DELETE_FILES_CLEAN_PREFIX,
+          CatalogMetaProperties.DATA_EXPIRATION_PREFIX,
+          CatalogMetaProperties.TABLE_TRASH_PREFIX,
+          CatalogMetaProperties.AUTO_CREATE_TAG_PREFIX,
+          // mixed format reading config keys
+          TableProperties.SPLIT_OPEN_FILE_COST,
+          TableProperties.SPLIT_LOOKBACK,
+          TableProperties.SPLIT_SIZE,
+          // mixed format writing config keys
+          TableProperties.UPSERT_ENABLED,
+          // mixed-hive config keys
+          HiveTableProperties.AUTO_SYNC_HIVE_SCHEMA_CHANGE,
+          HiveTableProperties.AUTO_SYNC_HIVE_DATA_WRITE,
+          HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED);
 }

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/MixedFormatCatalogUtil.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/MixedFormatCatalogUtil.java
@@ -23,8 +23,12 @@ import org.apache.amoro.io.AuthenticatedFileIO;
 import org.apache.amoro.op.MixedHadoopTableOperations;
 import org.apache.amoro.op.MixedTableOperations;
 import org.apache.amoro.properties.CatalogMetaProperties;
+import org.apache.amoro.properties.HiveTableProperties;
+import org.apache.amoro.shade.guava32.com.google.common.annotations.VisibleForTesting;
 import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
+import org.apache.amoro.shade.guava32.com.google.common.base.Splitter;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Sets;
 import org.apache.amoro.table.TableProperties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -40,7 +44,14 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class MixedFormatCatalogUtil {
@@ -167,6 +178,122 @@ public class MixedFormatCatalogUtil {
     mergedProperties.putAll(tableProperties);
 
     return mergedProperties;
+  }
+
+  /**
+   * merge catalog default writable(write into underlying table) properties to table properties
+   *
+   * @param tableProperties properties in table
+   * @param catalogProperties properties in catalog
+   * @return merged table properties
+   */
+  public static Map<String, String> mergePersistedCatalogPropertiesToTable(
+      Map<String, String> tableProperties, Map<String, String> catalogProperties) {
+    Splitter splitter = Splitter.on(';').omitEmptyStrings();
+    Set<String> append =
+        splitter
+            .splitToStream(
+                catalogProperties.getOrDefault(
+                    CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_ADDITIONAL, ""))
+            .collect(Collectors.toSet());
+    Set<String> excluded =
+        splitter
+            .splitToStream(
+                catalogProperties.getOrDefault(
+                    CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_EXCLUDED, ""))
+            .collect(Collectors.toSet());
+    HashSet<String> notWritableRules =
+        new HashSet<>(TableProperties.DEFAULT_NON_PERSISTED_TABLE_PROPERTIES);
+    HashSet<String> intersection = new HashSet(append);
+    intersection.retainAll(excluded);
+    if (intersection.size() > 0) {
+      append.removeAll(intersection);
+      excluded.removeAll(intersection);
+    }
+    // According to excluded/additional rules, edit notWritableRules
+    notWritableRules.removeAll(excluded);
+    notWritableRules.addAll(append);
+
+    Set<String> excludedKeys =
+        excluded.stream().filter(e -> !e.endsWith(".")).collect(Collectors.toSet());
+    Set<String> defaultNotWritable = getMergeOnLoadProperties(notWritableRules, excludedKeys);
+
+    // remove `table.` prefix
+    Map<String, String> defaultCatalogProperties =
+        catalogProperties.entrySet().stream()
+            .filter(e -> e.getKey().startsWith(CatalogMetaProperties.TABLE_PROPERTIES_PREFIX))
+            .collect(
+                Collectors.toMap(
+                    e ->
+                        e.getKey()
+                            .substring(CatalogMetaProperties.TABLE_PROPERTIES_PREFIX.length()),
+                    Map.Entry::getValue));
+
+    // eliminate catalog-level default not writable(merge on load) properties
+    Map<String, String> defaultCatalogWritable =
+        defaultCatalogProperties.entrySet().stream()
+            .filter(
+                e ->
+                    defaultNotWritable.stream()
+                        // find table properties with prefix or exact match in blacklist
+                        .noneMatch(
+                            nw ->
+                                nw.endsWith(".")
+                                    ? e.getKey().startsWith(nw)
+                                    : e.getKey().equals(nw)))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    // handle log-store properties exclusively
+    if (!PropertyUtil.propertyAsBoolean(
+        tableProperties,
+        TableProperties.ENABLE_LOG_STORE,
+        TableProperties.ENABLE_LOG_STORE_DEFAULT)) {
+      defaultCatalogWritable =
+          defaultCatalogWritable.entrySet().stream()
+              .filter(
+                  e -> !e.getKey().startsWith(CatalogMetaProperties.LOG_STORE_PROPERTIES_PREFIX))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    // merge into table properties
+    defaultCatalogWritable.putAll(tableProperties);
+    return defaultCatalogWritable;
+  }
+
+  @VisibleForTesting
+  public static Set<String> getMergeOnLoadProperties(
+      Set<String> notWritableRules, Set<String> excludedKeys) {
+    HashSet<String> notWritables = Sets.newHashSet();
+    try {
+      List<String> classes =
+          Arrays.asList(TableProperties.class.getName(), HiveTableProperties.class.getName());
+      for (int i = 0; i < classes.size(); i++) {
+        Class<?> clazz = Class.forName(classes.get(i));
+        for (Field field : clazz.getFields()) {
+          int modifiers = field.getModifiers();
+          if (Modifier.isStatic(modifiers)
+              && Modifier.isFinal(modifiers)
+              && Modifier.isPublic(modifiers)
+              && field.getType() == String.class) {
+            String propKey =
+                Optional.ofNullable(field.get(null)).orElseGet(() -> "null").toString();
+            if (notWritableRules.stream()
+                .anyMatch(r -> r.endsWith(".") ? propKey.startsWith(r) : propKey.equals(r))) {
+              notWritables.add(propKey);
+            }
+          }
+        }
+        // A special case:
+        // A specific excluded key may have conflicts with its prefix key which is within rule,
+        // i.e 'self-optimizing.enabled' is in the excluded list and 'self-optimizing.' in
+        // not-writable list.
+        // so we need to remove it from defaultNotWritable
+        notWritables.removeAll(excludedKeys);
+      }
+    } catch (ClassNotFoundException | IllegalAccessException e) {
+      LOG.error("parse table properties keys failed", e);
+    }
+    return notWritables;
   }
 
   /**

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestMixedFormatCatalogUtil.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/utils/TestMixedFormatCatalogUtil.java
@@ -20,6 +20,7 @@ package org.apache.amoro.utils;
 
 import org.apache.amoro.properties.CatalogMetaProperties;
 import org.apache.amoro.shade.guava32.com.google.common.collect.ImmutableMap;
+import org.apache.amoro.table.TableProperties;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.junit.Assert;
@@ -310,5 +311,274 @@ public class TestMixedFormatCatalogUtil {
     Assert.assertEquals(name, props.get(keyWarehouse));
     Assert.assertFalse(props.containsKey(type));
     Assert.assertEquals(restImpl, props.get(CatalogProperties.CATALOG_IMPL));
+  }
+
+  /** test merge writable properties basic case */
+  @Test
+  public void testMergeDefaultWritableProperties1() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("log-store.enabled", "true");
+    expected.put("log-store.topic", "topic1");
+    expected.put("log-store.address", "168.0.0.1:9092");
+    expected.put("log-store.type", "kafka");
+    expected.put("log-store.consistency.guarantee.enable", "true");
+    expected.put("write.upsert.enable", "true");
+    expected.put("write.parquet.compression-codec", "true");
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("log-store.enabled", "true");
+    tableProperties.put("log-store.topic", "topic1");
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.log-store.enabled", "false");
+    catalogProperties.put("table.log-store.address", "168.0.0.1:9092");
+    catalogProperties.put("table.log-store.type", "kafka");
+    catalogProperties.put("table.log-store.consistency.guarantee.enable", "true");
+    catalogProperties.put("table.self-optimizing.enabled", "false");
+    catalogProperties.put("table.write.upsert.enable", "true");
+    catalogProperties.put("table.write.parquet.compression-codec", "true");
+
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test handling log-store related properties */
+  @Test
+  public void testMergeDefaultWritableProperties2() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("log-store.enabled", "false");
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("log-store.enabled", "false");
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.log-store.enabled", "false");
+    catalogProperties.put("table.log-store.address", "168.0.0.1:9092");
+    catalogProperties.put("table.log-store.type", "kafka");
+    catalogProperties.put("table.self-optimizing.enabled", "false");
+
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test merge additional properties */
+  @Test
+  public void testMergeDefaultWritableProperties3() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("log-store.enabled", "true");
+    expected.put("log-store.topic", "topic1");
+    expected.put("log-store.type", "kafka");
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("log-store.enabled", "true");
+    tableProperties.put("log-store.topic", "topic1");
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.log-store.enabled", "false");
+    catalogProperties.put("table.log-store.address", "168.0.0.1:9092"); // would not merge
+    catalogProperties.put("table.log-store.type", "kafka");
+    catalogProperties.put("table.self-optimizing.enabled", "false");
+
+    // add additional props
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_ADDITIONAL,
+        TableProperties.LOG_STORE_ADDRESS);
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test merge additional props */
+  @Test
+  public void testMergeDefaultWritableProperties4() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("log-store.enabled", "true");
+    expected.put("log-store.name", "cluster1");
+    expected.put("log-store.topic", "topic1");
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("log-store.enabled", "true");
+    tableProperties.put("log-store.topic", "topic1");
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.log-store.enabled", "false");
+    catalogProperties.put("table.log-store.name", "cluster1");
+    catalogProperties.put("table.log-store.address", "168.0.0.1:9092"); // would not merge
+    catalogProperties.put("table.log-store.type", "kafka"); // would not merge
+
+    // add additional prefix
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_ADDITIONAL,
+        "log-store.address;log-store.type");
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test merge additional prefix */
+  @Test
+  public void testMergeDefaultWritableProperties5() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("log-store.enabled", "true");
+    expected.put("log-store.topic", "topic1");
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("log-store.enabled", "true");
+    tableProperties.put("log-store.topic", "topic1");
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.log-store.enabled", "false");
+    catalogProperties.put("table.log-store.address", "168.0.0.1:9092"); // would not merge
+    catalogProperties.put("table.log-store.type", "kafka");
+    catalogProperties.put("table.change.data.ttl.minutes", "10080");
+
+    // add additional prefix
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_ADDITIONAL, "log-store.;change.data.");
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test merge excluded props */
+  @Test
+  public void testMergeDefaultWritableProperties6() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("self-optimizing.enabled", "false");
+    expected.put("self-optimizing.quota", "0.1");
+
+    Map<String, String> tableProperties = new HashMap<>();
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.self-optimizing.enabled", "false");
+    catalogProperties.put("table.self-optimizing.quota", "0.1");
+    catalogProperties.put("table.clean-orphan-file.min-existing-time-minutes", "0.1");
+
+    // add excluded props
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_EXCLUDED,
+        "self-optimizing.enabled;self-optimizing.quota");
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test merge excluded prefix */
+  @Test
+  public void testMergeDefaultWritableProperties7() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("self-optimizing.enabled", "false");
+    expected.put("self-optimizing.execute.num-retries", "3");
+    expected.put("data-expire.enabled", "true");
+
+    Map<String, String> tableProperties = new HashMap<>();
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.self-optimizing.enabled", "false");
+    catalogProperties.put("table.self-optimizing.execute.num-retries", "3");
+    catalogProperties.put("table.data-expire.enabled", "true");
+    catalogProperties.put("table.clean-orphan-file.min-existing-time-minutes", "0.1");
+
+    // add excluded prefix
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_EXCLUDED,
+        "self-optimizing.;data-expire.");
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test merge excluded prefix */
+  @Test
+  public void testMergeDefaultWritableProperties8() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("snapshot.base.keep.minutes", "720");
+
+    Map<String, String> tableProperties = new HashMap<>();
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.snapshot.base.keep.minutes", "720");
+    catalogProperties.put("table.self-optimizing.execute.num-retries", "3");
+    catalogProperties.put("table.data-expire.enabled", "true");
+    catalogProperties.put("table.clean-orphan-file.min-existing-time-minutes", "0.1");
+
+    // add excluded key
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_EXCLUDED,
+        "snapshot.base.keep.minutes");
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test conflicts between excluded and additional config prop which is a default not-writable */
+  @Test
+  public void testMergeDefaultWritableProperties9() {
+    Map<String, String> expected = new HashMap<>();
+
+    Map<String, String> tableProperties = new HashMap<>();
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.write.upsert.enabled", "false");
+
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_EXCLUDED, "write.upsert.enabled");
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_ADDITIONAL, "write.upsert.enabled");
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test conflicts between excluded and additional config prop which is a default not-writable */
+  @Test
+  public void testMergeDefaultWritableProperties10() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("tag.auto-create.trigger.max-delay.minutes", "60");
+
+    Map<String, String> tableProperties = new HashMap<>();
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.tag.auto-create.trigger.max-delay.minutes", "60");
+    catalogProperties.put("table.tag.auto-create.trigger.offset.minutes", "1");
+
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_EXCLUDED,
+        "tag.auto-create.trigger.max-delay.minutes");
+    catalogProperties.put(
+        CatalogMetaProperties.TABLE_NON_PERSISTED_PROPERTIES_ADDITIONAL, "tag.auto-create.");
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
+  }
+
+  /** test default non-persisted mixed-hive properties */
+  @Test
+  public void testMergeDefaultWritableProperties11() {
+    Map<String, String> expected = new HashMap<>();
+
+    Map<String, String> tableProperties = new HashMap<>();
+
+    Map<String, String> catalogProperties = new HashMap<>();
+    catalogProperties.put("table.base.hive.auto-sync-data-write", "false");
+
+    Map<String, String> result =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            tableProperties, catalogProperties);
+    Assert.assertEquals(expected, result);
   }
 }

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/main/java/org/apache/amoro/flink/catalog/FlinkUnifiedCatalog.java
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/main/java/org/apache/amoro/flink/catalog/FlinkUnifiedCatalog.java
@@ -39,6 +39,7 @@ import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
 import org.apache.amoro.table.TableIdentifier;
 import org.apache.amoro.table.TableMetaStore;
 import org.apache.amoro.utils.CatalogUtil;
+import org.apache.amoro.utils.MixedFormatCatalogUtil;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -245,6 +246,12 @@ public class FlinkUnifiedCatalog extends AbstractCatalog {
       throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
     Configuration configuration = new Configuration();
     table.getOptions().forEach(configuration::setString);
+    unifiedCatalog.refresh();
+    table
+        .getOptions()
+        .putAll(
+            MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+                table.getOptions(), unifiedCatalog.properties()));
     TableFormat format = TableFormat.valueOf(configuration.get(TABLE_FORMAT));
     TableIdentifier tableIdentifier =
         TableIdentifier.of(

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/java/org/apache/amoro/flink/catalog/FlinkCatalogContext.java
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/java/org/apache/amoro/flink/catalog/FlinkCatalogContext.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -85,7 +85,11 @@ public class FlinkCatalogContext {
             schema,
             "Flink managed table",
             new ArrayList<>(),
-            Collections.singletonMap(TABLE_FORMAT.key(), tableFormat)),
+            new HashMap<String, String>() {
+              {
+                put(TABLE_FORMAT.key(), tableFormat);
+              }
+            }),
         resolvedSchema);
   }
 

--- a/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/src/main/java/org/apache/amoro/spark/SparkUnifiedCatalogBase.java
+++ b/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/src/main/java/org/apache/amoro/spark/SparkUnifiedCatalogBase.java
@@ -33,6 +33,7 @@ import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
 import org.apache.amoro.shade.guava32.com.google.common.collect.ImmutableMap;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
 import org.apache.amoro.table.TableMetaStore;
+import org.apache.amoro.utils.MixedFormatCatalogUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.spark.SparkUtil;
@@ -256,6 +257,10 @@ public class SparkUnifiedCatalogBase implements TableCatalog, SupportsNamespaces
     }
     TableFormat format = TableFormat.valueOf(provider.toUpperCase());
     TableCatalog catalog = tableCatalog(format);
+    unifiedCatalog.refresh();
+    properties =
+        MixedFormatCatalogUtil.mergePersistedCatalogPropertiesToTable(
+            properties, unifiedCatalog.properties());
     return catalog.createTable(ident, schema, partitions, properties);
   }
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3470.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- 

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (not applicable)
