### PR TITLE
UI/UX: Mock API server enabled in production build masks real error/loading UX

### DIFF
--- a/amoro-web/vite.config.ts
+++ b/amoro-web/vite.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
       logger: false,
       include: 'mock',
       infixName: false,
-      enableProd: true,
+      enableProd: false,
     }),
     createSvgIconsPlugin({
       iconDirs: [path.resolve(process.cwd(), 'src/assets/icons/svg')],


### PR DESCRIPTION
Hi there! 👋

While exploring the codebase, I noticed a minor opportunity for improvement in `amoro-web/vite.config.ts`.

**Context:**
`vitePluginFakeServer` is configured with `enableProd: true`, so mock endpoints can be active in production. This can cause the UI to always receive successful mocked data, hiding real backend latency/failures and preventing users from seeing real loading, empty, and error states. It also risks shipping stale/fake data paths.


**Proposed fix:**
Disable fake server in production and gate it by mode: `export default defineConfig(({ mode }) => ({ ... plugins: [ ... vitePluginFakeServer({ enableProd: false, ... }) ] }))` or conditionally include the plugin only when `mode === 'development'`.

**Files changed:**
- `amoro-web/vite.config.ts` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

——
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com


Closes #4155