### PR TITLE
[AMORO-4163][ams] Fix Version-N-already-exists race in newTableOperations for legacy mixed-iceberg

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/internal/InternalMixedIcebergHandler.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/internal/InternalMixedIcebergHandler.java
@@ -32,6 +32,7 @@ import org.apache.amoro.utils.TablePropertyUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitFailedException;
 
 import java.util.Map;
 
@@ -81,7 +82,18 @@ public class InternalMixedIcebergHandler extends InternalIcebergHandler {
       org.apache.iceberg.TableMetadata legacyCurrent = legacyTableMetadata(current, changeStore);
       if (!current.equals(legacyCurrent)) {
         // add rest based mixed-format table properties
-        ops.commit(current, legacyCurrent);
+        try {
+          ops.commit(current, legacyCurrent);
+        } catch (CommitFailedException e) {
+          // A concurrent caller (e.g. background table-explorer racing with onTableCreated) may
+          // have already committed the same property update. Refresh to get the latest metadata;
+          // if properties are now up-to-date, proceed normally. Otherwise re-throw.
+          current = ops.refresh();
+          legacyCurrent = legacyTableMetadata(current, changeStore);
+          if (!current.equals(legacyCurrent)) {
+            throw e;
+          }
+        }
       }
       return ops;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up fix for [AMORO-4163](https://github.com/apache/amoro/pull/4182). The original fix changed `ops.current()` to `ops.refresh()` inside `InternalMixedIcebergHandler.newTableOperations()` so that the returned `TableMetadata` reference satisfies Iceberg 1.7.x's reference-equality check in `commit()`. However, this introduced a new race condition:

`DefaultTableManager.createTable()` consists of two sequential steps:
1. `catalog.createTable()` — saves the table to the database (the table is now visible to all threads)
2. `onTableCreated()` → `triggerTableAdded()` → `newTableOperations()` → `ops.commit()` — tries to write `v2.metadata.json`

The background `tableExplorerScheduler` runs `exploreInternalCatalog()` concurrently. If it scans the database between steps 1 and 2, it finds the new table (not yet in `tableRuntimeMap`) and also calls `triggerTableAdded()` → `newTableOperations()` → `ops.commit()`. Whichever thread wins writes `v2.metadata.json` first; the other then fails with:

```
CommitFailedException: Version 2 already exists: .../base/metadata/v2.metadata.json
```

**Fix**: catch `CommitFailedException` in the commit block, refresh to obtain the latest on-disk metadata, and proceed normally if a concurrent writer already committed the correct mixed-format properties. Re-throw only when the properties still differ after refresh, indicating a genuine conflict.

## How was this patch tested?

The existing `CompatibilityCatalogTests.testNewCatalogLoadHistorical` in `TestInternalMixedCatalogService` covers this scenario — it was consistently failing in CI before this fix.