### PR TITLE
[AMORO-3608] Enhance RollingFileCleaner to preserve full URI for remote filesystems

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/utils/RollingFileCleaner.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/utils/RollingFileCleaner.java
@@ -59,24 +59,7 @@ public class RollingFileCleaner {
     }
 
     collectedFiles.add(filePath);
-    // Preserve the full URI including scheme (e.g., s3://, s3a://, hdfs://) for S3 and other remote
-    // file systems
-    URI uri = URI.create(filePath);
-    String parentDir;
-    if (uri.getScheme() != null && uri.getAuthority() != null) {
-      // For URIs with scheme and authority (e.g., s3://bucket/path/file), construct full parent
-      // path
-      Path path = new Path(uri.getPath());
-      Path parent = path.getParent();
-      if (parent != null) {
-        parentDir = uri.getScheme() + "://" + uri.getAuthority() + parent;
-      } else {
-        parentDir = uri.getScheme() + "://" + uri.getAuthority();
-      }
-    } else {
-      // For local paths or paths without scheme
-      parentDir = new Path(uri.getPath()).getParent().toString();
-    }
+    String parentDir = TableFileUtil.getParent(filePath);
     parentDirectories.add(parentDir);
     int currentCount = fileCounter.incrementAndGet();
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/util/TestRollingFileCleaner.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/util/TestRollingFileCleaner.java
@@ -38,7 +38,7 @@ public class TestRollingFileCleaner {
     // generate some files
     Set<String> expiredFiles = Sets.newHashSet();
     for (int i = 0; i < 5050; i++) {
-      String filePath = "file_" + i + ".txt";
+      String filePath = "file://bucket/warehouse/date=2025-01-01/file_" + i + ".txt";
       io.addFile(filePath, ("file_content" + i).getBytes());
       expiredFiles.add(filePath);
       fileCleaner.addFile(filePath);

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/io/AuthenticatedFileIOAdapter.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/io/AuthenticatedFileIOAdapter.java
@@ -19,6 +19,7 @@
 package org.apache.amoro.io;
 
 import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -53,10 +54,15 @@ public class AuthenticatedFileIOAdapter implements AuthenticatedFileIO {
 
   @Override
   public boolean exists(String path) {
-    if (io instanceof AuthenticatedFileIO) {
-      return ((AuthenticatedFileIO) io).exists(path);
+    try {
+      if (io instanceof AuthenticatedFileIO) {
+        return ((AuthenticatedFileIO) io).exists(path);
+      }
+
+      return AuthenticatedFileIO.super.exists(path);
+    } catch (NotFoundException e) {
+      return false;
     }
-    return AuthenticatedFileIO.super.exists(path);
   }
 
   @Override


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Fix #3630

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- as title

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
