### PR TITLE
[AMORO-4135][amoro-web] Fix blank duration column for sub-second optimizing durations

### DIFF
--- a/amoro-web/src/utils/index.ts
+++ b/amoro-web/src/utils/index.ts
@@ -93,6 +93,10 @@ export function formatMS2Time(ms: number): string {
   }
 
   // Trim any trailing spaces and return the formatted result
+  // Handle sub-second durations (0 < ms < 1000)
+  if (!result && ms > 0) {
+    return '<1s'
+  }
   return result.trim()
 }
 /**


### PR DESCRIPTION
## Problem

When the backend returns an optimizing duration between `1ms` and `999ms`, the duration column in the Optimizing table page is **blank**.

This happens because `formatMS2Time()` in `amoro-web/src/utils/index.ts` only appends time units whose value is greater than 0. For values smaller than `1000ms`, all units (days/hours/minutes/seconds) are `0` after `Math.floor`, so the formatted result is an empty string.

fix #4135

## Fix Scope

Single file: `amoro-web/src/utils/index.ts`

Added a check after the formatting loop: if the result string is empty but `ms > 0`, return `<1s` instead of an empty string.

```typescript
if (!result && ms > 0) {
  return '<1s'
}
```

## Verification

Tested with `npm run dev:mock` — added a mock record with `duration: 500` and confirmed the duration column displays `<1s`.

**Before (duration: 500ms):** blank cell
**After (duration: 500ms):** `<1s`

<!-- Paste screenshot below -->

### Unit test results

| Input (ms) | Expected | Actual | Result |
|---|---|---|---|
| 0 | `` | `` | ✅ |
| 1 | `<1s` | `<1s` | ✅ |
| 500 | `<1s` | `<1s` | ✅ |
| 999 | `<1s` | `<1s` | ✅ |
| 1000 | `1s` | `1s` | ✅ |
| 1500 | `1s` | `1s` | ✅ |
| 3000 | `3s` | `3s` | ✅ |
| 60000 | `1min` | `1min` | ✅ |
| 61000 | `1min 1s` | `1min 1s` | ✅ |
| 1195501081 | `13d 20h` | `13d 20h` | ✅ |