### PR TITLE
Fix flaky TestInternalMixedCatalogService by hardening test cleanup

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalMixedCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalMixedCatalogService.java
@@ -197,7 +197,11 @@ public class TestInternalMixedCatalogService extends RestCatalogServiceTestBase 
       } catch (Exception e) {
         LOG.warn("Failed to drop table during cleanup", e);
       }
-      catalog.dropDatabase(database);
+      try {
+        catalog.dropDatabase(database);
+      } catch (Exception e) {
+        LOG.warn("Failed to drop database during cleanup", e);
+      }
     }
 
     @ParameterizedTest(name = "CatalogTableOperationTest[withPrimaryKey={0}]")

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalMixedCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalMixedCatalogService.java
@@ -257,8 +257,18 @@ public class TestInternalMixedCatalogService extends RestCatalogServiceTestBase 
 
     @AfterEach
     public void after() {
-      catalog.dropTable(tableIdentifier, true);
-      catalog.dropDatabase(database);
+      try {
+        if (catalog.tableExists(tableIdentifier)) {
+          catalog.dropTable(tableIdentifier, true);
+        }
+      } catch (Exception e) {
+        LOG.warn("Failed to drop table during cleanup", e);
+      }
+      try {
+        catalog.dropDatabase(database);
+      } catch (Exception e) {
+        LOG.warn("Failed to drop database during cleanup", e);
+      }
     }
 
     @ParameterizedTest(name = "TableCommitTest[withPrimaryKey={0}]")
@@ -320,7 +330,18 @@ public class TestInternalMixedCatalogService extends RestCatalogServiceTestBase 
 
     @AfterEach
     public void cleanDatabase() {
-      catalog.dropDatabase(database);
+      try {
+        if (catalog.tableExists(tableIdentifier)) {
+          catalog.dropTable(tableIdentifier, true);
+        }
+      } catch (Exception e) {
+        LOG.warn("Failed to drop table during cleanup", e);
+      }
+      try {
+        catalog.dropDatabase(database);
+      } catch (Exception e) {
+        LOG.warn("Failed to drop database during cleanup", e);
+      }
     }
 
     @ParameterizedTest(name = "Test-NewCatalog-Load-HistoricalTable[withPrimaryKey={0}]")


### PR DESCRIPTION
## Why are the changes needed?

When a test method in `TestInternalMixedCatalogService` fails mid-way after creating a table but before dropping it, the `@AfterEach` cleanup could not drop the non-empty database. This left residual state that caused cascading failures in subsequent nested test classes (`Database already exists`, assertion on `listDatabases().isEmpty()`, etc.).

## Brief change log

- `TestTableCommit.after()`: Guard `dropTable` with `tableExists` check, wrap both `dropTable` and `dropDatabase` in try-catch to prevent cascading cleanup failures
- `CompatibilityCatalogTests.cleanDatabase()`: Drop residual table before dropping database, wrap both in try-catch
- `TestTableOperation.after()`: Wrap `dropDatabase` in try-catch for consistency with other nested test classes

## How was this patch tested?

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable