### PR TITLE
[AMORO-3817] Don't close fileIO when cleaning orphan files

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/maintainer/IcebergTableMaintainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/maintainer/IcebergTableMaintainer.java
@@ -368,30 +368,28 @@ public class IcebergTableMaintainer implements TableMaintainer {
     String dataLocation = table.location() + File.separator + DATA_FOLDER_NAME;
     int expected = 0, deleted = 0;
 
-    try (AuthenticatedFileIO io = fileIO()) {
-      // listPrefix will not return the directory and the orphan file clean should clean the empty
-      // dir.
-      if (io.supportFileSystemOperations()) {
-        SupportsFileSystemOperations fio = io.asFileSystemIO();
-        Set<PathInfo> directories = new HashSet<>();
-        Set<String> filesToDelete =
-            deleteInvalidFilesInFs(fio, dataLocation, lastTime, exclude, directories);
-        expected = filesToDelete.size();
-        deleted = TableFileUtil.deleteFiles(io, filesToDelete);
-        /* delete empty directories */
-        deleteEmptyDirectories(fio, directories, lastTime, exclude);
-      } else if (io.supportPrefixOperations()) {
-        SupportsPrefixOperations pio = io.asPrefixFileIO();
-        Set<String> filesToDelete =
-            deleteInvalidFilesByPrefix(pio, dataLocation, lastTime, exclude);
-        expected = filesToDelete.size();
-        deleted = TableFileUtil.deleteFiles(io, filesToDelete);
-      } else {
-        LOG.warn(
-            String.format(
-                "Table %s doesn't support a fileIo with listDirectory or listPrefix, so skip clear files.",
-                table.name()));
-      }
+    AuthenticatedFileIO io = fileIO();
+    // listPrefix will not return the directory and the orphan file clean should clean the empty
+    // dir.
+    if (io.supportFileSystemOperations()) {
+      SupportsFileSystemOperations fio = io.asFileSystemIO();
+      Set<PathInfo> directories = new HashSet<>();
+      Set<String> filesToDelete =
+          deleteInvalidFilesInFs(fio, dataLocation, lastTime, exclude, directories);
+      expected = filesToDelete.size();
+      deleted = TableFileUtil.deleteFiles(io, filesToDelete);
+      /* delete empty directories */
+      deleteEmptyDirectories(fio, directories, lastTime, exclude);
+    } else if (io.supportPrefixOperations()) {
+      SupportsPrefixOperations pio = io.asPrefixFileIO();
+      Set<String> filesToDelete = deleteInvalidFilesByPrefix(pio, dataLocation, lastTime, exclude);
+      expected = filesToDelete.size();
+      deleted = TableFileUtil.deleteFiles(io, filesToDelete);
+    } else {
+      LOG.warn(
+          String.format(
+              "Table %s doesn't support a fileIo with listDirectory or listPrefix, so skip clear files.",
+              table.name()));
     }
 
     final int finalExpected = expected;
@@ -420,30 +418,29 @@ public class IcebergTableMaintainer implements TableMaintainer {
     String metadataLocation = table.location() + File.separator + METADATA_FOLDER_NAME;
     LOG.info("start orphan files clean in {}", metadataLocation);
 
-    try (AuthenticatedFileIO io = fileIO()) {
-      if (io.supportPrefixOperations()) {
-        SupportsPrefixOperations pio = io.asPrefixFileIO();
-        Set<String> filesToDelete =
-            deleteInvalidMetadataFile(
-                pio, metadataLocation, lastTime, validFiles, excludeFileNameRegex);
-        int deleted = TableFileUtil.deleteFiles(io, filesToDelete);
+    AuthenticatedFileIO io = fileIO();
+    if (io.supportPrefixOperations()) {
+      SupportsPrefixOperations pio = io.asPrefixFileIO();
+      Set<String> filesToDelete =
+          deleteInvalidMetadataFile(
+              pio, metadataLocation, lastTime, validFiles, excludeFileNameRegex);
+      int deleted = TableFileUtil.deleteFiles(io, filesToDelete);
 
-        runWithCondition(
-            !filesToDelete.isEmpty(),
-            () -> {
-              LOG.info(
-                  "Deleted {}/{} metadata files for table {}",
-                  deleted,
-                  filesToDelete.size(),
-                  table.name());
-              orphanFilesCleaningMetrics.completeOrphanMetadataFiles(filesToDelete.size(), deleted);
-            });
-      } else {
-        LOG.warn(
-            String.format(
-                "Table %s doesn't support a fileIo with listDirectory or listPrefix, so skip clear files.",
-                table.name()));
-      }
+      runWithCondition(
+          !filesToDelete.isEmpty(),
+          () -> {
+            LOG.info(
+                "Deleted {}/{} metadata files for table {}",
+                deleted,
+                filesToDelete.size(),
+                table.name());
+            orphanFilesCleaningMetrics.completeOrphanMetadataFiles(filesToDelete.size(), deleted);
+          });
+    } else {
+      LOG.warn(
+          String.format(
+              "Table %s doesn't support a fileIo with listDirectory or listPrefix, so skip clear files.",
+              table.name()));
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3817.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Avoid using the closed fileIO when cleaning orphan metadata files

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
