### PR TITLE
[Hotfix] Fix CI Docker API compatibility for Testcontainers

### DIFF
--- a/amoro-ams/pom.xml
+++ b/amoro-ams/pom.xml
@@ -450,14 +450,14 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.17.2</version>
+            <version>1.20.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.17.2</version>
+            <version>1.20.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -478,7 +478,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
-            <version>1.19.6</version>
+            <version>1.20.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/amoro-ams/src/test/resources/docker-java.properties
+++ b/amoro-ams/src/test/resources/docker-java.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+api.version=1.44

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/resources/docker-java.properties
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/resources/docker-java.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+api.version=1.44

--- a/dev/deps/dependencies-hadoop-2-spark-3.3
+++ b/dev/deps/dependencies-hadoop-2-spark-3.3
@@ -78,8 +78,9 @@ eclipse-collections-api/11.1.0//eclipse-collections-api-11.1.0.jar
 eclipse-collections/11.1.0//eclipse-collections-11.1.0.jar
 ehcache/3.3.1//ehcache-3.3.1.jar
 endpoints-spi/2.24.12//endpoints-spi-2.24.12.jar
-error_prone_annotations/2.10.0//error_prone_annotations-2.10.0.jar
+error_prone_annotations/2.18.0//error_prone_annotations-2.18.0.jar
 eventstream/1.0.1//eventstream-1.0.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
 flatbuffers-java/23.5.26//flatbuffers-java-23.5.26.jar
 flink-annotations/1.20.3//flink-annotations-1.20.3.jar
 flink-clients/1.20.3//flink-clients-1.20.3.jar
@@ -105,7 +106,7 @@ flink-streaming-java/1.20.3//flink-streaming-java-1.20.3.jar
 geronimo-jcache_1.0_spec/1.0-alpha-1//geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 glue/2.24.12//glue-2.24.12.jar
 gson/2.8.6//gson-2.8.6.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/32.1.1-jre//guava-32.1.1-jre.jar
 hadoop-annotations/2.10.2//hadoop-annotations-2.10.2.jar
 hadoop-auth/2.10.2//hadoop-auth-2.10.2.jar
 hadoop-aws/2.10.2//hadoop-aws-2.10.2.jar
@@ -162,6 +163,7 @@ iceberg-spark-extensions-3.3_2.12/1.6.1//iceberg-spark-extensions-3.3_2.12-1.6.1
 icu4j/69.1//icu4j-69.1.jar
 identity-spi/2.24.12//identity-spi-2.24.12.jar
 ivy/2.5.1//ivy-2.5.1.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jackson-annotations/2.14.2//jackson-annotations-2.14.2.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.14.2//jackson-core-2.14.2.jar
@@ -282,6 +284,7 @@ kyuubi-hive-jdbc-shaded/1.10.2//kyuubi-hive-jdbc-shaded-1.10.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.9.3//libthrift-0.9.3.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
 log4j-api/2.20.0//log4j-api-2.20.0.jar
 log4j-core/2.20.0//log4j-core-2.20.0.jar


### PR DESCRIPTION
## Why are the changes needed?

GitHub Actions runner updated its Docker engine to Docker 29+, which raised the minimum API version from 1.24 to 1.44. The `docker-java` library used by Testcontainers defaults to API version 1.32, causing `AmoroAMSTest` and Kafka-based Flink tests to fail with:

```
client version 1.32 is too old. Minimum supported API version is 1.44
```

This breaks all CI workflows (Core/hadoop2, Core/hadoop3, Deps, Trino).

See: [testcontainers/testcontainers-java#11210](https://github.com/testcontainers/testcontainers-java/issues/11210)

## Brief change log

- Add `docker-java.properties` with `api.version=1.44` to `amoro-ams` and `amoro-mixed-flink-common` test resources to override docker-java's default API version
- Upgrade Testcontainers in `amoro-ams/pom.xml` from 1.17.2/1.19.6 to 1.20.1 (aligned with existing `k3s` artifact version)
- Update `dev/deps/dependencies-hadoop-2-spark-3.3` to reflect changed transitive dependencies (guava 14.0.1 → 32.1.1-jre, error_prone_annotations 2.10.0 → 2.18.0, added failureaccess, j2objc-annotations, listenablefuture)

> **Note:** Flink modules keep their original Testcontainers versions (1.17.2/1.18.1) to avoid `ContainerDef` class incompatibility with `flink-test-utils-junit`'s transitive `testcontainers:1.18.3`. The `docker-java.properties` approach fixes the Docker API version issue regardless of the Testcontainers version.

## How was this patch tested?

- [x] Verified `AmoroAMSTest` passes with Docker 29+ after adding `docker-java.properties`
- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable