### PR TITLE
[Hotfix] Add missing ams-optimizing-uri to Kubernetes optimizer container Helm template

### DIFF
--- a/charts/amoro/templates/_optimizer.tpl
+++ b/charts/amoro/templates/_optimizer.tpl
@@ -131,6 +131,7 @@ properties:
 {{- define "amoro.optimizer.container.kubernetes" -}}
 container-impl: org.apache.amoro.server.manager.KubernetesOptimizerContainer
 properties:
+  ams-optimizing-uri: {{include "amoro.svc.optimizing.uri" . | quote}}
   {{- with .Values.optimizer.kubernetes.properties -}}
     {{- toYaml . | nindent 2 }}
   {{- end -}}


### PR DESCRIPTION
## Why are the changes needed?

When using `KubernetesOptimizerContainer`, the Helm chart template for the Kubernetes optimizer is missing the `ams-optimizing-uri` property. This causes the optimizer to fall back to `server-expose-host` which is hardcoded to `127.0.0.1` in the ConfigMap, resulting in optimizer pods failing to connect to the AMS optimizing service.

Both the Flink and Spark optimizer templates already include `ams-optimizing-uri`, but the Kubernetes optimizer template does not.

## Brief change log

- Added `ams-optimizing-uri` property to the `amoro.optimizer.container.kubernetes` template in `charts/amoro/templates/_optimizer.tpl`, using the same `amoro.svc.optimizing.uri` helper that Flink and Spark templates use.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

Verified that the rendered Helm template now includes the correct `ams-optimizing-uri` value (`thrift://{release}-optimizing.{namespace}.svc.{clusterDomain}:1261`) for the Kubernetes optimizer container.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
