### PR TITLE
[AMORO-4027] Bump shade plugin to fix compilation failure on JDK 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-        <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
         <maven-scala-plugin.version>4.8.1</maven-scala-plugin.version>
         <maven-antlr4-plugin.version>4.3</maven-antlr4-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>


### PR DESCRIPTION

## Why are the changes needed?
Fix compilation failure on JDK 17
The latest version is 3.6.1,  Maybe It's fixed in 3.3.0
https://github.com/apache/maven-shade-plugin/issues/655

Close #4027.

## Brief change log
Bump shade plugin from 3.2.4 to 3.6.1


