### PR TITLE
[Bug] fix the of TestOptimizerGroupKeeper unit test suffers from intermittent failures.

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestOptimizerGroupKeeper.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestOptimizerGroupKeeper.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 @RunWith(Parameterized.class)
 public class TestOptimizerGroupKeeper extends AMSTableTestBase {
@@ -80,7 +81,7 @@ public class TestOptimizerGroupKeeper extends AMSTableTestBase {
   @Before
   public void prepare() throws Exception {
     optimizerRegistrar = registerInfo -> optimizingService().authenticate(registerInfo);
-    setupMockContainer();
+    setupMockContainer(() -> currentGroupName);
   }
 
   @After
@@ -124,9 +125,10 @@ public class TestOptimizerGroupKeeper extends AMSTableTestBase {
   }
 
   /** Setup mock container and inject it into Containers using reflection. */
-  private void setupMockContainer() throws Exception {
+  private void setupMockContainer(Supplier<String> targetGroupNameSupplier) throws Exception {
     MockOptimizerContainer mockContainer =
-        new MockOptimizerContainer(resourceAvailable, scaleOutCallCount, optimizerRegistrar);
+        new MockOptimizerContainer(
+            resourceAvailable, scaleOutCallCount, optimizerRegistrar, targetGroupNameSupplier);
 
     // Use reflection to set isInitialized to true
     DynFields.UnboundField<Boolean> initializedField =
@@ -339,14 +341,17 @@ public class TestOptimizerGroupKeeper extends AMSTableTestBase {
     private final AtomicBoolean resourceAvailable;
     private final AtomicInteger scaleOutCallCount;
     private final Function<OptimizerRegisterInfo, String> optimizerRegistrar;
+    private final Supplier<String> targetGroupNameSupplier;
 
     public MockOptimizerContainer(
         AtomicBoolean resourceAvailable,
         AtomicInteger scaleOutCallCount,
-        Function<OptimizerRegisterInfo, String> optimizerRegistrar) {
+        Function<OptimizerRegisterInfo, String> optimizerRegistrar,
+        Supplier<String> targetGroupNameSupplier) {
       this.resourceAvailable = resourceAvailable;
       this.scaleOutCallCount = scaleOutCallCount;
       this.optimizerRegistrar = optimizerRegistrar;
+      this.targetGroupNameSupplier = targetGroupNameSupplier;
     }
 
     @Override
@@ -354,6 +359,12 @@ public class TestOptimizerGroupKeeper extends AMSTableTestBase {
 
     @Override
     protected Map<String, String> doScaleOut(Resource resource) {
+      String targetGroup = targetGroupNameSupplier != null ? targetGroupNameSupplier.get() : null;
+      if (targetGroup != null && !targetGroup.equals(resource.getGroupName())) {
+        // Stale task from a previously leaked group; silently ignore to prevent cross-test
+        // contamination of scaleOutCallCount via the shared static Containers registry.
+        return Maps.newHashMap();
+      }
       scaleOutCallCount.incrementAndGet();
       if (!resourceAvailable.get()) {
         throw new RuntimeException("No resources available");


### PR DESCRIPTION

## Why are the changes needed?
This issue causes unit tests to fail during compilation.

Close #4151 .

## Brief change log
Pass a `Supplier<String> targetGroupNameSupplier` (which dynamically returns the current `currentGroupName`) to `MockOptimizerContainer`; within `doScaleOut`, filter out residual task invocations belonging to non-target groups to prevent cross-test count pollution.

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
