### PR TITLE
[AMORO-3970][doc] Update README.md with correct Spark versions for Mixed format

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Amoro support multiple processing engines for Mixed format as below:
 | Processing Engine | Version                | Batch Read  | Batch Write | Batch Overwrite | Streaming Read | Streaming Write | Create Table | Alter Table |
 |-------------------|------------------------|-------------|-------------|-----------------|----------------|-----------------|--------------|-------------|
 | Flink             | 1.16.x, 1.17.x, 1.18.x |  &#x2714;   |   &#x2714;   |       &#x2716;   |      &#x2714;   |       &#x2714;   |    &#x2714;   |   &#x2716;   |
-| Spark             | 3.1, 3.2, 3.3          |  &#x2714;   |   &#x2714;   |       &#x2714;   |      &#x2716;   |       &#x2716;   |    &#x2714;   |   &#x2714;   |
+| Spark             | 3.3, 3.5               |  &#x2714;   |   &#x2714;   |       &#x2714;   |      &#x2716;   |       &#x2716;   |    &#x2714;   |   &#x2714;   |
 | Hive              | 2.x, 3.x               |  &#x2714;  |   &#x2716;  |       &#x2714;  |      &#x2716;  |       &#x2716;  |    &#x2716;  |   &#x2714;  |
 | Trino             | 406                    |  &#x2714;  |   &#x2716;  |       &#x2714;  |      &#x2716;  |       &#x2716;  |    &#x2716;  |   &#x2714;  |
 


### PR DESCRIPTION
## Why are the changes needed?

The README.md documentation listed outdated Spark versions for Mixed format support. The table showed "3.1, 3.2, 3.3" but the actual codebase only supports Spark 3.3 and 3.5:
- `amoro-format-mixed/amoro-mixed-spark/v3.3/`
- `amoro-format-mixed/amoro-mixed-spark/v3.5/`

Spark 3.1 and 3.2 modules have been removed, while Spark 3.5 support has been added.

Close #3970.

## Brief change log

- Updated the Spark version in the Mixed format supported engines table from "3.1, 3.2, 3.3" to "3.3, 3.5" in README.md

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
  - N/A - Documentation change only

- [x] Run test locally before making a pull request
  - Verified the codebase structure matches the updated documentation

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable