### PR TITLE
[hotfix] fix primary key conflict issue caused by multiple insertions in single-node persistence.

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
@@ -850,12 +850,11 @@ public class DefaultTableService extends PersistentBase implements TableService 
       // else: follower does not assign; meta.bucketId remains null until leader assigns
     }
 
-    doAs(TableRuntimeMapper.class, mapper -> mapper.insertRuntime(meta));
-
     // Only skip local runtime creation when master-slave mode is fully wired (bucketAssignStore
     // is non-null). When bucketAssignStore is null (e.g. 3-arg test constructor), fall through
     // and create the runtime in memory as in non-master-slave mode.
     if (isMasterSlaveMode && haContainer != null && bucketAssignStore != null) {
+      doAs(TableRuntimeMapper.class, mapper -> mapper.insertRuntime(meta));
       return true;
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

```
### Error updating database.  Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '1000' for key 'PRIMARY'
### The error may exist in org/apache/amoro/server/persistence/mapper/TableRuntimeMapper.java (best guess)
### The error may involve org.apache.amoro.server.persistence.mapper.TableRuntimeMapper.insertRuntime-Inline
### The error occurred while setting parameters
### SQL: INSERT INTO table_runtime (table_id, group_name, status_code, table_config, table_summary, bucket_id) VALUES (?, ?, ?, ?, ?, ?)
### Cause: java.sql.SQLIntegrityConstraintViolationException: Duplicate entry '1000' for key 'PRIMARY'
at org.apache.ibatis.exceptions.ExceptionFactory.wrapException(ExceptionFactory.java:30) ~[mybatis-3.5.15.jar:3.5.15]
at org.apache.ibatis.session.defaults.DefaultSqlSession.update(DefaultSqlSession.java:199) ~[mybatis-3.5.15.jar:3.5.15]
at org.apache.ibatis.session.defaults.DefaultSqlSession.insert(DefaultSqlSession.java:184) ~[mybatis-3.5.15.jar:3.5.15]
at org.apache.ibatis.binding.MapperMethod.execute(MapperMethod.java:62) ~[mybatis-3.5.15.jar:3.5.15]
at org.apache.ibatis.binding.MapperProxy$PlainMethodInvoker.invoke(MapperProxy.java:141) ~[mybatis-3.5.15.jar:3.5.15]
at org.apache.ibatis.binding.MapperProxy.invoke(MapperProxy.java:86) ~[mybatis-3.5.15.jar:3.5.15]
at com.sun.proxy.$Proxy59.insertRuntime(Unknown Source) ~[?:?]
at org.apache.amoro.server.table.DefaultTableService.lambda$triggerTableAdded$36(DefaultTableService.java:912) ~[classes/:?]
at org.apache.amoro.server.persistence.PersistentBase.doAs(PersistentBase.java:67) ~[classes/:?]
... 12 more
```

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- fix primary key conflict issue caused by multiple insertions in single-node persistence. ConradJam A minute ago

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
