### PR TITLE
[Hotfix] Add LDAP login configuration options for Dashboard deployment

### DIFF
--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -70,6 +70,13 @@ data:
       http-server:
         rest-auth-type: {{ .Values.server.rest.restAuthType }}
         bind-port: {{ .Values.server.rest.port }}
+        login-auth-provider: {{ .Values.amoroConf.ams.loginAuthProvider | quote }}
+        {{- if .Values.amoroConf.ams.loginAuthLdap.url }}
+        login-auth-ldap-url: {{ .Values.amoroConf.ams.loginAuthLdap.url | quote }}
+        {{- end }}
+        {{- if .Values.amoroConf.ams.loginAuthLdap.userPattern }}
+        login-auth-ldap-user-pattern: {{ .Values.amoroConf.ams.loginAuthLdap.userPattern | quote }}
+        {{- end }}
 
       refresh-external-catalogs:
         interval: 3min # 180000

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -143,6 +143,12 @@ amoroConf:
   ams:
     adminUsername: admin
     adminPassword: admin
+    loginAuthProvider: org.apache.amoro.server.authentication.DefaultPasswdAuthenticationProvider
+    ## LDAP login settings (only used when loginAuthProvider is
+    ## org.apache.amoro.server.authentication.LdapPasswdAuthenticationProvider)
+    loginAuthLdap:
+      url: ~
+      userPattern: ~
 
   ## AMS config shade properties
   ##

--- a/dist/src/main/amoro-bin/conf/config.yaml
+++ b/dist/src/main/amoro-bin/conf/config.yaml
@@ -35,6 +35,11 @@ ams:
     session-timeout: 7d
     bind-port: 1630
     rest-auth-type: token
+    login-auth-provider: org.apache.amoro.server.authentication.DefaultPasswdAuthenticationProvider
+    # To enable dashboard LDAP login, uncomment the following settings:
+    # login-auth-provider: org.apache.amoro.server.authentication.LdapPasswdAuthenticationProvider
+    # login-auth-ldap-url: "ldap://ldap.example.com:389"
+    # login-auth-ldap-user-pattern: "uid={0},ou=people,dc=example,dc=com"
 
   refresh-external-catalogs:
     interval: 3min # 180000

--- a/docs/admin-guides/deployment.md
+++ b/docs/admin-guides/deployment.md
@@ -77,6 +77,8 @@ If you want to use AMS in a production environment, it is recommended to modify 
 - The `ams.http-server.bind-port` configuration specifies the port to which the HTTP service is bound. The Dashboard and Open API are bound to this port, and the default value is 1630.
 - The `ams.http-server.rest-auth-type` configuration specifies the REST API auth type, which could be token(default), basic or jwt (JSON Web Token).
 - The `ams.http-server.auth-basic-provider` configuration specifies the REST API basic authentication provider. By default, it uses `ams.admin-username` and `ams.admin-password` for authentication. You can also specify a custom implementation by providing the fully qualified class name of a class that implements the `org.apache.amoro.authentication.PasswdAuthenticationProvider` interface.
+- The `ams.http-server.login-auth-provider` configuration specifies the Dashboard login authentication provider. By default, it uses `org.apache.amoro.server.authentication.DefaultPasswdAuthenticationProvider` (admin username/password login).
+- To enable LDAP login for Dashboard, set `ams.http-server.login-auth-provider` to `org.apache.amoro.server.authentication.LdapPasswdAuthenticationProvider`, and configure `ams.http-server.login-auth-ldap-url` and `ams.http-server.login-auth-ldap-user-pattern`.
 - The `ams.http-server.auth-jwt-provider` configuration specifies the REST API JWT authentication provider. Set this to the fully qualified class name of your custom provider implementing the `org.apache.amoro.authentication.TokenAuthenticationProvider` interface. This is required when `ams.http-server.rest-auth-type` is set to `jwt`.
 - The `ams.http-server.proxy-client-ip-header` configuration specifies the HTTP header to use for extracting the real client IP address when AMS is deployed behind a reverse proxy (such as Nginx or a load balancer). Common values include `X-Forwarded-For` or `X-Real-IP`. If not set, AMS will use the remote address from the connection.
 
@@ -94,6 +96,11 @@ ams:
   http-server:
     session-timeout: 7d #Re-login after 7days
     bind-port: 1630 #The port for accessing AMS Dashboard.
+    login-auth-provider: org.apache.amoro.server.authentication.DefaultPasswdAuthenticationProvider
+    # Enable LDAP login for Dashboard:
+    # login-auth-provider: org.apache.amoro.server.authentication.LdapPasswdAuthenticationProvider
+    # login-auth-ldap-url: "ldap://ldap.example.com:389"
+    # login-auth-ldap-user-pattern: "uid={0},ou=people,dc=example,dc=com"
 ```
 
 {{< hint info >}}
@@ -337,4 +344,3 @@ Restart AMS with the following commands:
 ```shell
 bin/ams.sh restart
 ```
-


### PR DESCRIPTION
## Why are the changes needed?

The Dashboard login authentication provider could be switched to LDAP, but the deploy-facing configuration surfaces were incomplete.
This made LDAP login setup harder for users deploying with binary config or Helm.

Close #xxx.

## Brief change log

- Add LDAP login settings to `dist` default `config.yaml` comments.
- Add Helm values for LDAP login (`amoroConf.ams.loginAuthLdap.url` and `userPattern`).
- Render LDAP login config keys in Helm `amoro-configmap.yaml` when provided.
- Document LDAP Dashboard login options in deployment guide.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

Notes:
- Verified by local Maven build/package and startup with LDAP configuration.

## Documentation

- Does this pull request introduce a new feature? (yes / no): no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented): not applicable
