### PR TITLE
[AMORO-4172] Self-heal stuck RUNNING optimizing process in TableRuntimeRefreshExecutor

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingProcess.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingProcess.java
@@ -44,6 +44,21 @@ public interface OptimizingProcess {
 
   MetricsSummary getSummary();
 
+  /**
+   * Whether all tasks in this process have reached {@code SUCCESS} status and are ready to be
+   * committed.
+   *
+   * <p>This flag is primarily used by {@link
+   * org.apache.amoro.server.table.executor.TableRuntimeRefreshExecutor} to detect a stuck {@code
+   * RUNNING} process whose tasks all succeeded but never transitioned to {@code COMMITTING} (see
+   * issue #4172: transient failures of {@code beginCommitting()}, such as DB lock wait timeout,
+   * leave the table permanently stuck in {@code *_OPTIMIZING} until AMS is restarted).
+   *
+   * @return {@code true} if the process has at least one task and all of them are in {@code
+   *     SUCCESS} status
+   */
+  boolean allTasksPrepared();
+
   enum Status {
     RUNNING,
     CLOSED,

--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -525,15 +525,26 @@ public class OptimizingQueue extends PersistentBase {
     }
 
     /**
-     * if all tasks are Prepared
+     * Whether all tasks in this process are in {@code SUCCESS} status.
+     *
+     * <p>Lock-protected so that callers from other threads (e.g. {@link
+     * org.apache.amoro.server.table.executor.TableRuntimeRefreshExecutor}) observe a consistent
+     * view of {@code taskMap}. See issue #4172.
      *
      * @return true if tasks is not empty and all Prepared
      */
-    private boolean allTasksPrepared() {
-      if (!taskMap.isEmpty()) {
-        return taskMap.values().stream().allMatch(t -> t.getStatus() == TaskRuntime.Status.SUCCESS);
+    @Override
+    public boolean allTasksPrepared() {
+      lock.lock();
+      try {
+        if (!taskMap.isEmpty()) {
+          return taskMap.values().stream()
+              .allMatch(t -> t.getStatus() == TaskRuntime.Status.SUCCESS);
+        }
+        return false;
+      } finally {
+        lock.unlock();
       }
-      return false;
     }
 
     /**

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/executor/TableRuntimeRefreshExecutor.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/executor/TableRuntimeRefreshExecutor.java
@@ -21,6 +21,7 @@ package org.apache.amoro.server.table.executor;
 import org.apache.amoro.AmoroTable;
 import org.apache.amoro.config.TableConfiguration;
 import org.apache.amoro.server.optimizing.OptimizingProcess;
+import org.apache.amoro.server.optimizing.OptimizingStatus;
 import org.apache.amoro.server.optimizing.plan.OptimizingEvaluator;
 import org.apache.amoro.server.table.TableManager;
 import org.apache.amoro.server.table.TableRuntime;
@@ -91,8 +92,53 @@ public class TableRuntimeRefreshExecutor extends BaseTableExecutor {
               && lastOptimizedSnapshotId != tableRuntime.getCurrentSnapshotId())) {
         tryEvaluatingPendingInput(tableRuntime, mixedTable);
       }
+      // issue #4172: a RUNNING process whose tasks all succeeded may remain stuck in
+      // *_OPTIMIZING when a previous beginCommitting() failed transiently (e.g. DB lock
+      // wait timeout). Detect it here and re-drive the transition to COMMITTING so that
+      // OptimizingCommitExecutor can take over normally.
+      tryHealStuckCommitting(tableRuntime);
     } catch (Throwable throwable) {
       logger.error("Refreshing table {} failed.", tableRuntime.getTableIdentifier(), throwable);
+    }
+  }
+
+  /**
+   * Detects and heals a {@code RUNNING} optimizing process whose tasks have all succeeded but the
+   * table's status never transitioned to {@link OptimizingStatus#COMMITTING} (e.g. because the
+   * previous {@code beginCommitting()} DB update failed transiently). Without this self-heal, the
+   * table stays in {@code *_OPTIMIZING} forever until AMS is restarted - see issue #4172.
+   *
+   * <p>When a stuck state is detected, this method re-invokes {@link
+   * TableRuntime#beginCommitting()}. On success, the status transition will fire {@code
+   * handleTableChanged} and the normal {@link OptimizingCommitExecutor} pipeline will resume. On
+   * failure (e.g. the DB is still unhealthy), this method logs and returns; the next refresh cycle
+   * will try again.
+   */
+  private void tryHealStuckCommitting(TableRuntime tableRuntime) {
+    OptimizingProcess process = tableRuntime.getOptimizingProcess();
+    if (process == null
+        || process.getStatus() != OptimizingProcess.Status.RUNNING
+        || tableRuntime.getOptimizingStatus() == OptimizingStatus.COMMITTING
+        || !tableRuntime.getOptimizingStatus().isProcessing()) {
+      return;
+    }
+    if (!process.allTasksPrepared()) {
+      return;
+    }
+    logger.warn(
+        "{} detected stuck RUNNING optimizing process (processId={}, status={}): all tasks have "
+            + "succeeded but the table never transitioned to COMMITTING. Self-healing by "
+            + "re-driving beginCommitting() (issue #4172).",
+        tableRuntime.getTableIdentifier(),
+        process.getProcessId(),
+        tableRuntime.getOptimizingStatus());
+    try {
+      tableRuntime.beginCommitting();
+    } catch (Exception e) {
+      logger.warn(
+          "{} self-heal beginCommitting() failed, will retry on the next refresh cycle.",
+          tableRuntime.getTableIdentifier(),
+          e);
     }
   }
 }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultOptimizingService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultOptimizingService.java
@@ -270,6 +270,51 @@ public class TestDefaultOptimizingService extends AMSTableTestBase {
     assertTaskCompleted(taskRuntime);
   }
 
+  /**
+   * Regression test for issue #4172: a {@code RUNNING} optimizing process whose tasks have all
+   * succeeded must not stay stuck in {@code *_OPTIMIZING} forever when a previous {@code
+   * beginCommitting()} transition failed. {@link TableRuntimeRefreshExecutor#execute} should detect
+   * the stuck state and re-drive the transition to {@code COMMITTING}.
+   */
+  @Test
+  public void testRefreshExecutorHealsStuckRunningProcess() throws Exception {
+    // 1. poll / ack / complete - the table should be in COMMITTING with a RUNNING process.
+    OptimizingTask task = optimizingService().pollTask(token, THREAD_ID);
+    Assertions.assertNotNull(task);
+    optimizingService().ackTask(token, THREAD_ID, task.getTaskId());
+    optimizingService().completeTask(token, buildOptimizingTaskResult(task.getTaskId()));
+
+    TableRuntime runtime = tableService().getRuntime(serverTableIdentifier().getId());
+    Assertions.assertEquals(OptimizingStatus.COMMITTING, runtime.getOptimizingStatus());
+    OptimizingProcess process = runtime.getOptimizingProcess();
+    Assertions.assertNotNull(process);
+    Assertions.assertEquals(OptimizingProcess.Status.RUNNING, process.getStatus());
+    Assertions.assertTrue(
+        process.allTasksPrepared(), "All tasks should be prepared after successful completeTask()");
+
+    // 2. Simulate the stuck state described in issue #4172: pretend beginCommitting() never
+    // transitioned the status out of *_OPTIMIZING (e.g. DB lock wait timeout made the UPDATE
+    // fail and invokeConsistency rolled the in-memory status back).
+    java.lang.reflect.Field statusField = TableRuntime.class.getDeclaredField("optimizingStatus");
+    statusField.setAccessible(true);
+    statusField.set(runtime, OptimizingStatus.MINOR_OPTIMIZING);
+    Assertions.assertEquals(OptimizingStatus.MINOR_OPTIMIZING, runtime.getOptimizingStatus());
+
+    // 3. Trigger a refresh cycle - the executor should detect the stuck state and self-heal
+    // by re-invoking beginCommitting().
+    TableRuntimeRefresher refresher = new TableRuntimeRefresher();
+    try {
+      refresher.refreshPending();
+    } finally {
+      refresher.dispose();
+    }
+
+    Assertions.assertEquals(
+        OptimizingStatus.COMMITTING,
+        runtime.getOptimizingStatus(),
+        "TableRuntimeRefreshExecutor must re-drive beginCommitting() for a stuck RUNNING process");
+  }
+
   @Test
   public void testReloadScheduledTask() {
     // 1.poll task


### PR DESCRIPTION
Fixes #4172.

## Problem

When a table's optimizing process reaches the post-execution phase — all tasks
are `SUCCESS` and the code is about to transition the table to `COMMITTING` —
a transient failure of `TableRuntime#beginCommitting()` (e.g. DB lock wait
timeout in the underlying `UPDATE table_runtime`) causes `invokeConsistency`
to roll back the in-memory status. The process stays `RUNNING` but the table
status remains `*_OPTIMIZING`, **forever, until AMS is restarted**. The issue
reporter confirmed exactly this symptom.

Root cause: there is no code path that retries or re-drives
\`beginCommitting()\` when it transiently fails. \`OptimizingCommitExecutor\`
only schedules when the status is already \`COMMITTING\`, so the stuck state
is invisible to it.

## Approach (A1: narrow, targeted self-heal)

Leverage the existing \`TableRuntimeRefreshExecutor\`, which already scans every
table periodically. At the end of \`execute()\`, detect the stuck pattern and
re-drive the transition:

\`\`\`
process != null
  && process.getStatus() == RUNNING
  && tableRuntime.getOptimizingStatus() != COMMITTING
  && tableRuntime.getOptimizingStatus().isProcessing()
  && process.allTasksPrepared()
\`\`\`

When all conditions hold we call \`tableRuntime.beginCommitting()\`. On
success the normal \`handleTableChanged\` → \`OptimizingCommitExecutor\` path
resumes. On failure we log and retry on the next refresh cycle (≤ 1 minute
by default).

## Why this location

- \`TableRuntimeRefreshExecutor\` already does \`enabled() == true\` for every
  table — no new thread pool, no new scheduling mechanism.
- \`OptimizingCommitExecutor\` is intentionally kept as-is; it is only notified
  via the existing \`handleTableChanged\` event once the self-heal succeeds.
- \`OptimizingQueue.acceptResult()\` hot path (concurrent task completion) is
  **not** changed — we only expose an existing read method.

## Changes

| File | Change |
|---|---|
| \`OptimizingProcess.java\` | Add \`boolean allTasksPrepared()\` to the interface. |
| \`OptimizingQueue.java\` | \`TableOptimizingProcess.allTasksPrepared()\` becomes \`@Override public\` and lock-protected for cross-thread visibility. |
| \`TableRuntimeRefreshExecutor.java\` | New private \`tryHealStuckCommitting()\` invoked at the end of \`execute()\`. |
| \`TestDefaultOptimizingService.java\` | New regression test \`testRefreshExecutorHealsStuckRunningProcess\` that uses reflection to simulate the stuck state, then verifies \`execute()\` transitions back to \`COMMITTING\`. |

## Verification

Target test passes locally:

\`\`\`
mvn -pl amoro-ams -am test \
  -Dtest='TestDefaultOptimizingService#testRefreshExecutorHealsStuckRunningProcess' \
  -Dsurefire.failIfNoSpecifiedTests=false -DskipITs

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
\`\`\`

Self-heal path logs are observable during the test:

\`\`\`
WARN TableRuntimeRefresher: ...detected stuck RUNNING optimizing process
(processId=..., status=MINOR_OPTIMIZING): all tasks have succeeded but the
table never transitioned to COMMITTING. Self-healing by re-driving
beginCommitting() (issue #4172).
\`\`\`

## Risk

- No change to concurrent hot paths; only one additional idempotent read
  (\`allTasksPrepared\`) per refresh cycle, short-circuited early for
  tables that are not processing.
- Worst case if the underlying DB stays unhealthy: self-heal keeps logging
  at \`WARN\` and retrying every refresh cycle — exactly the same cost as
  before plus one cheap read. Strictly better than today's
  "stuck until restart".
- Opened as **draft** first to let CI confirm, then I'll flip to ready
  for review if green.