### PR TITLE
[AMORO-3752] Resolve data inconsistency issue during HA failover

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmoroServiceContainer.java
@@ -136,7 +136,14 @@ public class AmoroServiceContainer {
         } catch (Exception e) {
           LOG.error("AMS start error", e);
         } finally {
-          service.disposeOptimizingService();
+          try {
+            service.disposeOptimizingService();
+          } catch (Exception e) {
+            LOG.warn("AMS dispose error", e);
+          } finally {
+            // if HA enabled, make sure the dispose complete signal is sent to ZK
+            service.signalDisposeComplete();
+          }
         }
       }
     } catch (Throwable t) {
@@ -151,6 +158,10 @@ public class AmoroServiceContainer {
 
   public void waitFollowerShip() throws Exception {
     haContainer.waitFollowerShip();
+  }
+
+  public void signalDisposeComplete() {
+    haContainer.signalDisposeComplete();
   }
 
   public void startRestServices() throws Exception {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestHighAvailabilityContainer.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestHighAvailabilityContainer.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server;
+
+import static org.apache.amoro.server.AmoroManagementConf.HA_CLUSTER_NAME;
+import static org.apache.amoro.server.AmoroManagementConf.HA_ENABLE;
+import static org.apache.amoro.server.AmoroManagementConf.HA_ZOOKEEPER_ADDRESS;
+import static org.apache.amoro.server.AmoroManagementConf.SERVER_EXPOSE_HOST;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.amoro.client.AmsServerInfo;
+import org.apache.amoro.config.Configurations;
+import org.apache.amoro.properties.AmsHAProperties;
+import org.apache.amoro.shade.zookeeper3.org.apache.curator.framework.CuratorFramework;
+import org.apache.amoro.shade.zookeeper3.org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.amoro.shade.zookeeper3.org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.amoro.shade.zookeeper3.org.apache.zookeeper.CreateMode;
+import org.apache.amoro.utils.JacksonUtil;
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TestHighAvailabilityContainer {
+
+  private TestingServer zkTestServer;
+  private CuratorFramework zkClient;
+  private String clusterName;
+  private String zkConnectionString;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    // Start embedded ZooKeeper test server
+    int port = (int) (Math.random() * 4000) + 14000;
+    zkTestServer = new TestingServer(port, true);
+    zkTestServer.start();
+    // Wait for server to start
+    zkTestServer.restart();
+    zkConnectionString = "127.0.0.1:" + port;
+    clusterName = "test-cluster";
+
+    // Create ZooKeeper client
+    ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(1000, 3);
+    zkClient = CuratorFrameworkFactory.newClient(zkConnectionString, retryPolicy);
+    zkClient.start();
+    // Wait for connection
+    if (!zkClient.blockUntilConnected(30, TimeUnit.SECONDS)) {
+      throw new RuntimeException("Failed to connect to ZooKeeper server");
+    }
+
+    // Clean up existing nodes
+    String basePath = "/" + clusterName + "/arctic/ams";
+    try {
+      if (zkClient.checkExists().forPath(basePath) != null) {
+        zkClient.delete().deletingChildrenIfNeeded().forPath(basePath);
+      }
+    } catch (Exception e) {
+      // Ignore deletion exceptions
+    }
+  }
+
+  @AfterEach
+  public void teardown() {
+    if (zkClient != null) {
+      try {
+        zkClient.close();
+      } catch (Exception e) {
+        // Ignore close exceptions
+      }
+    }
+    if (zkTestServer != null) {
+      try {
+        zkTestServer.stop();
+      } catch (Exception e) {
+        // Ignore close exceptions
+      }
+    }
+  }
+
+  private Configurations createHAConfig() {
+    Configurations config = new Configurations();
+    config.set(HA_ENABLE, true);
+    config.set(HA_ZOOKEEPER_ADDRESS, zkConnectionString);
+    config.set(HA_CLUSTER_NAME, clusterName);
+    config.set(SERVER_EXPOSE_HOST, "localhost");
+    // Use existing configuration items
+    config.set(AmoroManagementConf.TABLE_SERVICE_THRIFT_BIND_PORT, 12345);
+    config.set(AmoroManagementConf.HTTP_SERVER_PORT, 19090);
+    config.set(AmoroManagementConf.OPTIMIZING_SERVICE_THRIFT_BIND_PORT, 12346);
+    return config;
+  }
+
+  private void cleanupPath(String path) {
+    try {
+      if (zkClient.checkExists().forPath(path) != null) {
+        // If path exists, clear its data
+        zkClient.setData().forPath(path, new byte[0]);
+      }
+    } catch (Exception e) {
+      // Ignore deletion exceptions
+    }
+  }
+
+  /**
+   * create previous leader info in ZooKeeper
+   *
+   * @param host
+   * @param thriftPort
+   * @param restPort
+   * @throws Exception
+   */
+  private void setupPreviousLeaderInfo(String host, int thriftPort, int restPort) throws Exception {
+    // Set up "previous leader" information that differs from current node
+    String tableServiceMasterPath = AmsHAProperties.getTableServiceMasterPath(clusterName);
+    String optimizingServiceMasterPath =
+        AmsHAProperties.getOptimizingServiceMasterPath(clusterName);
+
+    AmsServerInfo serverInfo = new AmsServerInfo();
+    serverInfo.setHost(host);
+    serverInfo.setThriftBindPort(thriftPort);
+    serverInfo.setRestBindPort(restPort);
+    String serverInfoJson = JacksonUtil.toJSONString(serverInfo);
+
+    try {
+      zkClient
+          .create()
+          .creatingParentsIfNeeded()
+          .withMode(CreateMode.PERSISTENT)
+          .forPath(tableServiceMasterPath, serverInfoJson.getBytes(StandardCharsets.UTF_8));
+      zkClient
+          .create()
+          .creatingParentsIfNeeded()
+          .withMode(CreateMode.PERSISTENT)
+          .forPath(optimizingServiceMasterPath, serverInfoJson.getBytes(StandardCharsets.UTF_8));
+    } catch (
+        org.apache.amoro.shade.zookeeper3.org.apache.zookeeper.KeeperException.NodeExistsException
+            e) {
+      zkClient
+          .setData()
+          .forPath(tableServiceMasterPath, serverInfoJson.getBytes(StandardCharsets.UTF_8));
+      zkClient
+          .setData()
+          .forPath(optimizingServiceMasterPath, serverInfoJson.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  private void executeAndWaitForLeadership(
+      HighAvailabilityContainer haContainer,
+      AtomicBoolean hasLeadership,
+      AtomicReference<Exception> exceptionRef)
+      throws InterruptedException {
+    // Execute waitLeaderShip in another thread and wait for result
+    CountDownLatch leadershipLatch = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.submit(
+        () -> {
+          try {
+            haContainer.waitLeaderShip();
+            hasLeadership.set(true);
+            leadershipLatch.countDown();
+          } catch (Exception e) {
+            exceptionRef.set(e);
+          }
+        });
+
+    boolean success = leadershipLatch.await(30, TimeUnit.SECONDS);
+    // Check for exceptions
+    Exception thrownException = exceptionRef.get();
+    if (thrownException != null) {
+      throw new AssertionError(
+          "Exception occurred during waitLeaderShip: " + thrownException.getMessage(),
+          thrownException);
+    }
+
+    assertTrue(success, "Should acquire leadership within timeout");
+    assertTrue(hasLeadership.get(), "Should have acquired leadership");
+    executor.shutdown();
+  }
+
+  @Test
+  public void testWaitLeadershipWithNoPreviousLeader() throws Exception {
+    Configurations config = createHAConfig();
+
+    // Ensure nodes are cleaned before test starts to avoid using previous test data
+    String tableServiceMasterPath = AmsHAProperties.getTableServiceMasterPath(clusterName);
+    cleanupPath(tableServiceMasterPath);
+
+    HighAvailabilityContainer haContainer = new HighAvailabilityContainer(config);
+
+    // Simulate waiting for leadership in another thread
+    AtomicBoolean hasLeadership = new AtomicBoolean(false);
+    AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+    executeAndWaitForLeadership(haContainer, hasLeadership, exceptionRef);
+
+    haContainer.close();
+  }
+
+  @Test
+  public void testWaitLeadershipWithSamePreviousLeaderInfo() throws Exception {
+    Configurations config = createHAConfig();
+    HighAvailabilityContainer haContainer = new HighAvailabilityContainer(config);
+
+    // Set up "previous leader" info that matches current node (simulate restart scenario)
+    setupPreviousLeaderInfo("localhost", 12345, 19090);
+
+    // Simulate waiting for leadership in another thread
+    AtomicBoolean hasLeadership = new AtomicBoolean(false);
+    AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+    executeAndWaitForLeadership(haContainer, hasLeadership, exceptionRef);
+
+    haContainer.close();
+  }
+
+  @Test
+  public void testWaitLeadershipTimeoutWaitingForPreviousLeader() throws Exception {
+    Configurations config = createHAConfig();
+    HighAvailabilityContainer haContainer = new HighAvailabilityContainer(config);
+
+    // Set up different "previous leader" info without creating disposeCompletePath (simulate
+    // unresponsive previous leader)
+    setupPreviousLeaderInfo("other-host", 12345, 19090);
+
+    // Simulate waiting for leadership in another thread
+    CountDownLatch leadershipLatch = new CountDownLatch(1);
+    AtomicBoolean hasLeadership = new AtomicBoolean(false);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    executor.submit(
+        () -> {
+          try {
+            haContainer.waitLeaderShip();
+            hasLeadership.set(true);
+            leadershipLatch.countDown();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    // Wait for leadership (should take over after timeout)
+    boolean success =
+        leadershipLatch.await(40, TimeUnit.SECONDS); // Wait beyond default 30s timeout
+    assertTrue(
+        success,
+        "Should acquire leadership after timeout even if previous leader does not respond");
+    assertTrue(hasLeadership.get(), "Should have acquired leadership");
+
+    haContainer.close();
+    executor.shutdown();
+  }
+
+  @Test
+  public void testSignalDisposeComplete() throws Exception {
+    Configurations config = createHAConfig();
+    HighAvailabilityContainer haContainer = new HighAvailabilityContainer(config);
+
+    String disposeCompletePath = AmsHAProperties.getMasterReleaseConfirmPath(clusterName);
+
+    // Create node
+    try {
+      zkClient
+          .create()
+          .creatingParentsIfNeeded()
+          .withMode(CreateMode.PERSISTENT)
+          .forPath(disposeCompletePath);
+    } catch (
+        org.apache.amoro.shade.zookeeper3.org.apache.zookeeper.KeeperException.NodeExistsException
+            e) {
+      // Ignore if node already exists
+    }
+
+    // Ensure node exists
+    assertNotNull(zkClient.checkExists().forPath(disposeCompletePath));
+
+    // Call signal complete method
+    haContainer.signalDisposeComplete();
+
+    // Verify node has been deleted
+    assertNull(zkClient.checkExists().forPath(disposeCompletePath));
+
+    haContainer.close();
+  }
+
+  @Test
+  public void testSignalDisposeCompleteWithNoPath() throws Exception {
+    Configurations config = createHAConfig();
+    HighAvailabilityContainer haContainer = new HighAvailabilityContainer(config);
+
+    String disposeCompletePath = AmsHAProperties.getMasterReleaseConfirmPath(clusterName);
+
+    // Ensure node does not exist
+    assertNull(zkClient.checkExists().forPath(disposeCompletePath));
+
+    // Call signal complete method - should not throw exception
+    assertDoesNotThrow(() -> haContainer.signalDisposeComplete());
+
+    haContainer.close();
+  }
+}

--- a/amoro-common/src/main/java/org/apache/amoro/properties/AmsHAProperties.java
+++ b/amoro-common/src/main/java/org/apache/amoro/properties/AmsHAProperties.java
@@ -26,6 +26,7 @@ public class AmsHAProperties {
   private static final String TABLE_SERVICE_MASTER_PATH = "/master";
   private static final String OPTIMIZING_SERVICE_MASTER_PATH = "/optimizing-service-master";
   private static final String NAMESPACE_DEFAULT = "default";
+  private static final String MASTER_RELEASE_CONFIRM = "/master-release-confirm";
 
   private static String getBasePath(String namespace) {
     if (Strings.isNullOrEmpty(namespace)) {
@@ -40,6 +41,10 @@ public class AmsHAProperties {
 
   public static String getOptimizingServiceMasterPath(String namespace) {
     return getBasePath(namespace) + OPTIMIZING_SERVICE_MASTER_PATH;
+  }
+
+  public static String getMasterReleaseConfirmPath(String namespace) {
+    return getBasePath(namespace) + MASTER_RELEASE_CONFIRM;
   }
 
   public static String getLeaderPath(String namespace) {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3752.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->
When enables HA, the new primary node creates a ZooKeeper path named `disposeCompletePath`. During a primary-standby node switchover, the old primary node deletes this path after releasing the AMS service, thereby notifying the new primary node that it can start the AMS service.

1、Detect previous primary node information:

- Check the current primary node information stored in ZooKeeper

- Determine if it matches the current node information

- If it is the same node (e.g., during restart), no waiting is required

- If it is a different node, wait for the previous primary node to complete resource release

2、Wait for previous primary node release completion:

- Create a special ZooKeeper path `disposeCompletePath` for signal notification

- Wait up to 30 seconds until the previous primary node deletes this path

- If no signal is received after the timeout, proceed with master node operations (to prevent system blocking due to unresponsive previous nodes)

3、Send completion signal upon resource release:

- Within the `signalDisposeComplete()` method, the master node deletes the `disposeCompletePath` path upon shutdown

- This allows the new master node to detect that the previous master node has completed resource release

    Because it cannot effectively distinguish whether amoro is performing a primary-standby node switchover or a restart operation, the current PR has an unavoidable issue: 
     when HA is enabled, after the ams service restarts following a period of operation, the elected primary node (different from the one before the restart) will wait 30 seconds before starting the ams service.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
