### PR TITLE
[Improvement]: The Spark optimizer uses the same name as Flink to facilitate problem location #3824

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
@@ -166,18 +166,21 @@ public class SparkOptimizerContainer extends AbstractOptimizerContainer {
                 OptimizerProperties.EXPORT_PROPERTY_PREFIX + ENV_HADOOP_USER_NAME, "hadoop");
     String jobArgs = super.buildOptimizerStartupArgsString(resource);
     // ./bin/spark-submit --master <master> --deploy-mode=<sparkMode> <options> --proxy-user <user>
+    // --name <appName>
     // --class
     // <main-class>
     // <job-file>
     // <arguments>
     //  options: --conf <property=value>
     return String.format(
-        "%s/bin/spark-submit --master %s --deploy-mode=%s %s --proxy-user %s --class %s %s %s",
+        "%s/bin/spark-submit --master %s --deploy-mode=%s %s --proxy-user %s --name %s --class %s %s %s",
         sparkHome,
         sparkMaster,
         deployMode.getValue(),
         sparkOptions,
         proxyUser,
+        String.join(
+            "-", "Amoro-spark-optimizer", resource.getGroupName(), resource.getResourceId()),
         SPARK_JOB_MAIN_CLASS,
         jobUri,
         jobArgs);


### PR DESCRIPTION
The current spark optimizer has no specified name, as shown below.
<img width="1764" height="126" alt="image" src="https://github.com/user-attachments/assets/b1896b49-d43b-4591-8a32-1bcacfa76257" />
The name of the Flink optimizer contains the optimizer group and id, which is more convenient for problem location. Spark should also be changed to this
<img width="1708" height="230" alt="image" src="https://github.com/user-attachments/assets/92974912-011d-4250-9005-9ba147cf6ffd" />

The expected effect after the modification is as follows.

<img width="1506" height="166" alt="image" src="https://github.com/user-attachments/assets/2da521d4-be3d-476d-a278-3027a110dcb2" />


## Why are the changes needed?
The spark optimizer name displays the optimizer resource group and instance ID.

Close #3824 

## Brief change log
The spark optimizer name displays the optimizer resource group and instance ID.

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
