### PR TITLE
[Test] Add transactionId assertion in TestDefaultKeyedFile.

### DIFF
--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/data/TestDefaultKeyedFile.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/data/TestDefaultKeyedFile.java
@@ -51,7 +51,7 @@ public class TestDefaultKeyedFile extends TableTestBase {
     Assert.assertEquals(DataFileType.INSERT_FILE, defaultKeyedFile.type());
     Assert.assertEquals(3, defaultKeyedFile.node().mask());
     Assert.assertEquals(0, defaultKeyedFile.node().index());
-    // TODO check transactionId
+    Assert.assertEquals(txId, defaultKeyedFile.transactionId());
 
   }
 

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/data/TestDefaultKeyedFile.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/data/TestDefaultKeyedFile.java
@@ -52,7 +52,6 @@ public class TestDefaultKeyedFile extends TableTestBase {
     Assert.assertEquals(3, defaultKeyedFile.node().mask());
     Assert.assertEquals(0, defaultKeyedFile.node().index());
     Assert.assertEquals(txId, defaultKeyedFile.transactionId());
-
   }
 
   private List<Record> writeRecords() {


### PR DESCRIPTION
## Why are the changes needed?

This PR completes the test coverage for `DefaultKeyedFile` by implementing the transactionId assertion that was previously marked as TODO. The change ensures that the transactionId field is properly validated in the test case.

Close #xxx.

## Brief change log

- Replace `// TODO check transactionId` comment with actual assertion in `TestDefaultKeyedFile.java:54`
- Add `Assert.assertEquals(txId, defaultKeyedFile.transactionId())` to verify the transaction ID is correctly set

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? **(no)**
- If yes, how is the feature documented? **(not applicable)**