### PR TITLE
[AMORO-3794] Wrap task operation with process lock

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/TaskRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/TaskRuntime.java
@@ -81,7 +81,7 @@ public class TaskRuntime<T extends StagedTaskDescriptor<?, ?, ?>> extends Stated
     return future;
   }
 
-  public void complete(OptimizerThread thread, OptimizingTaskResult result) {
+  void complete(OptimizerThread thread, OptimizingTaskResult result) {
     invokeConsistency(
         () -> {
           validThread(thread);
@@ -121,7 +121,7 @@ public class TaskRuntime<T extends StagedTaskDescriptor<?, ?, ?>> extends Stated
         });
   }
 
-  public void schedule(OptimizerThread thread) {
+  void schedule(OptimizerThread thread) {
     invokeConsistency(
         () -> {
           statusMachine.accept(Status.SCHEDULED);
@@ -132,7 +132,7 @@ public class TaskRuntime<T extends StagedTaskDescriptor<?, ?, ?>> extends Stated
         });
   }
 
-  public void ack(OptimizerThread thread) {
+  void ack(OptimizerThread thread) {
     invokeConsistency(
         () -> {
           validThread(thread);

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/utils/TestOptimizingUtil.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/utils/TestOptimizingUtil.java
@@ -98,7 +98,9 @@ public class TestOptimizingUtil extends AMSTableTestBase {
     Assert.assertEquals(
         1, queue.collectTasks(t -> t.getStatus() == TaskRuntime.Status.ACKED).size());
     Assert.assertNotNull(task);
-    queue.completeTask(optimizerThread, buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.SUCCESS, task.getStatus());
 
     List<TaskRuntime.TaskQuota> quotas = new ArrayList<>();

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/utils/TestOptimizingUtil.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/utils/TestOptimizingUtil.java
@@ -93,15 +93,12 @@ public class TestOptimizingUtil extends AMSTableTestBase {
     DefaultTableRuntime tableRuntime = initTableWithFiles();
     OptimizingQueue queue = buildOptimizingGroupService(tableRuntime);
     Assert.assertEquals(0, queue.collectTasks().size());
-    TaskRuntime task = queue.pollTask(MAX_POLLING_TIME);
-    task.schedule(optimizerThread);
-    task.ack(optimizerThread);
+    TaskRuntime<?> task = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
+    queue.ackTask(task.getTaskId(), optimizerThread);
     Assert.assertEquals(
         1, queue.collectTasks(t -> t.getStatus() == TaskRuntime.Status.ACKED).size());
     Assert.assertNotNull(task);
-    task.complete(
-        optimizerThread,
-        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(optimizerThread, buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.SUCCESS, task.getStatus());
 
     List<TaskRuntime.TaskQuota> quotas = new ArrayList<>();

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
@@ -191,7 +191,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     TaskRuntime<?> task2 = queue.pollTask(optimizerThread, MAX_POLLING_TIME, false);
     Assert.assertNull(task2);
 
-    queue.completeTask(optimizerThread, buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.SUCCESS, task.getStatus());
 
     TaskRuntime<?> retryTask = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
@@ -223,7 +225,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     TaskRuntime<?> task2 = queue.pollTask(optimizerThread, MAX_POLLING_TIME, true);
     Assert.assertNotNull(task2);
 
-    queue.completeTask(optimizerThread, buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.SUCCESS, task.getStatus());
     TaskRuntime<?> task4 = queue.pollTask(optimizerThread, MAX_POLLING_TIME, false);
     Assert.assertNull(task4);
@@ -250,7 +254,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
         1, queue.collectTasks(t -> t.getStatus() == TaskRuntime.Status.ACKED).size());
     Assert.assertNotNull(task);
     Assert.assertTrue(tableRuntime.getTableIdentifier().getId() == task.getTableId());
-    queue.completeTask(optimizerThread, buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.SUCCESS, task.getStatus());
     OptimizingProcess optimizingProcess = tableRuntime.getOptimizingProcess();
     Assert.assertEquals(ProcessStatus.RUNNING, optimizingProcess.getStatus());
@@ -295,7 +301,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
       TaskRuntime<?> retryTask = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
       Assert.assertEquals(retryTask.getTaskId(), task.getTaskId());
       queue.ackTask(task.getTaskId(), optimizerThread);
-      queue.completeTask(optimizerThread, buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
+      queue.completeTask(
+          optimizerThread,
+          buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
       Assert.assertEquals(TaskRuntime.Status.PLANNED, task.getStatus());
     }
 
@@ -303,7 +311,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     TaskRuntime<?> retryTask = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
     Assert.assertEquals(retryTask.getTaskId(), task.getTaskId());
     queue.ackTask(task.getTaskId(), optimizerThread);
-    queue.completeTask(optimizerThread, buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.FAILED, task.getStatus());
     queue.dispose();
   }
@@ -319,7 +329,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     Assert.assertEquals(
         1, queue.collectTasks(t -> t.getStatus() == TaskRuntime.Status.ACKED).size());
     Assert.assertNotNull(task);
-    queue.completeTask(optimizerThread, buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.SUCCESS, task.getStatus());
 
     // 7.commit
@@ -348,7 +360,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     Assert.assertEquals(
         1, queue.collectTasks(t -> t.getStatus() == TaskRuntime.Status.ACKED).size());
     Assert.assertNotNull(firstTask);
-    queue.completeTask(optimizerThread, buildOptimizingTaskResult(firstTask.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(firstTask.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.SUCCESS, firstTask.getStatus());
 
     queue.pollTask(optimizerThread, MAX_POLLING_TIME);
@@ -360,7 +374,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
       TaskRuntime<?> retryTask = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
       Assert.assertEquals(retryTask.getTaskId(), task.getTaskId());
       queue.ackTask(task.getTaskId(), optimizerThread);
-      queue.completeTask(optimizerThread, buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
+      queue.completeTask(
+          optimizerThread,
+          buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
       Assert.assertEquals(TaskRuntime.Status.PLANNED, task.getStatus());
     }
 
@@ -370,7 +386,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     queue.ackTask(retryTask.getTaskId(), optimizerThread);
 
     OptimizingProcess optimizingProcess = tableRuntime.getOptimizingProcess();
-    queue.completeTask(optimizerThread, buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskFailed(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(TaskRuntime.Status.FAILED, task.getStatus());
     optimizingProcess.commit();
     Assert.assertEquals(ProcessStatus.FAILED, optimizingProcess.getStatus());
@@ -449,7 +467,9 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     Assert.assertEquals(0, idleTablesGauge.getValue().longValue());
     Assert.assertEquals(0, committingTablesGauge.getValue().longValue());
 
-    queue.completeTask(optimizerThread, buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
     Assert.assertEquals(0, queueTasksGauge.getValue().longValue());
     Assert.assertEquals(0, executingTasksGauge.getValue().longValue());
     Assert.assertEquals(0, planingTablesGauge.getValue().longValue());


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

#3399 removed lock protection from [StatedPersistentBase.java](https://github.com/apache/amoro/commits/master/amoro-ams/src/main/java/org/apache/amoro/server/persistence/StatedPersistentBase.java) and lead to some unexpected issue like #3794.

This PR tried to wrap all operations on the `TaskRuntime` with the `TableOptimizingProcess` lock, which will resolve the conflict operation errors on `TaskRuntime`, besides preventing the deadlock issue like #2623.

Close #3794.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Wrap all task operations with the process lock

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
