### PR TITLE
[AMORO-3831] Fix `isFullNecessary()` logic to use enoughContent() for undersized segment

### DIFF
--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
@@ -376,7 +376,7 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
     }
     return anyDeleteExist()
         || fragmentFileCount >= 2
-        || undersizedSegmentFileCount >= 2
+        || enoughContent()
         || rewriteSegmentFileCount > 0
         || rewritePosSegmentFileCount > 0;
   }


### PR DESCRIPTION

## Why are the changes needed?

Close #3831.

## Brief change log

- `undersizedSegmentFileCount >= 2` change to `enoughContent()`

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
