### PR TITLE
[AMORO-4022] [Improvement]: AMS Iceberg maintainer moved to the amoro-iceberg module

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/maintainer/DefaultTableMaintainerContext.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/maintainer/DefaultTableMaintainerContext.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.optimizing.maintainer;
+
+import org.apache.amoro.config.TableConfiguration;
+import org.apache.amoro.maintainer.MaintainerMetrics;
+import org.apache.amoro.maintainer.OptimizingInfo;
+import org.apache.amoro.maintainer.TableMaintainerContext;
+import org.apache.amoro.server.table.DefaultTableRuntime;
+import org.apache.amoro.server.table.TableOrphanFilesCleaningMetrics;
+import org.apache.amoro.server.utils.HiveLocationUtil;
+import org.apache.amoro.table.MixedTable;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Default implementation of TableMaintainerContext for AMS. Adapts DefaultTableRuntime to
+ * TableMaintainerContext interface.
+ */
+public class DefaultTableMaintainerContext implements TableMaintainerContext {
+
+  private final DefaultTableRuntime tableRuntime;
+  private final MixedTable mixedTable;
+
+  public DefaultTableMaintainerContext(DefaultTableRuntime tableRuntime) {
+    this.tableRuntime = tableRuntime;
+    this.mixedTable = null;
+  }
+
+  public DefaultTableMaintainerContext(DefaultTableRuntime tableRuntime, MixedTable mixedTable) {
+    this.tableRuntime = tableRuntime;
+    this.mixedTable = mixedTable;
+  }
+
+  @Override
+  public TableConfiguration getTableConfiguration() {
+    return tableRuntime.getTableConfiguration();
+  }
+
+  @Override
+  public MaintainerMetrics getMetrics() {
+    TableOrphanFilesCleaningMetrics metrics = tableRuntime.getOrphanFilesCleaningMetrics();
+    return new MaintainerMetrics() {
+      @Override
+      public void recordOrphanDataFilesCleaned(int expected, int cleaned) {
+        metrics.completeOrphanDataFiles(expected, cleaned);
+      }
+
+      @Override
+      public void recordOrphanMetadataFilesCleaned(int expected, int cleaned) {
+        metrics.completeOrphanMetadataFiles(expected, cleaned);
+      }
+    };
+  }
+
+  @Override
+  public OptimizingInfo getOptimizingInfo() {
+    return new DefaultOptimizingInfo(tableRuntime);
+  }
+
+  @Override
+  public Set<String> getHiveLocationPaths() {
+    // Use HiveLocationUtil to get Hive location paths
+    if (mixedTable == null) {
+      return Collections.emptySet();
+    }
+    return HiveLocationUtil.getHiveLocation(mixedTable);
+  }
+
+  /** OptimizingInfo implementation based on DefaultTableRuntime. */
+  private static class DefaultOptimizingInfo implements OptimizingInfo {
+
+    private final DefaultTableRuntime tableRuntime;
+
+    DefaultOptimizingInfo(DefaultTableRuntime tableRuntime) {
+      this.tableRuntime = tableRuntime;
+    }
+
+    @Override
+    public boolean isProcessing() {
+      return tableRuntime.getOptimizingStatus().isProcessing();
+    }
+
+    @Override
+    public long getTargetSnapshotId() {
+      if (!isProcessing()) {
+        return Long.MAX_VALUE;
+      }
+      return tableRuntime.getOptimizingProcess().getTargetSnapshotId();
+    }
+  }
+}

--- a/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/DanglingDeleteFilesCleaningExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/DanglingDeleteFilesCleaningExecutor.java
@@ -21,7 +21,7 @@ package org.apache.amoro.server.scheduler.inline;
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.TableRuntime;
 import org.apache.amoro.config.TableConfiguration;
-import org.apache.amoro.server.optimizing.maintainer.TableMaintainer;
+import org.apache.amoro.maintainer.TableMaintainer;
 import org.apache.amoro.server.optimizing.maintainer.TableMaintainers;
 import org.apache.amoro.server.scheduler.PeriodicTableScheduler;
 import org.apache.amoro.server.table.DefaultTableRuntime;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/DataExpiringExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/DataExpiringExecutor.java
@@ -21,7 +21,7 @@ package org.apache.amoro.server.scheduler.inline;
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.TableRuntime;
 import org.apache.amoro.config.TableConfiguration;
-import org.apache.amoro.server.optimizing.maintainer.TableMaintainer;
+import org.apache.amoro.maintainer.TableMaintainer;
 import org.apache.amoro.server.optimizing.maintainer.TableMaintainers;
 import org.apache.amoro.server.scheduler.PeriodicTableScheduler;
 import org.apache.amoro.server.table.TableService;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/OrphanFilesCleaningExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/OrphanFilesCleaningExecutor.java
@@ -21,7 +21,7 @@ package org.apache.amoro.server.scheduler.inline;
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.TableRuntime;
 import org.apache.amoro.config.TableConfiguration;
-import org.apache.amoro.server.optimizing.maintainer.TableMaintainer;
+import org.apache.amoro.maintainer.TableMaintainer;
 import org.apache.amoro.server.optimizing.maintainer.TableMaintainers;
 import org.apache.amoro.server.scheduler.PeriodicTableScheduler;
 import org.apache.amoro.server.table.TableService;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/SnapshotsExpiringExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/SnapshotsExpiringExecutor.java
@@ -21,7 +21,7 @@ package org.apache.amoro.server.scheduler.inline;
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.TableRuntime;
 import org.apache.amoro.config.TableConfiguration;
-import org.apache.amoro.server.optimizing.maintainer.TableMaintainer;
+import org.apache.amoro.maintainer.TableMaintainer;
 import org.apache.amoro.server.optimizing.maintainer.TableMaintainers;
 import org.apache.amoro.server.scheduler.PeriodicTableScheduler;
 import org.apache.amoro.server.table.TableService;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/TagsAutoCreatingExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/scheduler/inline/TagsAutoCreatingExecutor.java
@@ -22,7 +22,7 @@ import org.apache.amoro.AmoroTable;
 import org.apache.amoro.TableFormat;
 import org.apache.amoro.TableRuntime;
 import org.apache.amoro.config.TableConfiguration;
-import org.apache.amoro.server.optimizing.maintainer.TableMaintainer;
+import org.apache.amoro.maintainer.TableMaintainer;
 import org.apache.amoro.server.optimizing.maintainer.TableMaintainers;
 import org.apache.amoro.server.scheduler.PeriodicTableScheduler;
 import org.apache.amoro.server.table.TableService;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOptimizingMetrics.java
@@ -31,7 +31,6 @@ import org.apache.amoro.metrics.MetricRegistry;
 import org.apache.amoro.optimizing.OptimizingType;
 import org.apache.amoro.server.AmoroServiceConstants;
 import org.apache.amoro.server.optimizing.OptimizingStatus;
-import org.apache.amoro.server.optimizing.maintainer.IcebergTableMaintainer;
 import org.apache.amoro.shade.guava32.com.google.common.collect.ImmutableMap;
 import org.apache.amoro.shade.guava32.com.google.common.primitives.Longs;
 import org.apache.iceberg.Snapshot;
@@ -350,7 +349,10 @@ public class TableOptimizingMetrics extends AbstractTableMetrics {
     }
     // ignore snapshot which is created by amoro maintain commits or no files added
     if (snapshot.summary().values().stream()
-            .anyMatch(IcebergTableMaintainer.AMORO_MAINTAIN_COMMITS::contains)
+            .anyMatch(
+                org.apache.amoro.formats.iceberg.maintainer.IcebergTableMaintainer
+                        .AMORO_MAINTAIN_COMMITS
+                    ::contains)
         || Long.parseLong(snapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP, "0"))
             == 0) {
       return;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOrphanFilesCleaningMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/TableOrphanFilesCleaningMetrics.java
@@ -21,12 +21,14 @@ package org.apache.amoro.server.table;
 import static org.apache.amoro.metrics.MetricDefine.defineCounter;
 
 import org.apache.amoro.ServerTableIdentifier;
+import org.apache.amoro.maintainer.MaintainerMetrics;
 import org.apache.amoro.metrics.Counter;
 import org.apache.amoro.metrics.MetricDefine;
 import org.apache.amoro.metrics.MetricRegistry;
 
 /** Table Orphan Files Cleaning metrics. */
-public class TableOrphanFilesCleaningMetrics extends AbstractTableMetrics {
+public class TableOrphanFilesCleaningMetrics extends AbstractTableMetrics
+    implements MaintainerMetrics {
   private final Counter orphanDataFilesCount = new Counter();
   private final Counter expectedOrphanDataFilesCount = new Counter();
 
@@ -88,5 +90,15 @@ public class TableOrphanFilesCleaningMetrics extends AbstractTableMetrics {
   public void completeOrphanMetadataFiles(int expected, int cleaned) {
     expectedOrphanMetadataFilesCount.inc(expected);
     orphanMetadataFilesCount.inc(cleaned);
+  }
+
+  @Override
+  public void recordOrphanDataFilesCleaned(int expected, int cleaned) {
+    completeOrphanDataFiles(expected, cleaned);
+  }
+
+  @Override
+  public void recordOrphanMetadataFilesCleaned(int expected, int cleaned) {
+    completeOrphanMetadataFiles(expected, cleaned);
   }
 }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestOrphanFileCleanHive.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestOrphanFileCleanHive.java
@@ -18,12 +18,13 @@
 
 package org.apache.amoro.server.optimizing.maintainer;
 
-import static org.apache.amoro.server.optimizing.maintainer.IcebergTableMaintainer.DATA_FOLDER_NAME;
+import static org.apache.amoro.formats.iceberg.maintainer.IcebergTableMaintainer.DATA_FOLDER_NAME;
 
 import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.TableFormat;
 import org.apache.amoro.TableTestHelper;
 import org.apache.amoro.catalog.CatalogTestHelper;
+import org.apache.amoro.formats.iceberg.maintainer.MixedTableMaintainer;
 import org.apache.amoro.hive.TestHMS;
 import org.apache.amoro.hive.catalog.HiveCatalogTestHelper;
 import org.apache.amoro.hive.catalog.HiveTableTestHelper;
@@ -84,7 +85,8 @@ public class TestOrphanFileCleanHive extends TestOrphanFileClean {
     changeOrphanDataFile.createOrOverwrite().close();
     Assert.assertTrue(getMixedTable().io().exists(hiveOrphanFilePath));
 
-    MixedTableMaintainer maintainer = new MixedTableMaintainer(getMixedTable(), null);
+    MixedTableMaintainer maintainer =
+        new MixedTableMaintainer(getMixedTable(), TestTableMaintainerContext.of(getMixedTable()));
     TableIdentifier tableIdentifier = getMixedTable().id();
     TableOrphanFilesCleaningMetrics orphanFilesCleaningMetrics =
         new TableOrphanFilesCleaningMetrics(

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestOrphanFileCleanIceberg.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestOrphanFileCleanIceberg.java
@@ -23,6 +23,7 @@ import org.apache.amoro.TableFormat;
 import org.apache.amoro.TableTestHelper;
 import org.apache.amoro.catalog.BasicCatalogTestHelper;
 import org.apache.amoro.catalog.CatalogTestHelper;
+import org.apache.amoro.formats.iceberg.maintainer.IcebergTableMaintainer;
 import org.apache.amoro.hive.io.writer.AdaptHiveGenericTaskWriterBuilder;
 import org.apache.amoro.io.writer.SortedPosDeleteWriter;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
@@ -101,7 +102,8 @@ public class TestOrphanFileCleanIceberg extends TestOrphanFileClean {
     assertDanglingDeleteFiles(testTable, 1);
 
     IcebergTableMaintainer tableMaintainer =
-        new IcebergTableMaintainer(testTable, testTable.id(), null);
+        new IcebergTableMaintainer(
+            testTable, testTable.id(), TestTableMaintainerContext.of(testTable));
     tableMaintainer.doCleanDanglingDeleteFiles();
 
     assertDanglingDeleteFiles(testTable, 0);

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestSnapshotExpireHive.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestSnapshotExpireHive.java
@@ -21,11 +21,13 @@ package org.apache.amoro.server.optimizing.maintainer;
 import org.apache.amoro.TableFormat;
 import org.apache.amoro.TableTestHelper;
 import org.apache.amoro.catalog.CatalogTestHelper;
+import org.apache.amoro.formats.iceberg.maintainer.MixedTableMaintainer;
 import org.apache.amoro.hive.TestHMS;
 import org.apache.amoro.hive.catalog.HiveCatalogTestHelper;
 import org.apache.amoro.hive.catalog.HiveTableTestHelper;
 import org.apache.amoro.hive.io.HiveDataTestHelpers;
 import org.apache.amoro.hive.utils.HiveTableUtil;
+import org.apache.amoro.maintainer.TableMaintainerContext;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Iterables;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 import org.apache.amoro.table.MixedTable;
@@ -111,7 +113,8 @@ public class TestSnapshotExpireHive extends TestSnapshotExpire {
         isKeyedTable()
             ? getMixedTable().asKeyedTable().baseTable()
             : getMixedTable().asUnkeyedTable();
-    MixedTableMaintainer mixedTableMaintainer = new MixedTableMaintainer(getMixedTable(), null);
+    TableMaintainerContext context = TestTableMaintainerContext.of(getMixedTable());
+    MixedTableMaintainer mixedTableMaintainer = new MixedTableMaintainer(getMixedTable(), context);
     mixedTableMaintainer.getBaseMaintainer().expireSnapshots(System.currentTimeMillis(), 1);
     Assert.assertEquals(1, Iterables.size(unkeyedTable.snapshots()));
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestTableMaintainerContext.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/maintainer/TestTableMaintainerContext.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.optimizing.maintainer;
+
+import org.apache.amoro.config.TableConfiguration;
+import org.apache.amoro.maintainer.MaintainerMetrics;
+import org.apache.amoro.maintainer.OptimizingInfo;
+import org.apache.amoro.maintainer.TableMaintainerContext;
+import org.apache.amoro.server.table.TableConfigurations;
+import org.apache.amoro.server.utils.HiveLocationUtil;
+import org.apache.amoro.table.KeyedTable;
+import org.apache.amoro.table.MixedTable;
+import org.apache.amoro.table.UnkeyedTable;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** Utility class for creating test TableMaintainerContext instances. */
+public class TestTableMaintainerContext {
+
+  /** Create a test TableMaintainerContext for the given MixedTable. */
+  public static TableMaintainerContext of(MixedTable table) {
+    return new Impl(TableConfigurations.parseTableConfig(table.properties()), table);
+  }
+
+  /** Create a test TableMaintainerContext for the given KeyedTable. */
+  public static TableMaintainerContext of(KeyedTable table) {
+    return new Impl(TableConfigurations.parseTableConfig(table.properties()));
+  }
+
+  /** Create a test TableMaintainerContext for the given UnkeyedTable. */
+  public static TableMaintainerContext of(UnkeyedTable table) {
+    return new Impl(TableConfigurations.parseTableConfig(table.properties()));
+  }
+
+  /** Test implementation of TableMaintainerContext. */
+  public static class Impl implements TableMaintainerContext {
+    private final TableConfiguration tableConfiguration;
+    private OptimizingInfo optimizingInfo;
+    private final MixedTable mixedTable;
+
+    public Impl(TableConfiguration tableConfiguration) {
+      this.tableConfiguration = tableConfiguration;
+      this.optimizingInfo = OptimizingInfo.EMPTY;
+      this.mixedTable = null;
+    }
+
+    public Impl(TableConfiguration tableConfiguration, MixedTable mixedTable) {
+      this.tableConfiguration = tableConfiguration;
+      this.optimizingInfo = OptimizingInfo.EMPTY;
+      this.mixedTable = mixedTable;
+    }
+
+    public void setOptimizingInfo(OptimizingInfo optimizingInfo) {
+      this.optimizingInfo = optimizingInfo;
+    }
+
+    @Override
+    public TableConfiguration getTableConfiguration() {
+      return tableConfiguration;
+    }
+
+    @Override
+    public MaintainerMetrics getMetrics() {
+      return MaintainerMetrics.NOOP;
+    }
+
+    @Override
+    public OptimizingInfo getOptimizingInfo() {
+      return optimizingInfo;
+    }
+
+    @Override
+    public Set<String> getHiveLocationPaths() {
+      // Use HiveLocationUtil to get Hive location paths
+      if (mixedTable == null) {
+        return Collections.emptySet();
+      }
+      return HiveLocationUtil.getHiveLocation(mixedTable);
+    }
+  }
+}

--- a/amoro-common/src/main/java/org/apache/amoro/maintainer/MaintainerMetrics.java
+++ b/amoro-common/src/main/java/org/apache/amoro/maintainer/MaintainerMetrics.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.maintainer;
+
+/**
+ * Metrics collector interface for table maintenance operations. Implementations can collect metrics
+ * to different monitoring systems.
+ */
+public interface MaintainerMetrics {
+
+  /**
+   * Record orphan data files cleaning result.
+   *
+   * @param expected expected number of files to clean
+   * @param cleaned actual number of files cleaned
+   */
+  void recordOrphanDataFilesCleaned(int expected, int cleaned);
+
+  /**
+   * Record orphan metadata files cleaning result.
+   *
+   * @param expected expected number of files to clean
+   * @param cleaned actual number of files cleaned
+   */
+  void recordOrphanMetadataFilesCleaned(int expected, int cleaned);
+
+  /** No-op implementation that does nothing. */
+  MaintainerMetrics NOOP =
+      new MaintainerMetrics() {
+        @Override
+        public void recordOrphanDataFilesCleaned(int expected, int cleaned) {}
+
+        @Override
+        public void recordOrphanMetadataFilesCleaned(int expected, int cleaned) {}
+      };
+}

--- a/amoro-common/src/main/java/org/apache/amoro/maintainer/OptimizingInfo.java
+++ b/amoro-common/src/main/java/org/apache/amoro/maintainer/OptimizingInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.maintainer;
+
+/**
+ * Optimizing process information interface. Provides information about ongoing optimizing
+ * processes.
+ */
+public interface OptimizingInfo {
+
+  /**
+   * Check if there is an optimizing process currently processing.
+   *
+   * @return true if an optimizing process is in progress
+   */
+  boolean isProcessing();
+
+  /**
+   * Get the target snapshot id that the optimizing process is based on.
+   *
+   * @return target snapshot id, or {@code Long.MAX_VALUE} if no process is running
+   */
+  long getTargetSnapshotId();
+
+  /** Empty implementation indicating no optimizing process. */
+  OptimizingInfo EMPTY =
+      new OptimizingInfo() {
+        @Override
+        public boolean isProcessing() {
+          return false;
+        }
+
+        @Override
+        public long getTargetSnapshotId() {
+          return Long.MAX_VALUE;
+        }
+      };
+}

--- a/amoro-common/src/main/java/org/apache/amoro/maintainer/TableMaintainer.java
+++ b/amoro-common/src/main/java/org/apache/amoro/maintainer/TableMaintainer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.amoro.server.optimizing.maintainer;
+package org.apache.amoro.maintainer;
 
 /**
  * API for maintaining table.
@@ -24,7 +24,6 @@ package org.apache.amoro.server.optimizing.maintainer;
  * <p>Includes: clean content files, clean metadata, clean dangling delete files, expire snapshots,
  * auto create tags.
  */
-// TODO TableMaintainer should not be in this optimizing.xxx package.
 public interface TableMaintainer {
 
   /** Clean table orphan files. Includes: data files, metadata files. */

--- a/amoro-common/src/main/java/org/apache/amoro/maintainer/TableMaintainerContext.java
+++ b/amoro-common/src/main/java/org/apache/amoro/maintainer/TableMaintainerContext.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.maintainer;
+
+import org.apache.amoro.config.TableConfiguration;
+
+import java.util.Set;
+
+/**
+ * Context interface for table maintainer operations.
+ *
+ * <p>Provides necessary configuration and runtime information for table maintenance without
+ * depending on AMS-specific implementations.
+ */
+public interface TableMaintainerContext {
+
+  /**
+   * Get the table configuration.
+   *
+   * @return table configuration containing all maintenance-related settings
+   */
+  TableConfiguration getTableConfiguration();
+
+  /**
+   * Get the metrics collector for maintenance operations.
+   *
+   * @return metrics collector, may return NoopMaintainerMetrics if metrics not supported
+   */
+  MaintainerMetrics getMetrics();
+
+  /**
+   * Get optimizing process information if available.
+   *
+   * @return optimizing information, may return EmptyOptimizingInfo if no optimizing process
+   */
+  OptimizingInfo getOptimizingInfo();
+
+  /**
+   * Get Hive table/partition location paths if the table is a Hive-backed table.
+   *
+   * <p>This is used to exclude Hive-managed files from being cleaned during maintenance operations.
+   * For non-Hive tables, returns an empty set.
+   *
+   * @return set of Hive location paths, or empty set if not a Hive table
+   */
+  Set<String> getHiveLocationPaths();
+}

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/maintainer/AutoCreateIcebergTagAction.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/maintainer/AutoCreateIcebergTagAction.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.amoro.server.optimizing.maintainer;
+package org.apache.amoro.formats.iceberg.maintainer;
 
 import org.apache.amoro.config.TagConfiguration;
 import org.apache.iceberg.ManageSnapshots;

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/IcebergTableUtil.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/IcebergTableUtil.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.formats.iceberg.utils;
+
+import org.apache.amoro.IcebergFileEntry;
+import org.apache.amoro.iceberg.Constants;
+import org.apache.amoro.scan.TableEntriesScan;
+import org.apache.amoro.shade.guava32.com.google.common.base.Predicate;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Iterables;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
+import org.apache.amoro.utils.TableFileUtil;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataOperations;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.ReachableFileUtil;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Util class for Iceberg table operations in format-iceberg module. */
+public class IcebergTableUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergTableUtil.class);
+
+  private IcebergTableUtil() {}
+
+  public static long getSnapshotId(Table table, boolean refresh) {
+    Snapshot currentSnapshot = getSnapshot(table, refresh);
+    if (currentSnapshot == null) {
+      return Constants.INVALID_SNAPSHOT_ID;
+    } else {
+      return currentSnapshot.snapshotId();
+    }
+  }
+
+  public static Snapshot getSnapshot(Table table, boolean refresh) {
+    if (refresh) {
+      table.refresh();
+    }
+    return table.currentSnapshot();
+  }
+
+  public static Optional<Snapshot> findFirstMatchSnapshot(
+      Table table, Predicate<Snapshot> predicate) {
+    List<Snapshot> snapshots = Lists.newArrayList(table.snapshots());
+    Collections.reverse(snapshots);
+    return Optional.ofNullable(Iterables.tryFind(snapshots, predicate).orNull());
+  }
+
+  /**
+   * Find the latest optimizing snapshot in the table.
+   *
+   * @param table the Iceberg table
+   * @return Optional snapshot
+   */
+  public static Optional<Snapshot> findLatestOptimizingSnapshot(Table table) {
+    return IcebergTableUtil.findFirstMatchSnapshot(
+        table,
+        snapshot ->
+            snapshot.summary().containsValue("OPTIMIZE")
+                && DataOperations.REPLACE.equals(snapshot.operation()));
+  }
+
+  public static Set<String> getAllContentFilePath(Table internalTable) {
+    Set<String> validFilesPath = new HashSet<>();
+
+    TableEntriesScan entriesScan =
+        TableEntriesScan.builder(internalTable)
+            .includeFileContent(
+                FileContent.DATA, FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES)
+            .allEntries()
+            .build();
+    try (CloseableIterable<IcebergFileEntry> entries = entriesScan.entries()) {
+      for (IcebergFileEntry entry : entries) {
+        validFilesPath.add(TableFileUtil.getUriPath(entry.getFile().path().toString()));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    return validFilesPath;
+  }
+
+  public static Set<String> getAllStatisticsFilePath(Table table) {
+    return ReachableFileUtil.statisticsFilesLocations(table).stream()
+        .map(TableFileUtil::getUriPath)
+        .collect(Collectors.toSet());
+  }
+
+  public static Set<DeleteFile> getDanglingDeleteFiles(Table internalTable) {
+    if (internalTable.currentSnapshot() == null) {
+      return Collections.emptySet();
+    }
+    long snapshotId = internalTable.currentSnapshot().snapshotId();
+    Set<String> deleteFilesPath = new HashSet<>();
+    TableScan tableScan = internalTable.newScan().useSnapshot(snapshotId);
+    try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
+      for (FileScanTask fileScanTask : fileScanTasks) {
+        for (DeleteFile delete : fileScanTask.deletes()) {
+          deleteFilesPath.add(delete.path().toString());
+        }
+      }
+    } catch (IOException e) {
+      LOG.error("table scan plan files error", e);
+      return Collections.emptySet();
+    }
+
+    Set<DeleteFile> danglingDeleteFiles = new HashSet<>();
+    TableEntriesScan entriesScan =
+        TableEntriesScan.builder(internalTable)
+            .useSnapshot(snapshotId)
+            .includeFileContent(FileContent.EQUALITY_DELETES, FileContent.POSITION_DELETES)
+            .build();
+    try (CloseableIterable<IcebergFileEntry> entries = entriesScan.entries()) {
+      for (IcebergFileEntry entry : entries) {
+        ContentFile<?> file = entry.getFile();
+        String path = file.path().toString();
+        if (!deleteFilesPath.contains(path)) {
+          danglingDeleteFiles.add((DeleteFile) file);
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Error when fetch iceberg entries", e);
+    }
+
+    return danglingDeleteFiles;
+  }
+
+  /**
+   * Fetch all manifest files of an Iceberg Table.
+   *
+   * @param table An iceberg table, or maybe base store or change store of mixed-iceberg format.
+   * @return Path set of all valid manifest files.
+   */
+  public static Set<String> getAllManifestFiles(Table table) {
+    TableOperations ops = ((HasTableOperations) table).operations();
+
+    Table allManifest =
+        MetadataTableUtils.createMetadataTableInstance(
+            ops,
+            table.name(),
+            table.name() + "#" + MetadataTableType.ALL_MANIFESTS.name(),
+            MetadataTableType.ALL_MANIFESTS);
+
+    Set<String> allManifestFiles =
+        Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap());
+    TableScan scan = allManifest.newScan().select("path");
+
+    CloseableIterable<FileScanTask> tasks = scan.planFiles();
+    CloseableIterable<CloseableIterable<StructLike>> transform =
+        CloseableIterable.transform(tasks, task -> task.asDataTask().rows());
+
+    try (CloseableIterable<StructLike> rows = CloseableIterable.concat(transform)) {
+      rows.forEach(r -> allManifestFiles.add(r.get(0, String.class)));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return allManifestFiles;
+  }
+}

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/RollingFileCleaner.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/RollingFileCleaner.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.formats.iceberg.utils;
+
+import org.apache.amoro.io.AuthenticatedFileIO;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Sets;
+import org.apache.amoro.utils.TableFileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Rolling file cleaner for Iceberg table maintenance operations. */
+public class RollingFileCleaner {
+  private final Set<String> collectedFiles = Sets.newConcurrentHashSet();
+  private final Set<String> excludeFiles;
+  private final Set<String> parentDirectories = Sets.newConcurrentHashSet();
+
+  private static final int CLEANED_FILE_GROUP_SIZE = 1_000;
+
+  private final AtomicInteger fileCounter = new AtomicInteger(0);
+  private final AtomicInteger cleanedFileCounter = new AtomicInteger(0);
+
+  private final AuthenticatedFileIO fileIO;
+
+  private static final Logger LOG = LoggerFactory.getLogger(RollingFileCleaner.class);
+
+  public RollingFileCleaner(AuthenticatedFileIO fileIO, Set<String> excludeFiles) {
+    this.fileIO = fileIO;
+    this.excludeFiles =
+        excludeFiles != null
+            ? Sets.newConcurrentHashSet(excludeFiles)
+            : Sets.newConcurrentHashSet();
+  }
+
+  public void addFile(String filePath) {
+    if (isFileExcluded(filePath)) {
+      LOG.debug("File {} is excluded from cleaning", filePath);
+      return;
+    }
+
+    collectedFiles.add(filePath);
+    String parentDir = TableFileUtil.getParent(filePath);
+    parentDirectories.add(parentDir);
+    int currentCount = fileCounter.incrementAndGet();
+
+    if (currentCount % CLEANED_FILE_GROUP_SIZE == 0) {
+      doCleanFiles();
+    }
+  }
+
+  private boolean isFileExcluded(String filePath) {
+    if (excludeFiles.isEmpty()) {
+      return false;
+    }
+
+    if (excludeFiles.contains(filePath)) {
+      return true;
+    }
+
+    String uriPath = URI.create(filePath).getPath();
+    if (excludeFiles.contains(uriPath)) {
+      return true;
+    }
+
+    String parentPath = new Path(uriPath).getParent().toString();
+    return excludeFiles.contains(parentPath);
+  }
+
+  private void doCleanFiles() {
+    if (collectedFiles.isEmpty()) {
+      return;
+    }
+
+    if (fileIO.supportBulkOperations()) {
+      try {
+        fileIO.asBulkFileIO().deleteFiles(collectedFiles);
+        cleanedFileCounter.addAndGet(collectedFiles.size());
+      } catch (BulkDeletionFailureException e) {
+        LOG.warn("Failed to delete {} expired files in bulk", e.numberFailedObjects());
+      }
+    } else {
+      for (String filePath : collectedFiles) {
+        try {
+          fileIO.deleteFile(filePath);
+          cleanedFileCounter.incrementAndGet();
+        } catch (Exception e) {
+          LOG.warn("Failed to delete expired file: {}", filePath, e);
+        }
+      }
+    }
+    // Try to delete empty parent directories
+    for (String parentDir : parentDirectories) {
+      TableFileUtil.deleteEmptyDirectory(fileIO, parentDir, excludeFiles);
+    }
+    parentDirectories.clear();
+
+    LOG.debug("Cleaned expired a file group, total files: {}", collectedFiles.size());
+
+    collectedFiles.clear();
+  }
+
+  public int fileCount() {
+    return fileCounter.get();
+  }
+
+  public int cleanedFileCount() {
+    return cleanedFileCounter.get();
+  }
+
+  public void clear() {
+    if (!collectedFiles.isEmpty()) {
+      doCleanFiles();
+    }
+
+    collectedFiles.clear();
+    excludeFiles.clear();
+  }
+}


### PR DESCRIPTION
[AMORO-4022] [Improvement]: AMS Iceberg maintainer moved to the amoro-iceberg module (#4022)

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #4022 .

## Brief change log

- TableMaintainer interface remove to amoro-common
- Add TableMaintainerContext、MaintainerMetrics、OptimizingInfo interface
- Impl DefaultTableMaintainerContext
- MixedTableMaintainer & IcebergTableMaintainer remove to amoro-iceberg
- Iceberg Maintainer Test from ams move to amoro-iceberg (executor can't remove to amoro-iceberg,execute in ams and tests)


## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
