### PR TITLE
[AMORO-3966][Helm] Support custom volumes and volumeMounts

### DIFF
--- a/charts/amoro/templates/_pod.tpl
+++ b/charts/amoro/templates/_pod.tpl
@@ -92,6 +92,10 @@ spark distribution package will be installed to here*/ -}}
 - name: spark-install
   mountPath: /opt/spark
 {{- end -}}
+{{- /* additional volume mounts from values */ -}}
+{{- with .Values.volumeMounts }}
+{{- tpl (toYaml .) $ | nindent 0 }}
+{{- end -}}
 {{- end -}}
 {{- /* define amoro.pod.container.mounts end */ -}}
 
@@ -112,6 +116,10 @@ spark distribution package will be installed to here*/ -}}
 {{- if .Values.optimizer.spark.enabled }}
 - name: spark-install
   emptyDir: {}
+{{- end -}}
+{{- /* additional volumes from values */ -}}
+{{- with .Values.volumes }}
+{{- tpl (toYaml .) $ | nindent 0 }}
 {{- end -}}
 {{- end -}}
 {{- /* define "amoro.pod.volumes" end */ -}}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds support for custom `volumes` and `volumeMounts` in Amoro Helm chart, enabling users to mount additional volumes without modifying chart templates.

**Resolves #3966**

### Why are the changes needed?

Users need to mount custom resources like:
- Java truststore for SSL/TLS certificates
- Configuration files
- Secrets (API keys, credentials)
- Persistent volumes

Currently, these require forking/patching the chart.

### Does this PR introduce any user-facing change?

Yes. Users can now specify custom volumes in `values.yaml`:

```yaml
volumes:
  - name: java-truststore
    secret:
      secretName: java-truststore-secret

volumeMounts:
  - name: java-truststore
    mountPath: /opt/java/truststore
    readOnly: true
```

### How was this patch tested?

- Verified Helm template rendering with custom volumes
- Tested with Java truststore secret mount
- Confirmed backward compatibility (no volumes specified = no change)