### PR TITLE
[AMORO-4063] Fix missing S3 AK/SK in Apache Paimon format

### DIFF
--- a/amoro-common/src/main/java/org/apache/amoro/table/TableMetaStore.java
+++ b/amoro-common/src/main/java/org/apache/amoro/table/TableMetaStore.java
@@ -127,6 +127,7 @@ public class TableMetaStore implements Serializable {
   private final boolean disableAuth;
   private final String accessKey;
   private final String secretKey;
+  private final String storageType;
 
   private transient RuntimeContext runtimeContext;
   private transient String authInformation;
@@ -146,6 +147,7 @@ public class TableMetaStore implements Serializable {
       String krbPrincipal,
       String accessKey,
       String secretKey,
+      String storageType,
       boolean disableAuth) {
     Preconditions.checkArgument(
         authMethod == null
@@ -165,6 +167,7 @@ public class TableMetaStore implements Serializable {
     this.disableAuth = disableAuth;
     this.accessKey = accessKey;
     this.secretKey = secretKey;
+    this.storageType = storageType;
   }
 
   private TableMetaStore(Configuration configuration) {
@@ -179,6 +182,7 @@ public class TableMetaStore implements Serializable {
     this.krbPrincipal = null;
     this.accessKey = null;
     this.secretKey = null;
+    this.storageType = null;
     this.runtimeContext = new RuntimeContext();
     runtimeContext.setConfiguration(configuration);
   }
@@ -217,6 +221,10 @@ public class TableMetaStore implements Serializable {
 
   public String getSecretKey() {
     return secretKey;
+  }
+
+  public String getStorageType() {
+    return storageType;
   }
 
   public boolean isKerberosAuthMethod() {
@@ -586,6 +594,7 @@ public class TableMetaStore implements Serializable {
     private String krbPrincipal;
     private String accessKey;
     private String secretKey;
+    private String storageType;
     private boolean disableAuth = true;
     private final Map<String, String> properties = Maps.newHashMap();
     private Configuration configuration;
@@ -640,11 +649,12 @@ public class TableMetaStore implements Serializable {
       return this;
     }
 
-    public Builder withAkSkAuth(String accessKey, String secretKey) {
+    public Builder withAkSkAuth(String accessKey, String secretKey, String storageType) {
       this.disableAuth = false;
       this.authMethod = AUTH_METHOD_AK_SK;
       this.accessKey = accessKey;
       this.secretKey = secretKey;
+      this.storageType = storageType;
       return this;
     }
 
@@ -785,6 +795,7 @@ public class TableMetaStore implements Serializable {
         } else if (AUTH_METHOD_AK_SK.equals(authMethod)) {
           Preconditions.checkNotNull(accessKey);
           Preconditions.checkNotNull(secretKey);
+          Preconditions.checkNotNull(storageType);
         } else if (authMethod != null) {
           throw new IllegalArgumentException("Unsupported auth method:" + authMethod);
         }
@@ -805,6 +816,7 @@ public class TableMetaStore implements Serializable {
             krbPrincipal,
             accessKey,
             secretKey,
+            storageType,
             disableAuth);
       }
     }

--- a/amoro-common/src/main/java/org/apache/amoro/utils/CatalogUtil.java
+++ b/amoro-common/src/main/java/org/apache/amoro/utils/CatalogUtil.java
@@ -168,7 +168,9 @@ public class CatalogUtil {
               authType)) {
             String accessKey = authConfigs.get(CatalogMetaProperties.AUTH_CONFIGS_KEY_ACCESS_KEY);
             String secretKey = authConfigs.get(CatalogMetaProperties.AUTH_CONFIGS_KEY_SECRET_KEY);
-            builder.withAkSkAuth(accessKey, secretKey);
+            String storageType =
+                catalogMeta.getStorageConfigs().get(CatalogMetaProperties.STORAGE_CONFIGS_KEY_TYPE);
+            builder.withAkSkAuth(accessKey, secretKey, storageType);
           }
         }
       }
@@ -204,7 +206,9 @@ public class CatalogUtil {
               catalogMeta
                   .getCatalogProperties()
                   .get(CatalogMetaProperties.AUTH_CONFIGS_KEY_SECRET_KEY);
-          builder.withAkSkAuth(accessKey, secretKey);
+          String storageType =
+              catalogMeta.getStorageConfigs().get(CatalogMetaProperties.STORAGE_CONFIGS_KEY_TYPE);
+          builder.withAkSkAuth(accessKey, secretKey, storageType);
         }
       }
     }

--- a/amoro-format-paimon/src/main/java/org/apache/amoro/formats/paimon/PaimonCatalogFactory.java
+++ b/amoro-format-paimon/src/main/java/org/apache/amoro/formats/paimon/PaimonCatalogFactory.java
@@ -63,7 +63,8 @@ public class PaimonCatalogFactory implements FormatCatalogFactory {
                 HiveCatalogOptions.HIVE_CONF_DIR.key(), new File(url.getPath()).getParent()));
     if (CatalogMetaProperties.AUTH_CONFIGS_VALUE_TYPE_AK_SK.equalsIgnoreCase(
         metaStore.getAuthMethod())) {
-      if (CatalogMetaProperties.STORAGE_CONFIGS_VALUE_TYPE_S3.equals(metastoreType)) {
+      if (CatalogMetaProperties.STORAGE_CONFIGS_VALUE_TYPE_S3.equalsIgnoreCase(
+          metaStore.getStorageType())) {
         // s3.access-key, s3.secret-key
         catalogProperties.put(PAIMON_S3_ACCESS_KEY, metaStore.getAccessKey());
         catalogProperties.put(PAIMON_S3_SECRET_KEY, metaStore.getSecretKey());


### PR DESCRIPTION
fix #4063 

add storageType to fix s3.access-key, s3.secret-key in PaimonCatalogFactory
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #xxx.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->



## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

<img width="1637" height="969" alt="image" src="https://github.com/user-attachments/assets/db25a50f-9439-4762-ae07-e58b87d77bdd" />


## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
