### PR TITLE
Fixed the issue where the process table was completed after AMS restart, but the table status remained in the running state.

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -141,9 +141,6 @@ public class OptimizingQueue extends PersistentBase {
               mapper -> mapper.getProcessState(tableRuntime.getProcessId()));
       process = new TableOptimizingProcess(tableRuntime, meta, state);
       tableRuntime.recover(process);
-      if (process.getStatus() == ProcessStatus.SUCCESS) {
-        tableRuntime.completeProcess(true);
-      }
     }
 
     if (tableRuntime.getOptimizingConfig().isEnabled()) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -32,6 +32,7 @@ import org.apache.amoro.optimizing.TableRuntimeOptimizingState;
 import org.apache.amoro.optimizing.plan.AbstractOptimizingEvaluator;
 import org.apache.amoro.process.AmoroProcess;
 import org.apache.amoro.process.ProcessFactory;
+import org.apache.amoro.process.ProcessStatus;
 import org.apache.amoro.process.TableProcessStore;
 import org.apache.amoro.server.AmoroServiceConstants;
 import org.apache.amoro.server.optimizing.OptimizingProcess;
@@ -118,6 +119,9 @@ public class DefaultTableRuntime extends AbstractTableRuntime
       throw new IllegalStateException("Table runtime and processing are not matched!");
     }
     this.optimizingProcess = optimizingProcess;
+    if (this.optimizingProcess.getStatus() == ProcessStatus.SUCCESS) {
+      completeProcess(true);
+    }
   }
 
   @Override


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #4041.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Initialize the TableOptimizingProcess to retrieve the Process Status from the database instead of using the default RUNNING status.
- In the initTableRuntime, determine whether the Process Status is successful. If successful, perform the complete process operation.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
