### PR TITLE
[AMORO-1503][mixed-hive] Add INFO logs for partition operations

### DIFF
--- a/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/op/ReplaceHivePartitions.java
+++ b/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/op/ReplaceHivePartitions.java
@@ -325,6 +325,20 @@ public class ReplaceHivePartitions implements ReplacePartitions {
   }
 
   private void commitPartitionedTable() {
+    if (!rewritePartitions.isEmpty()) {
+      LOG.info(
+          "Altering {} Hive partitions for table {}, partitions {}",
+          rewritePartitions.size(),
+          table.id(),
+          partitionsSummary(rewritePartitions.values()));
+    }
+    if (!newPartitions.isEmpty()) {
+      LOG.info(
+          "Creating {} Hive partitions for table {}, partitions {}",
+          newPartitions.size(),
+          table.id(),
+          partitionsSummary(newPartitions.values()));
+    }
     try {
       transactionalHMSClient.run(
           c -> {
@@ -346,8 +360,28 @@ public class ReplaceHivePartitions implements ReplacePartitions {
             return 0;
           });
     } catch (TException | InterruptedException e) {
+      LOG.warn(
+          "Failed to commit Hive partition operations for table {}: alter {}, create {}",
+          table.id(),
+          rewritePartitions.size(),
+          newPartitions.size(),
+          e);
       throw new RuntimeException(e);
     }
+  }
+
+  private static String partitionsSummary(java.util.Collection<Partition> partitions) {
+    int max = 5;
+    return partitions.stream()
+        .limit(max)
+        .map(
+            p ->
+                "Partition(values: ["
+                    + Joiner.on("/").join(p.getValues())
+                    + "], location: "
+                    + p.getSd().getLocation()
+                    + ")")
+        .collect(Collectors.joining(", ", "[", partitions.size() > max ? ", ...]" : "]"));
   }
 
   private void checkDataFileInSameLocation(String partitionLocation, List<DataFile> files) {

--- a/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/op/UpdateHiveFiles.java
+++ b/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/op/UpdateHiveFiles.java
@@ -189,7 +189,7 @@ public abstract class UpdateHiveFiles<T extends SnapshotUpdate<T>> implements Sn
         commitPartitionedTable();
       }
     } catch (Exception e) {
-      LOG.warn("Commit operation to HMS failed.", e);
+      LOG.warn("Commit Hive partition operations to HMS failed for table {}.", table.id(), e);
     }
   }
 
@@ -455,6 +455,12 @@ public abstract class UpdateHiveFiles<T extends SnapshotUpdate<T>> implements Sn
 
   private void commitPartitionedTable() {
     if (!partitionToDelete.isEmpty()) {
+      LOG.info(
+          "Dropping {} Hive partitions for table {}, txId {}, partitions {}",
+          partitionToDelete.size(),
+          table.id(),
+          txId,
+          partitionsSummary(partitionToDelete.values()));
       for (Partition p : partitionToDelete.values()) {
         try {
           transactionClient.run(
@@ -469,22 +475,48 @@ public abstract class UpdateHiveFiles<T extends SnapshotUpdate<T>> implements Sn
                 return 0;
               });
         } catch (NoSuchObjectException e) {
-          LOG.warn("try to delete hive partition {} but partition not exist.", p);
+          LOG.warn(
+              "Tried to drop Hive partition for table {} but partition does not exist: {}",
+              table.id(),
+              partitionToString(p));
         } catch (TException | InterruptedException e) {
+          LOG.warn(
+              "Failed to drop Hive partition for table {}, partition {}",
+              table.id(),
+              partitionToString(p),
+              e);
           throw new RuntimeException(e);
         }
       }
     }
 
     if (!partitionToCreate.isEmpty()) {
+      LOG.info(
+          "Creating {} Hive partitions for table {}, txId {}, partitions {}",
+          partitionToCreate.size(),
+          table.id(),
+          txId,
+          partitionsSummary(partitionToCreate.values()));
       try {
         transactionClient.run(c -> c.addPartitions(Lists.newArrayList(partitionToCreate.values())));
       } catch (TException | InterruptedException e) {
+        LOG.warn(
+            "Failed to create {} Hive partitions for table {}, partitions {}",
+            partitionToCreate.size(),
+            table.id(),
+            partitionsSummary(partitionToCreate.values()),
+            e);
         throw new RuntimeException(e);
       }
     }
 
     if (!partitionToAlter.isEmpty()) {
+      LOG.info(
+          "Altering {} Hive partitions for table {}, txId {}, partitions {}",
+          partitionToAlter.size(),
+          table.id(),
+          txId,
+          partitionsSummary(partitionToAlter.values()));
       try {
         transactionClient.run(
             c -> {
@@ -501,9 +533,23 @@ public abstract class UpdateHiveFiles<T extends SnapshotUpdate<T>> implements Sn
               return null;
             });
       } catch (TException | InterruptedException e) {
+        LOG.warn(
+            "Failed to alter {} Hive partitions for table {}, partitions {}",
+            partitionToAlter.size(),
+            table.id(),
+            partitionsSummary(partitionToAlter.values()),
+            e);
         throw new RuntimeException(e);
       }
     }
+  }
+
+  private static String partitionsSummary(java.util.Collection<Partition> partitions) {
+    int max = 5;
+    return partitions.stream()
+        .limit(max)
+        .map(UpdateHiveFiles::partitionToString)
+        .collect(Collectors.joining(", ", "[", partitions.size() > max ? ", ...]" : "]"));
   }
 
   private void generateUnpartitionTableLocation() {
@@ -611,7 +657,7 @@ public abstract class UpdateHiveFiles<T extends SnapshotUpdate<T>> implements Sn
     return path1.equals(path2);
   }
 
-  private String partitionToString(Partition p) {
+  private static String partitionToString(Partition p) {
     return "Partition(values: ["
         + Joiner.on("/").join(p.getValues())
         + "], location: "

--- a/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/utils/HivePartitionUtil.java
+++ b/amoro-format-mixed/amoro-mixed-hive/src/main/java/org/apache/amoro/hive/utils/HivePartitionUtil.java
@@ -225,17 +225,20 @@ public class HivePartitionUtil {
   public static void alterPartition(
       HMSClientPool hiveClient, TableIdentifier tableIdentifier, String partition, String newPath)
       throws IOException {
+    String oldLocation = null;
     try {
-      LOG.info(
-          "alter table {} hive partition {} to new location {}",
-          tableIdentifier,
-          partition,
-          newPath);
       Partition oldPartition =
           hiveClient.run(
               client ->
                   client.getPartition(
                       tableIdentifier.getDatabase(), tableIdentifier.getTableName(), partition));
+      oldLocation = oldPartition.getSd().getLocation();
+      LOG.info(
+          "Altering Hive partition location for table {}, partition {}, location {} -> {}",
+          tableIdentifier,
+          partition,
+          oldLocation,
+          newPath);
       Partition newPartition = new Partition(oldPartition);
       newPartition.getSd().setLocation(newPath);
       hiveClient.run(
@@ -255,7 +258,20 @@ public class HivePartitionUtil {
                 }
                 return null;
               });
+      LOG.info(
+          "Altered Hive partition location for table {}, partition {}, location {} -> {}",
+          tableIdentifier,
+          partition,
+          oldLocation,
+          newPath);
     } catch (Exception e) {
+      LOG.warn(
+          "Failed to alter Hive partition location for table {}, partition {}, location {} -> {}",
+          tableIdentifier,
+          partition,
+          oldLocation,
+          newPath,
+          e);
       throw new IOException(e);
     }
   }
@@ -282,18 +298,40 @@ public class HivePartitionUtil {
               partition =
                   newPartition(
                       hiveTable, partitionValues, partitionLocation, dataFiles, accessTimestamp);
+              LOG.info(
+                  "Creating Hive partition for table {}, partition values {}, location {}",
+                  mixedTable.id(),
+                  partitionValues,
+                  partitionLocation);
               client.addPartition(partition);
+              LOG.info(
+                  "Created Hive partition for table {}, partition values {}, location {}",
+                  mixedTable.id(),
+                  partitionValues,
+                  partitionLocation);
               return partition;
             }
           });
     } catch (Exception e) {
+      LOG.warn(
+          "Failed to create Hive partition for table {}, partition values {}, location {}",
+          mixedTable.id(),
+          partitionValues,
+          partitionLocation,
+          e);
       throw new RuntimeException(e);
     }
   }
 
   public static void dropPartition(
       HMSClientPool hmsClient, MixedTable mixedTable, Partition hivePartition) {
+    String location = hivePartition.getSd() == null ? null : hivePartition.getSd().getLocation();
     try {
+      LOG.info(
+          "Dropping Hive partition for table {}, partition values {}, location {}",
+          mixedTable.id(),
+          hivePartition.getValues(),
+          location);
       hmsClient.run(
           client -> {
             PartitionDropOptions options =
@@ -308,7 +346,18 @@ public class HivePartitionUtil {
                 hivePartition.getValues(),
                 options);
           });
+      LOG.info(
+          "Dropped Hive partition for table {}, partition values {}, location {}",
+          mixedTable.id(),
+          hivePartition.getValues(),
+          location);
     } catch (TException | InterruptedException e) {
+      LOG.warn(
+          "Failed to drop Hive partition for table {}, partition values {}, location {}",
+          mixedTable.id(),
+          hivePartition.getValues(),
+          location,
+          e);
       throw new RuntimeException(e);
     }
   }
@@ -320,6 +369,13 @@ public class HivePartitionUtil {
       String newLocation,
       List<DataFile> dataFiles,
       int accessTimestamp) {
+    String oldLocation = hivePartition.getSd() == null ? null : hivePartition.getSd().getLocation();
+    LOG.info(
+        "Updating Hive partition location for table {}, partition values {}, location {} -> {}",
+        mixedTable.id(),
+        hivePartition.getValues(),
+        oldLocation,
+        newLocation);
     dropPartition(hmsClient, mixedTable, hivePartition);
     createPartitionIfAbsent(
         hmsClient, mixedTable, hivePartition.getValues(), newLocation, dataFiles, accessTimestamp);


### PR DESCRIPTION
## Summary

Closes #1503.

Adds INFO/WARN logs on the Mixed Hive Table partition operation paths
(create / drop / alter location). These operations are infrequent, so
logging them at INFO level makes after-the-fact diagnosis of missing
or mis-located partitions much easier with negligible runtime cost.

Logs are added at two layers:

- `HivePartitionUtil` — per-partition `LOG.info` on `createPartitionIfAbsent`,
  `dropPartition`, and `updatePartitionLocation`, plus matching `LOG.warn` on
  the failure paths. The existing `alterPartition` log now reports both old
  and new locations.
- `UpdateHiveFiles` / `ReplaceHivePartitions` — per-batch `LOG.info` for the
  drop / create / alter sets emitted by `commitPartitionedTable`, with a
  count and a sampled list of partitions (capped at 5, with `...` for the
  rest) to avoid log explosion on large commits, plus matching `LOG.warn`
  on commit failures.

Each log line carries the table identifier, partition values, location
(old → new on alter), and transaction id where available, so a single
log record is enough to identify the partition and trace it back to a
commit.

## Sample logs

Per-partition (single-partition path, `HivePartitionUtil`):

```
INFO  o.a.a.h.utils.HivePartitionUtil - Creating Hive partition for table catalog.db.tbl, partition values [2024-01-01], location s3://bkt/db/tbl/dt=2024-01-01/.amoro_xact_42
INFO  o.a.a.h.utils.HivePartitionUtil - Dropping Hive partition for table catalog.db.tbl, partition values [2024-01-01], location s3://bkt/db/tbl/dt=2024-01-01/.amoro_xact_41
INFO  o.a.a.h.utils.HivePartitionUtil - Altering Hive partition location for table catalog.db.tbl, partition dt=2024-01-01, location s3://bkt/db/tbl/dt=2024-01-01/.amoro_xact_41 -> s3://bkt/db/tbl/dt=2024-01-01/.amoro_xact_42
```

Per-batch (transaction commit path, `UpdateHiveFiles`):

```
INFO  o.a.a.hive.op.UpdateHiveFiles - Creating 3 Hive partitions for table catalog.db.tbl, txId 42, partitions [Partition(values: [2024-01-01], location: s3://bkt/.../.amoro_xact_42), Partition(values: [2024-01-02], location: s3://bkt/.../.amoro_xact_42), Partition(values: [2024-01-03], location: s3://bkt/.../.amoro_xact_42)]
INFO  o.a.a.hive.op.UpdateHiveFiles - Dropping 1 Hive partitions for table catalog.db.tbl, txId 42, partitions [Partition(values: [2024-01-01], location: s3://bkt/.../.amoro_xact_41)]
```

Failure path:

```
WARN  o.a.a.h.utils.HivePartitionUtil - Failed to alter Hive partition location for table catalog.db.tbl, partition dt=2024-01-01, location s3://bkt/.../.amoro_xact_41 -> s3://bkt/.../.amoro_xact_42
    org.apache.thrift.TException: ...
```

## Tests

No new unit tests; existing tests in the module continue to pass:

```
./mvnw test -pl amoro-format-mixed/amoro-mixed-hive \
  -Dtest=TestRewritePartitions,TestOverwriteFiles,TestSyncHiveMeta
# Tests run: 76, Failures: 0, Errors: 0, Skipped: 18
```

`mvn spotless:check` and `mvn checkstyle:check` are clean for the
touched module.