### PR TITLE
[Hotfix] Fix incorrect Last Commit Time showing year 58000+ in partition view

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/MixedAndIcebergTableDescriptor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/MixedAndIcebergTableDescriptor.java
@@ -553,7 +553,9 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
             // This will be updated once Iceberg supports reporting delete file sizes.
             // See: https://github.com/apache/iceberg/issues/14803
             partitionInfo.setFileSize(totalDataFileSize != null ? totalDataFileSize : 0L);
-            partitionInfo.setLastCommitTime(lastUpdatedAt != null ? lastUpdatedAt : 0L);
+            // last_updated_at from Iceberg PARTITIONS metadata table is in microseconds,
+            // convert to milliseconds for consistency with snapshot.timestampMillis()
+            partitionInfo.setLastCommitTime(lastUpdatedAt != null ? lastUpdatedAt / 1000 : 0L);
 
             partitions.add(partitionInfo);
           }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/TestIcebergServerTableDescriptor.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/TestIcebergServerTableDescriptor.java
@@ -107,15 +107,20 @@ public class TestIcebergServerTableDescriptor extends TestServerTableDescriptor 
     Assert.assertEquals("Should have 1 file total", 1, totalFiles);
 
     // Verify we used PARTITIONS metadata table which provides fileSize and lastCommitTime
+    // Year 2100 in milliseconds - any reasonable timestamp must be below this
+    long year2100InMillis = 4102444800000L;
     for (org.apache.amoro.table.descriptor.PartitionBaseInfo partition : partitions) {
       // File size should be available from PARTITIONS metadata table
       Assert.assertTrue(
           "FileSize should be available from PARTITIONS metadata table",
           partition.getFileSize() >= 0);
-      // Last commit time should be available from PARTITIONS metadata table
+      // Last commit time should be available and in milliseconds (not microseconds)
+      Assert.assertTrue("LastCommitTime should be positive", partition.getLastCommitTime() > 0);
       Assert.assertTrue(
-          "LastCommitTime should be available from PARTITIONS metadata table",
-          partition.getLastCommitTime() >= 0);
+          "LastCommitTime should be in milliseconds, not microseconds (got "
+              + partition.getLastCommitTime()
+              + ")",
+          partition.getLastCommitTime() < year2100InMillis);
     }
   }
 


### PR DESCRIPTION
## Why are the changes needed?

The "Last Commit Time" column in the table partition view displays incorrect dates (year ~58000) instead of the actual commit time.

**Root cause:** The `last_updated_at` column from Iceberg's `PARTITIONS` metadata table stores timestamps in **microseconds** since epoch, but the value was passed directly to the frontend which expects **milliseconds**. This 1000x difference causes `new Date()` to interpret the value as a far-future date.

For example:
- Actual microsecond value: `1,770,000,000,000,000`
- Frontend interprets as milliseconds → year ~58,060

Other code paths (e.g., `snapshot.timestampMillis()` used in file list and fallback partition scan) correctly return milliseconds, so only the `PARTITIONS` metadata table path was affected.

## Brief change log

- `MixedAndIcebergTableDescriptor#collectPartitionsFromTable`: Divide `last_updated_at` by 1000 to convert microseconds to milliseconds before setting `lastCommitTime`
- `TestIcebergServerTableDescriptor#testGetTablePartitions`: Add assertion to verify `lastCommitTime` is in milliseconds range (below year 2100)

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)