### PR TITLE
[AMORO-4113] Do not update snapshot markers on completeProcess(false)

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -385,8 +385,11 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
         .updateState(
             OPTIMIZING_STATE_KEY,
             state -> {
-              state.setLastOptimizedSnapshotId(optimizingProcess.getTargetSnapshotId());
-              state.setLastOptimizedChangeSnapshotId(optimizingProcess.getTargetChangeSnapshotId());
+              if (success) {
+                state.setLastOptimizedSnapshotId(optimizingProcess.getTargetSnapshotId());
+                state.setLastOptimizedChangeSnapshotId(
+                    optimizingProcess.getTargetChangeSnapshotId());
+              }
               if (processType == OptimizingType.MINOR) {
                 state.setLastMinorOptimizingTime(optimizingProcess.getPlanTime());
               } else if (processType == OptimizingType.MAJOR) {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
@@ -537,6 +537,79 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     queue.dispose();
   }
 
+  @Test
+  public void testProcessCloseKeepsLastOptimizedSnapshotId() {
+    DefaultTableRuntime tableRuntime = initTableWithFiles();
+    long snapshotIdBeforePlanning = tableRuntime.getLastOptimizedSnapshotId();
+    long changeSnapshotIdBeforePlanning = tableRuntime.getLastOptimizedChangeSnapshotId();
+
+    OptimizingQueue queue = buildOptimizingGroupService(tableRuntime);
+
+    // Poll task to trigger planning → process creation
+    TaskRuntime<?> task = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
+    Assert.assertNotNull(task);
+
+    OptimizingProcess process = tableRuntime.getOptimizingProcess();
+    Assert.assertNotNull(process);
+    Assert.assertEquals(ProcessStatus.RUNNING, process.getStatus());
+
+    // Close process without success (simulates group change / forced termination)
+    process.close(false);
+
+    // lastOptimizedSnapshotId and lastOptimizedChangeSnapshotId should NOT be updated
+    Assert.assertEquals(snapshotIdBeforePlanning, tableRuntime.getLastOptimizedSnapshotId());
+    Assert.assertEquals(
+        changeSnapshotIdBeforePlanning, tableRuntime.getLastOptimizedChangeSnapshotId());
+    Assert.assertEquals(OptimizingStatus.IDLE, tableRuntime.getOptimizingStatus());
+    Assert.assertNull(tableRuntime.getOptimizingProcess());
+    queue.dispose();
+  }
+
+  @Test
+  public void testTableRescheduledAfterProcessClose() {
+    DefaultTableRuntime tableRuntime = initTableWithFiles();
+
+    OptimizingQueue queue = buildOptimizingGroupService(tableRuntime);
+
+    // Poll task to trigger planning → process creation
+    TaskRuntime<?> task = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
+    Assert.assertNotNull(task);
+
+    OptimizingProcess process = tableRuntime.getOptimizingProcess();
+    Assert.assertNotNull(process);
+
+    // Force close instead of commit (simulates group change)
+    process.close(false);
+    Assert.assertEquals(OptimizingStatus.IDLE, tableRuntime.getOptimizingStatus());
+
+    // Verify snapshot marker was not updated — key condition for isTablePending()
+    Assert.assertNotEquals(
+        tableRuntime.getLastOptimizedSnapshotId(), tableRuntime.getCurrentSnapshotId());
+
+    // Simulate setPendingInput() transitioning IDLE → PENDING (done by evaluator in production)
+    tableRuntime
+        .store()
+        .begin()
+        .updateStatusCode(code -> OptimizingStatus.PENDING.getCode())
+        .commit();
+    Assert.assertEquals(OptimizingStatus.PENDING, tableRuntime.getOptimizingStatus());
+
+    // Set minPlanInterval to 0 so the table is immediately eligible for re-planning
+    tableRuntime
+        .store()
+        .begin()
+        .updateTableConfig(
+            config -> config.put(TableProperties.SELF_OPTIMIZING_MIN_PLAN_INTERVAL, "0"))
+        .commit();
+
+    // Build a new queue with the PENDING table — scheduler should NOT skip it
+    queue.dispose();
+    OptimizingQueue queue2 = buildOptimizingGroupService(tableRuntime);
+    TaskRuntime<?> task2 = queue2.pollTask(optimizerThread, MAX_POLLING_TIME);
+    Assert.assertNotNull(task2);
+    queue2.dispose();
+  }
+
   protected DefaultTableRuntime initTableWithFiles() {
     MixedTable mixedTable =
         (MixedTable) tableService().loadTable(serverTableIdentifier()).originalTable();


### PR DESCRIPTION
## Why are the changes needed?

When an optimizing process is closed without success (e.g., optimizer group change, task retry exhaustion), `completeProcess(false)` unconditionally updates `lastOptimizedSnapshotId` and `lastOptimizedChangeSnapshotId`. This causes `SchedulingPolicy.isTablePending()` to return `false`, permanently preventing the table from being re-planned. The table remains stuck in PENDING status until new data arrives.

Close #4113.

## Brief change log

- `DefaultTableRuntime.completeProcess()`: Only update `lastOptimizedSnapshotId` and `lastOptimizedChangeSnapshotId` when `success` is `true`
- `TestOptimizingQueue`: Add `testProcessCloseKeepsLastOptimizedSnapshotId` to verify snapshot markers are preserved on failed process close
- `TestOptimizingQueue`: Add `testTableRescheduledAfterProcessClose` to verify the table can be rescheduled after a forced process close

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable