### PR TITLE
[AMORO-3985] Fix flaky test: `Database: test_ns already exists`.

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/AmsEnvironment.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/AmsEnvironment.java
@@ -138,6 +138,8 @@ public class AmsEnvironment {
       return;
     }
 
+    MoreFiles.deleteRecursively(
+        Paths.get(rootPath + "/derby"), RecursiveDeleteOption.ALLOW_INSECURE);
     testHMS.start();
     startAms();
     DynFields.UnboundField<DefaultCatalogManager> amsCatalogManagerField =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #3985.

```
2025-11-29T08:00:54.3432635Z [INFO] Results:
2025-11-29T08:00:54.3433304Z [INFO] 
2025-11-29T08:00:54.3433738Z [ERROR] Failures: 
2025-11-29T08:00:54.3434507Z [ERROR]   TestInternalMixedCatalogService$TestDatabaseOperation.test:168 expected: <true> but was: <false>
2025-11-29T08:00:54.3435377Z [ERROR] Errors: 
2025-11-29T08:00:54.3437400Z [ERROR]   TestInternalMixedCatalogService$CompatibilityCatalogTests.assertHistoricalCatalogCannotLoadNewTable:376 » ServiceFailure Server error: PersistenceException: org.apache.ibatis.exceptions.PersistenceException: 
2025-11-29T08:00:54.3441306Z ### Error updating database.  Cause: org.apache.derby.shared.common.error.DerbySQLIntegrityConstraintViolationException: The statement was aborted because it would have caused a duplicate key value in a unique or primary key constraint or unique index identified by 'SQL251129080039620' defined on 'TABLE_RUNTIME'.
2025-11-29T08:00:54.3443723Z ### The error may exist in org/apache/amoro/server/persistence/mapper/TableRuntimeMapper.java (best guess)
2025-11-29T08:00:54.3444991Z ### The error may involve org.apache.amoro.server.persistence.mapper.TableRuntimeMapper.insertRuntime-Inline
2025-11-29T08:00:54.3445920Z ### The error occurred while setting parameters
2025-11-29T08:00:54.3446798Z ### SQL: INSERT INTO table_runtime (table_id, group_name, status_code, table_config, table_summary, bucket_id) VALUES (?, ?, ?, ?, ?, ?)
2025-11-29T08:00:54.3449544Z ### Cause: org.apache.derby.shared.common.error.DerbySQLIntegrityConstraintViolationException: The statement was aborted because it would have caused a duplicate key value in a unique or primary key constraint or unique index identified by 'SQL251129080039620' defined on 'TABLE_RUNTIME'.
2025-11-29T08:00:54.3452147Z [ERROR]   TestInternalMixedCatalogService$CompatibilityCatalogTests.setupTest:310 » AlreadyExists Database already exists, test_ns
2025-11-29T08:00:54.3453351Z [ERROR]   TestInternalMixedCatalogService$CompatibilityCatalogTests.setupTest:310 » AlreadyExists Database already exists, test_ns
2025-11-29T08:00:54.3454233Z [ERROR]   TestInternalMixedCatalogService$TestTableCommit.before:247 » AlreadyExists Database: test_ns already exists.
2025-11-29T08:00:54.3455215Z [ERROR]   TestInternalMixedCatalogService$TestTableCommit.before:247 » AlreadyExists Database: test_ns already exists.
2025-11-29T08:00:54.3456044Z [ERROR]   TestInternalMixedCatalogService$TestTableOperation.before:186 » AlreadyExists Database: test_ns already exists.
2025-11-29T08:00:54.3456888Z [ERROR]   TestInternalMixedCatalogService$TestTableOperation.before:186 » AlreadyExists Database: test_ns already exists.
```
## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Truncate all tables before all

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
