### PR TITLE
[AMORO-3981][FOLLOWUP] Refine the duration to string format 

### DIFF
--- a/amoro-common/src/main/java/org/apache/amoro/config/ConfigHelpers.java
+++ b/amoro-common/src/main/java/org/apache/amoro/config/ConfigHelpers.java
@@ -439,7 +439,8 @@ public class ConfigHelpers {
                       return orderedUnits.get(idx - 1);
                     }
                   })
-              .orElse(TimeUnit.MILLISECONDS);
+              // Use the largest unit if all divide evenly
+              .orElse(orderedUnits.get(orderedUnits.size() - 1));
 
       return String.format(
           "%d %s",

--- a/amoro-common/src/test/java/org/apache/amoro/config/ConfigHelpersTest.java
+++ b/amoro-common/src/test/java/org/apache/amoro/config/ConfigHelpersTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+public class ConfigHelpersTest {
+  @Test
+  public void testTimeUtils() {
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofNanos(1)).equals("1 ns");
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofNanos(1000)).equals("1 µs");
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofMillis(1)).equals("1 ms");
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofSeconds(1)).equals("1 s");
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofMinutes(1)).equals("1 min");
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofHours(1)).equals("1 h");
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofDays(1)).equals("1 d");
+    assert ConfigHelpers.TimeUtils.formatWithHighestUnit(Duration.ofHours(25)).equals("25 h");
+  }
+}

--- a/docs/configuration/ams-config.md
+++ b/docs/configuration/ams-config.md
@@ -52,10 +52,10 @@ table td:last-child, table th:last-child { width: 40%; word-break: break-all; }
 | clean-dangling-delete-files.enabled | true | Enable dangling delete files cleaning. |
 | clean-dangling-delete-files.thread-count | 10 | The number of threads used for dangling delete files cleaning. |
 | clean-orphan-files.enabled | true | Enable orphan files cleaning. |
-| clean-orphan-files.interval | 86400000 ms | Interval for cleaning orphan files. |
+| clean-orphan-files.interval | 1 d | Interval for cleaning orphan files. |
 | clean-orphan-files.thread-count | 10 | The number of threads used for orphan files cleaning. |
 | data-expiration.enabled | true | Enable data expiration |
-| data-expiration.interval | 86400000 ms | Execute interval for data expiration |
+| data-expiration.interval | 1 d | Execute interval for data expiration |
 | data-expiration.thread-count | 10 | The number of threads used for data expiring |
 | database.auto-create-tables | true | Auto init table schema when started |
 | database.connection-pool-max-idle | 16 | Max idle connect count of database connect pool. |
@@ -78,7 +78,7 @@ table td:last-child, table th:last-child { width: 40%; word-break: break-all; }
 | http-server.bind-port | 19090 | Port that the Http server is bound to. |
 | http-server.proxy-client-ip-header | X-Real-IP | The HTTP header to record the real client IP address. If your server is behind a load balancer or other proxy, the server will see this load balancer or proxy IP address as the client IP address, to get around this common issue, most load balancers or proxies offer the ability to record the real remote IP address in an HTTP header that will be added to the request for other devices to use. |
 | http-server.rest-auth-type | token | The authentication used by REST APIs, token (default), basic or jwt. |
-| http-server.session-timeout | 604800000 ms | Timeout for http session. |
+| http-server.session-timeout | 7 d | Timeout for http session. |
 | optimizer.heart-beat-timeout | 1 min | Timeout duration for Optimizer heartbeat. |
 | optimizer.max-planning-parallelism | 1 | Max planning parallelism in one optimizer group. |
 | optimizer.polling-timeout | 3 s | Optimizer polling task timeout. |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #xxx.
In https://github.com/apache/amoro/pull/3982, I support to generate the conf docs automatically.

However, the default value looks not human readable.

All the duration default value is in ns time unit.
<img width="1469" height="771" alt="image" src="https://github.com/user-attachments/assets/273d0801-446e-488d-b867-74176e672ce1" />

In this PR, we refine the Duration format to string.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Refine the duration format to string

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
