### PR TITLE
[hotfix] Fix doc error in displaying "Using Customized Encryption Method for Configurations" on admin guidance page

### DIFF
--- a/docs/admin-guides/using-customized-encryption-method-for-configurations.md
+++ b/docs/admin-guides/using-customized-encryption-method-for-configurations.md
@@ -2,11 +2,11 @@
 title: "Using Customized Encryption Method for Configurations"
 url: using-customized-encryption-method
 aliases:
-- "admin-guides/using-customized-encryption-method"
+    - "admin-guides/using-customized-encryption-method"
 menu:
-main:
-parent: Admin Guides
-weight: 400
+    main:
+        parent: Admin Guides
+        weight: 400
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
## Why are the changes needed?
We've added the page "Using Customized Encryption Method for Configurations" in #3417. However, the page is not displayed in the Admin Guides tree view as expected because of incorrect indentation.

<img width="1564" height="1202" alt="image" src="https://github.com/user-attachments/assets/60d2a0fa-444a-480b-9dcf-da071d6c74f4" />




## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- fix the indenting issue in the markdown file. 

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
