### PR TITLE
[AMORO-3772] Fix AuthenticatedHiveClientPool init fail and MixedTables#createChangeStore log printing error

### DIFF
--- a/amoro-common/src/main/java/org/apache/amoro/hive/AuthenticatedHiveClientPool.java
+++ b/amoro-common/src/main/java/org/apache/amoro/hive/AuthenticatedHiveClientPool.java
@@ -83,7 +83,9 @@ public class AuthenticatedHiveClientPool extends ClientPoolImpl<HMSClient, TExce
     this.hiveConf =
         new HiveConf(tableMetaStore.getConfiguration(), AuthenticatedHiveClientPool.class);
     this.hiveConf.addResource(tableMetaStore.getConfiguration());
-    this.hiveConf.addResource(tableMetaStore.getHiveSiteLocation().orElse(null));
+    if (tableMetaStore.getHiveSiteLocation().isPresent()) {
+      this.hiveConf.addResource(tableMetaStore.getHiveSiteLocation().get());
+    }
     this.metaStore = tableMetaStore;
   }
 

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/mixed/MixedTables.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/mixed/MixedTables.java
@@ -225,7 +225,7 @@ public class MixedTables {
       change = tableMetaStore.doAs(changeBuilder::create);
       return change;
     } catch (RuntimeException e) {
-      LOG.warn("Create base store failed for reason: {}", e.getMessage());
+      LOG.warn("Create change store failed for reason: {}", e.getMessage());
       tableMetaStore.doAs(() -> icebergCatalog.dropTable(baseIdentifier, true));
       throw e;
     }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3772.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-[amoro-common] Fix AuthenticatedHiveClientPool init
-[amoro-format-iceberg] Fix MixedTables#createChangeStore log printing error

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
