### PR TITLE
[amoro-4088] CI fail in GitHub Actions due to outdated Docker API version

### DIFF
--- a/.github/workflows/core-hadoop2-ci.yml
+++ b/.github/workflows/core-hadoop2-ci.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Docker for Testcontainers
+        uses: ./.github/workflows/setup-docker-java
+
       - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/core-hadoop3-ci.yml
+++ b/.github/workflows/core-hadoop3-ci.yml
@@ -43,6 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Docker for Testcontainers
+        uses: ./.github/workflows/setup-docker-java
+
       - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/setup-docker-java/action.yml
+++ b/.github/workflows/setup-docker-java/action.yml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Setup Docker Java'
+description: 'Fix docker-java API version for Testcontainers'
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Docker version info'
+      shell: bash
+      run: |
+        docker version
+        docker info
+
+    # Workaround: Docker Engine 29+ requires API ≥ 1.44, but docker-java
+    # (used by Testcontainers) negotiates with 1.32 which gets rejected.
+    # docker-java reads ~/.docker-java.properties at startup.
+    # Remove this step once Testcontainers ships a docker-java version
+    # that negotiates properly (track: https://github.com/testcontainers/testcontainers-java/issues/11212)
+    - name: Fix docker-java API version for Testcontainers
+      shell: bash
+      run: |
+        mkdir -p $HOME
+        echo "api.version=1.44" > $HOME/.docker-java.properties
+        cat $HOME/.docker-java.properties

--- a/amoro-ams/pom.xml
+++ b/amoro-ams/pom.xml
@@ -450,14 +450,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -471,14 +469,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>k3s</artifactId>
-            <version>1.20.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
-            <version>1.19.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-iceberg-bridge/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-iceberg-bridge/pom.xml
@@ -32,7 +32,6 @@
 
     <properties>
         <assertj.version>3.21.0</assertj.version>
-        <testcontainers.version>1.18.1</testcontainers.version>
         <flink.version>1.18.1</flink.version>
     </properties>
 
@@ -327,14 +326,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
@@ -34,7 +34,6 @@
 
     <properties>
         <assertj.version>3.21.0</assertj.version>
-        <testcontainers.version>1.18.1</testcontainers.version>
         <flink.version>1.18.1</flink.version>
     </properties>
 
@@ -394,14 +393,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/amoro-format-mixed/amoro-mixed-flink/v1.16/amoro-mixed-flink-1.16/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.16/amoro-mixed-flink-1.16/pom.xml
@@ -36,7 +36,6 @@
         <iceberg.version>1.4.3</iceberg.version>
         <kafka.version>3.2.3</kafka.version>
         <assertj.version>3.21.0</assertj.version>
-        <testcontainers.version>1.17.2</testcontainers.version>
         <flink.version>1.16.3</flink.version>
     </properties>
 

--- a/amoro-format-mixed/amoro-mixed-flink/v1.17/amoro-mixed-flink-1.17/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.17/amoro-mixed-flink-1.17/pom.xml
@@ -35,7 +35,6 @@
     <properties>
         <kafka.version>3.2.3</kafka.version>
         <assertj.version>3.21.0</assertj.version>
-        <testcontainers.version>1.17.2</testcontainers.version>
         <flink.version>1.17.2</flink.version>
     </properties>
 

--- a/amoro-format-mixed/amoro-mixed-flink/v1.18/amoro-mixed-flink-1.18/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.18/amoro-mixed-flink-1.18/pom.xml
@@ -35,7 +35,6 @@
     <properties>
         <kafka.version>3.2.3</kafka.version>
         <assertj.version>3.21.0</assertj.version>
-        <testcontainers.version>1.18.1</testcontainers.version>
         <flink.version>1.18.1</flink.version>
     </properties>
 

--- a/dev/deps/dependencies-hadoop-2-spark-3.3
+++ b/dev/deps/dependencies-hadoop-2-spark-3.3
@@ -78,8 +78,9 @@ eclipse-collections-api/11.1.0//eclipse-collections-api-11.1.0.jar
 eclipse-collections/11.1.0//eclipse-collections-11.1.0.jar
 ehcache/3.3.1//ehcache-3.3.1.jar
 endpoints-spi/2.24.12//endpoints-spi-2.24.12.jar
-error_prone_annotations/2.10.0//error_prone_annotations-2.10.0.jar
+error_prone_annotations/2.18.0//error_prone_annotations-2.18.0.jar
 eventstream/1.0.1//eventstream-1.0.1.jar
+failureaccess/1.0.1//failureaccess-1.0.1.jar
 flatbuffers-java/23.5.26//flatbuffers-java-23.5.26.jar
 flink-annotations/1.20.3//flink-annotations-1.20.3.jar
 flink-clients/1.20.3//flink-clients-1.20.3.jar
@@ -105,7 +106,7 @@ flink-streaming-java/1.20.3//flink-streaming-java-1.20.3.jar
 geronimo-jcache_1.0_spec/1.0-alpha-1//geronimo-jcache_1.0_spec-1.0-alpha-1.jar
 glue/2.24.12//glue-2.24.12.jar
 gson/2.8.6//gson-2.8.6.jar
-guava/14.0.1//guava-14.0.1.jar
+guava/32.1.1-jre//guava-32.1.1-jre.jar
 hadoop-annotations/2.10.2//hadoop-annotations-2.10.2.jar
 hadoop-auth/2.10.2//hadoop-auth-2.10.2.jar
 hadoop-aws/2.10.2//hadoop-aws-2.10.2.jar
@@ -162,6 +163,7 @@ iceberg-spark-extensions-3.3_2.12/1.6.1//iceberg-spark-extensions-3.3_2.12-1.6.1
 icu4j/69.1//icu4j-69.1.jar
 identity-spi/2.24.12//identity-spi-2.24.12.jar
 ivy/2.5.1//ivy-2.5.1.jar
+j2objc-annotations/2.8//j2objc-annotations-2.8.jar
 jackson-annotations/2.14.2//jackson-annotations-2.14.2.jar
 jackson-core-asl/1.9.13//jackson-core-asl-1.9.13.jar
 jackson-core/2.14.2//jackson-core-2.14.2.jar
@@ -282,6 +284,7 @@ kyuubi-hive-jdbc-shaded/1.10.2//kyuubi-hive-jdbc-shaded-1.10.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.9.3//libthrift-0.9.3.jar
+listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
 log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
 log4j-api/2.20.0//log4j-api-2.20.0.jar
 log4j-core/2.20.0//log4j-core-2.20.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1281,6 +1281,14 @@
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.21.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Why are the changes needed?
The integration tests (specifically AmoroAMSTest) are failing in the GitHub Actions environment. The error log indicates that Testcontainers is attempting to use Docker API version 1.32, which is no longer supported by the Docker daemon in the current GitHub Runner environment. The runner now requires a minimum API version of 1.44.

Close #4088.

## Brief change log
- Added a "Setup Docker for Testcontainers" step to manually configure the Docker API version (1.44), addressing compatibility issues with newer Docker Engines.
- Standardized all org.testcontainers dependencies by introducing the Testcontainers BOM to ensure version consistency across all modules.

- Ref: [alfredorueda/HexaStock@c90898c](https://github.com/alfredorueda/HexaStock/commit/c90898cca66a30a47b5e4f8bdda5d321ba5c6f27)

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not documented
