### PR TITLE
[Hotfix] Fetch the latest MemoryUsage inside each gauge call

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/AmsServiceMetrics.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/AmsServiceMetrics.java
@@ -30,7 +30,7 @@ import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryUsage;
+import java.lang.management.MemoryMXBean;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -108,16 +108,21 @@ public class AmsServiceMetrics {
   }
 
   private void registerHeapMetric() {
-    MemoryUsage heapMemoryUsage = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
+    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
     registerMetric(
-        registry, AMS_JVM_MEMORY_HEAP_USED, (Gauge<Long>) () -> heapMemoryUsage.getUsed());
+        registry,
+        AMS_JVM_MEMORY_HEAP_USED,
+        (Gauge<Long>) () -> memoryMXBean.getHeapMemoryUsage().getUsed());
 
     registerMetric(
         registry,
         AMS_JVM_MEMORY_HEAP_COMMITTED,
-        (Gauge<Long>) () -> heapMemoryUsage.getCommitted());
+        (Gauge<Long>) () -> memoryMXBean.getHeapMemoryUsage().getCommitted());
 
-    registerMetric(registry, AMS_JVM_MEMORY_HEAP_MAX, (Gauge<Long>) () -> heapMemoryUsage.getMax());
+    registerMetric(
+        registry,
+        AMS_JVM_MEMORY_HEAP_MAX,
+        (Gauge<Long>) () -> memoryMXBean.getHeapMemoryUsage().getMax());
   }
 
   private void registerThreadMetric() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->


## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

The registerHeapMetric method only reads the JVM heap usage once at registration time and then reuses that snapshot inside the gauges, which causes the heap metrics to never change after being registered.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
