### PR TITLE
Replace fully qualified Comparator reference with simple class name in AdaptHiveParquetUtil

### DIFF
--- a/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetUtil.java
+++ b/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetUtil.java
@@ -43,6 +43,7 @@ import org.apache.parquet.schema.MessageType;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +137,7 @@ public class AdaptHiveParquetUtil {
               Literal<?> min;
               Literal<?> max;
               @SuppressWarnings("unchecked")
-              java.util.Comparator<Object> cmp = (java.util.Comparator<Object>) val1.comparator();
+              Comparator<Object> cmp = (Comparator<Object>) val1.comparator();
               if (isInt96(column) && cmp.compare(val1.value(), val2.value()) > 0) {
                 min = val2;
                 max = val1;


### PR DESCRIPTION
## Why are the changes needed?

Replace fully qualified `java.util.Comparator` references with simple class name for better readability and consistency with other imports in the file.

## Brief change log

- Added `import java.util.Comparator` to `AdaptHiveParquetUtil.java`
- Replaced inline `java.util.Comparator<Object>` with `Comparator<Object>`

## How was this patch tested?

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable