### PR TITLE
[AMORO-3968] Update the thrift api compile command to use amoro shaded thrift

### DIFF
--- a/amoro-common/pom.xml
+++ b/amoro-common/pom.xml
@@ -184,7 +184,7 @@
     </build>
 
     <profiles>
-        <!--Compile thrift api with commend: ./mvnw -pl amoro-common -Pthrift-gen -->
+        <!--Compile thrift api with commend: ./mvnw -pl amoro-common -Pthrift-gen generate-sources -->
         <profile>
             <id>thrift-gen</id>
             <build>
@@ -226,10 +226,8 @@
                             </execution>
                         </executions>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/amoro-common/src/main/thrift/README.md
+++ b/amoro-common/src/main/thrift/README.md
@@ -41,5 +41,5 @@ export PATH="/usr/local/opt/thrift@0.20.0/bin:$PATH"
 ### Compile Thrift
 
 ```shell
-./mvnw -pl amoro-common thrift:compile antrun:run@relocate-thrift-package
+./mvnw -pl amoro-common -Pthrift-gen generate-sources
 ```


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3968.

I am working on the amoro adoption in ebay, and need to extend some thrift API.

Currently, the thrift compile command provided is not valid.
It uses the original org.apache.thrift instead of amoro shaded.

```
./mvnw -pl amoro-common thrift:compile
```
<img width="1728" height="953" alt="Image" src="https://github.com/user-attachments/assets/76424bf6-1245-4cae-b65b-e999783ba3be" />

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Update the thrift compile command for developer friendly.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

Looks good after this PR.
```
./mvnw -pl amoro-common -Pthrift-gen generate-sources
```
<img width="1728" height="1037" alt="image" src="https://github.com/user-attachments/assets/47eef3d7-d531-4935-b31a-cb08f584fac1" />

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
