### PR TITLE
UI/UX: Low-contrast secondary text color in global theme token

### DIFF
--- a/amoro-web/vite.config.ts
+++ b/amoro-web/vite.config.ts
@@ -37,7 +37,7 @@ const css = {
         'border-color-split': '#e8e8f0',
         'header-color': 'rgba(0, 0, 0, 0.85)',
         'text-color': '#79809a',
-        'text-color-secondary': '#c0c0ca',
+        'text-color-secondary': '#595959',
         'font-size-base': '14px',
         'dark-gray-color': '#2b354a',
         'dark-bg-color': '#202a40',


### PR DESCRIPTION
Hi there! 👋

While exploring the codebase, I noticed a minor opportunity for improvement in `amoro-web/vite.config.ts`.

**Context:**
The LESS variable `text-color-secondary` is set to `#c0c0ca`, which has poor contrast on light backgrounds (commonly white in Ant Design layouts). Because this token is used globally, secondary labels, helper text, and metadata can become hard to read for low-vision users and may fail WCAG AA contrast requirements.


**Proposed fix:**
Increase contrast by replacing the token with a darker value that meets AA on white, e.g.: ` 'text-color-secondary': '#595959', ` (or another color with >= 4.5:1 contrast for normal text). Update in `css.preprocessorOptions.less.modifyVars`.


**Files changed:**
- `amoro-web/vite.config.ts` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

——
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com


Closes #4157