### PR TITLE
[Improvement] Rename Maven property jackson.vesion to jackson.version

### DIFF
--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-iceberg-bridge/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common-iceberg-bridge/pom.xml
@@ -275,7 +275,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.vesion}</version>
+            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.vesion}</version>
+            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/amoro-format-mixed/amoro-mixed-flink/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/pom.xml
@@ -50,6 +50,6 @@
         <flink-kafka.version>3.2.0-1.18</flink-kafka.version>
         <kafka.version>3.4.0</kafka.version>
         <gson.version>2.9.0</gson.version>
-        <jackson.vesion>2.10.2</jackson.vesion>
+        <jackson.version>2.10.2</jackson.version>
     </properties>
 </project>


### PR DESCRIPTION
## Why are the changes needed?

Close #4129.

The Maven property `jackson.vesion` is a typo — it should be `jackson.version`. While it doesn't break the build (the property is consistently misspelled), it's confusing for contributors.

## Brief change log

- Renamed `jackson.vesion` to `jackson.version` in `amoro-format-mixed/amoro-mixed-flink/pom.xml` (property definition)
- Updated references in `amoro-mixed-flink-common/pom.xml` and `amoro-mixed-flink-common-iceberg-bridge/pom.xml`

## How was this patch tested?

- [x] Verified no remaining references to `jackson.vesion` via grep
- [ ] Run a lightweight build validation for the affected modules