### PR TITLE
[Hotfix] Fix uninitialized OPTIMIZER_LOG_CONF_FILE causing Log4j parsing error

### DIFF
--- a/dist/src/main/amoro-bin/bin/optimizer.sh
+++ b/dist/src/main/amoro-bin/bin/optimizer.sh
@@ -21,6 +21,10 @@ CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 . $CURRENT_DIR/load-config.sh
 
+if [ -z "$OPTIMIZER_LOG_CONF_FILE" ]; then
+    export OPTIMIZER_LOG_CONF_FILE="${AMORO_CONF_DIR}/optimize/log4j2.xml"
+fi
+
 LIB_PATH=$AMORO_HOME/lib
 export CLASSPATH=$AMORO_CONF_DIR/optimize:$LIB_PATH/:$(find $LIB_PATH/ -type f -name "*.jar" | paste -sd':' -)
 if [ -z "$(find $LIB_PATH/ -type f -name "*.jar" | paste -sd':' -)" ]; then


### PR DESCRIPTION
## Why are the changes needed?

When starting the optimizer, Log4j throws a parsing error:
```
ERROR StatusLogger Error parsing /usr/local/amoro/conf/optimize
org.xml.sax.SAXParseException; Content is not allowed in prolog.
```

The root cause is that `OPTIMIZER_LOG_CONF_FILE` variable is used in `optimizer.sh` but never initialized. When the variable is empty, Log4j falls back to CLASSPATH scanning and attempts to parse the `conf/optimize` directory as an XML file, causing the SAXParseException.

## Brief change log

- Initialize `OPTIMIZER_LOG_CONF_FILE` variable in `dist/src/main/amoro-bin/bin/optimizer.sh` to point to `${AMORO_CONF_DIR}/optimize/log4j2.xml`

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
