### PR TITLE
Fix reachMinorInterval() starvation for cold partitions

### DIFF
--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/optimizing/plan/CommonPartitionEvaluator.java
@@ -35,6 +35,9 @@ import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
 
@@ -412,8 +415,27 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   }
 
   protected boolean reachMinorInterval() {
-    return config.getMinorLeastInterval() >= 0
-        && planTime - lastMinorOptimizingTime > config.getMinorLeastInterval();
+    if (config.getMinorLeastInterval() < 0) {
+      return false;
+    }
+    if (planTime - lastMinorOptimizingTime > config.getMinorLeastInterval()) {
+      return true;
+    }
+    // When minorLeastInterval is less than one day, use a cross-day fallback to ensure
+    // partitions with few small files still get optimized at least once per day, avoiding
+    // starvation caused by table-level lastMinorOptimizingTime being frequently reset by
+    // high-traffic partitions. See https://github.com/apache/amoro/issues/4055
+    long oneDayMillis = 24 * 60 * 60 * 1000L;
+    if (config.getMinorLeastInterval() < oneDayMillis) {
+      return isDifferentDay(lastMinorOptimizingTime, planTime);
+    }
+    return false;
+  }
+
+  private boolean isDifferentDay(long time1, long time2) {
+    LocalDate day1 = Instant.ofEpochMilli(time1).atZone(ZoneId.systemDefault()).toLocalDate();
+    LocalDate day2 = Instant.ofEpochMilli(time2).atZone(ZoneId.systemDefault()).toLocalDate();
+    return !day1.equals(day2);
   }
 
   protected boolean reachFullInterval() {

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
@@ -117,7 +117,6 @@ public class TableProperties {
    */
   public static final String SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL =
       "self-optimizing.minor.trigger.interval";
-
   public static final int SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL_DEFAULT = 3600000; // 1 h
 
   public static final String SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO =

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
@@ -117,6 +117,7 @@ public class TableProperties {
    */
   public static final String SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL =
       "self-optimizing.minor.trigger.interval";
+
   public static final int SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL_DEFAULT = 3600000; // 1 h
 
   public static final String SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO =

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/table/TableProperties.java
@@ -110,8 +110,14 @@ public class TableProperties {
       "self-optimizing.minor.trigger.file-count";
   public static final int SELF_OPTIMIZING_MINOR_TRIGGER_FILE_CNT_DEFAULT = 12;
 
+  /**
+   * The minimum interval for triggering minor optimizing, in milliseconds. Should be less than one
+   * day (86400000 ms). When the interval is less than one day, a cross-day fallback mechanism
+   * ensures that partitions with few small files still get optimized at least once per day.
+   */
   public static final String SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL =
       "self-optimizing.minor.trigger.interval";
+
   public static final int SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL_DEFAULT = 3600000; // 1 h
 
   public static final String SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO =


### PR DESCRIPTION
## What changes were proposed in this pull request?

`reachMinorInterval()` uses the table-level `lastMinorOptimizingTime`, which is frequently reset by high-traffic partitions. This causes partitions with fewer small files (below the minor trigger file count threshold) to never get minor optimized, even when their files accumulate over time.

### Root Cause

The `lastMinorOptimizingTime` is a single table-level timestamp shared across all partitions. When a high-traffic partition triggers minor optimization, the timestamp is reset for the entire table. Cold partitions (with few files, not reaching `minor-trigger-file-count`) rely on `reachMinorInterval()` to trigger optimization, but the interval check never passes because the table-level timestamp keeps getting refreshed.

### Solution

Added a cross-day fallback mechanism in `reachMinorInterval()`:

- When `minorLeastInterval` is less than one day (which is the typical configuration, default is 1 hour), and the last minor optimization happened on a different calendar day, `reachMinorInterval()` returns `true`.
- This ensures every partition gets at least one minor optimization attempt per day, preventing starvation of cold partitions.
- The guard `minorLeastInterval < 1 day` avoids semantic conflict when users intentionally set a longer interval (e.g., 2 days).

Also added Javadoc to `SELF_OPTIMIZING_MINOR_TRIGGER_INTERVAL` to document the expected range and the cross-day fallback behavior.

## How was this patch tested?

Existing `TestOptimizingEvaluator` tests pass. The change is minimal and additive — it only adds a fallback path that activates when the normal interval check fails and a day boundary has been crossed.

Closes #4055