### PR TITLE
[Security] Disable external entity processing in XML upload to prevent XXE

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/PlatformFileInfoController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/PlatformFileInfoController.java
@@ -27,6 +27,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLInputFactory;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,7 +55,15 @@ public class PlatformFileInfoController {
     // validate xml config
     if (name.toLowerCase().endsWith(".xml")) {
       try {
-        Configuration configuration = new Configuration();
+        // Explicitly disable external entity processing to prevent XXE attacks,
+        // regardless of the underlying XML parser implementation on the classpath.
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        xif.setProperty(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        xif.createXMLStreamReader(new ByteArrayInputStream(bytes)).close();
+
+        Configuration configuration = new Configuration(false);
         configuration.addResource(new ByteArrayInputStream(bytes));
         configuration.setDeprecatedProperties();
       } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When users upload XML configuration files (e.g. `core-site.xml`, `hdfs-site.xml`) via the AMS dashboard, the uploaded bytes are parsed by `Hadoop Configuration.addResource()`. Although the current classpath includes Woodstox (which does not expand external entities by default), this implicit protection is fragile — it can silently break if the dependency is excluded due to a version conflict in the future.

This patch adds explicit XXE protection at the Amoro layer before delegating to Hadoop `Configuration`, ensuring the security guarantee holds regardless of the underlying XML parser implementation on the classpath.

## Why are the changes needed?

Without explicit protection, a malicious user could upload a crafted XML file containing an external entity reference like:

```xml
<?xml version="1.0"?>
<!DOCTYPE foo [
  <!ENTITY xxe SYSTEM "file:///etc/passwd">
]>
<configuration>&xxe;</configuration>
```

If the XXE implicit protection were ever lost (e.g. Woodstox excluded), this could allow:
- Arbitrary local file read from the AMS server
- SSRF (Server-Side Request Forgery) via external URLs in entity references

## How was this patch tested?

Manual testing: uploaded a well-formed XML file (accepted) and an XML file with an external entity reference (rejected with error response).

## Does this PR introduce _any_ user-facing change?

No. Legitimate Hadoop XML configuration files (`core-site.xml`, `hdfs-site.xml`, `hive-site.xml`) do not use external entities. Valid files continue to upload successfully.