### PR TITLE
[AMORO-4149]: Remove duplicate iceberg-bundled-guava dependency declaration in amoro-format-iceberg.

### DIFF
--- a/amoro-format-iceberg/pom.xml
+++ b/amoro-format-iceberg/pom.xml
@@ -159,12 +159,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-bundled-guava</artifactId>
-            <version>${iceberg.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
         </dependency>


### PR DESCRIPTION
## Why are the changes needed?

The `amoro-format-iceberg/pom.xml` file contains duplicate declarations of the `iceberg-bundled-guava` dependency at two different locations (lines 98-102 and lines 161-167). This redundancy causes unnecessary clutter in the build configuration and could potentially lead to confusion during maintenance.

Close #4149.

## Brief change log

- Remove the duplicate `iceberg-bundled-guava` dependency declaration (lines 161-167) from `amoro-format-iceberg/pom.xml`
- Keep the first declaration (lines 98-102) which is better organized with other iceberg-related dependencies


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
