### PR TITLE
[Hotfix][ams] Fix ResourceMapper.selectResourcesByGroup result mapping

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/ResourceMapper.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/persistence/mapper/ResourceMapper.java
@@ -59,15 +59,14 @@ public interface ResourceMapper {
   ResourceGroup selectResourceGroup(@Param("resourceGroup") String groupName);
 
   @Select(
-      "SELECT resource_id, group_name, container_name, start_time, thread_count, total_memory, properties"
+      "SELECT resource_id, group_name, container_name, thread_count, total_memory, properties"
           + " FROM resource WHERE group_name = #{resourceGroup}")
   @Results({
     @Result(property = "resourceId", column = "resource_id"),
-    @Result(property = "group", column = "group_name"),
-    @Result(property = "container", column = "container_name"),
-    @Result(property = "startTime", column = "start_time", typeHandler = Long2TsConverter.class),
+    @Result(property = "groupName", column = "group_name"),
+    @Result(property = "containerName", column = "container_name"),
     @Result(property = "threadCount", column = "thread_count"),
-    @Result(property = "totalMemory", column = "total_memory"),
+    @Result(property = "memoryMb", column = "total_memory"),
     @Result(property = "properties", column = "properties", typeHandler = Map2StringConverter.class)
   })
   List<Resource> selectResourcesByGroup(@Param("resourceGroup") String groupName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the `@Result` annotations on `ResourceMapper.selectResourcesByGroup` so that the property names actually match the fields on `Resource`:

| Column | Old `property` | Correct `property` |
| --- | --- | --- |
| `group_name` | `group` | `groupName` |
| `container_name` | `container` | `containerName` |
| `total_memory` | `totalMemory` | `memoryMb` |

Also drop the `start_time` column from the `SELECT` list and remove its `@Result` entry. `Resource` has no `startTime` field, so the mapping was silently discarded — keeping the column in the projection added no value.

## Why are the changes needed?

These mapping names have never matched the target class. Currently `DefaultOptimizerManager.listResourcesByGroup` is the only path that calls this mapper, and it has no caller on `master`, so the bug was latent. Any future caller (e.g. the auto-restart optimizer feature under development) that starts using this method would get back `Resource` instances with `null`/`0` values in `groupName`, `containerName`, and `memoryMb`. Fixing it as a standalone change keeps the diff minimal and makes it safe to cherry-pick.

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

- Verified no current caller of `selectResourcesByGroup` / `listResourcesByGroup` exists on master besides the declaration itself, so the change cannot regress existing behavior.
- `mvn spotless:apply` passes.