### PR TITLE
[AMORO-3786] Add missing logic to count failed optimizing processes

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
@@ -402,6 +402,7 @@ public class TableOptimizingMetrics extends AbstractTableMetrics {
       totalCounter.inc();
     }
     if (!success && failedCounter != null) {
+      processFailedCount.inc();
       failedCounter.inc();
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3786 

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Add the missing counter increment for the `table_optimizing_process_failed_count` metric.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
