### PR TITLE
[ams][test] Make RestCatalogService nested tests order-independent

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/RestCatalogServiceTestBase.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/RestCatalogServiceTestBase.java
@@ -43,13 +43,16 @@ import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class RestCatalogServiceTestBase {
 
   static AmsEnvironment ams = AmsEnvironment.getIntegrationInstances();
   static String restCatalogUri = RestCatalogService.ICEBERG_REST_API_PREFIX;
 
-  protected final String database = "test_ns";
+  private static final AtomicLong TEST_INSTANCE_COUNTER = new AtomicLong();
+
+  protected final String database = "test_ns_" + TEST_INSTANCE_COUNTER.incrementAndGet();
   protected final String table = "test_iceberg_tbl";
   protected final TableIdentifier tableIdentifier =
       TableIdentifier.of(catalogName(), database, table);

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
@@ -104,12 +104,18 @@ public class TestInternalIcebergCatalogService extends RestCatalogServiceTestBas
   public class NamespaceTests {
     @Test
     public void testNamespaceOperations() throws IOException {
-      Assertions.assertTrue(nsCatalog.listNamespaces().isEmpty());
-      nsCatalog.createNamespace(Namespace.of(database));
-      Assertions.assertEquals(1, nsCatalog.listNamespaces().size());
-      Assertions.assertEquals(0, nsCatalog.listNamespaces(Namespace.of(database)).size());
-      nsCatalog.dropNamespace(Namespace.of(database));
-      Assertions.assertTrue(nsCatalog.listNamespaces().isEmpty());
+      Namespace dbNamespace = Namespace.of(database);
+      int initialNamespaceCount = nsCatalog.listNamespaces().size();
+      Assertions.assertFalse(nsCatalog.listNamespaces().contains(dbNamespace));
+
+      nsCatalog.createNamespace(dbNamespace);
+      Assertions.assertEquals(initialNamespaceCount + 1, nsCatalog.listNamespaces().size());
+      Assertions.assertTrue(nsCatalog.listNamespaces().contains(dbNamespace));
+      Assertions.assertEquals(0, nsCatalog.listNamespaces(dbNamespace).size());
+
+      nsCatalog.dropNamespace(dbNamespace);
+      Assertions.assertEquals(initialNamespaceCount, nsCatalog.listNamespaces().size());
+      Assertions.assertFalse(nsCatalog.listNamespaces().contains(dbNamespace));
     }
   }
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalMixedCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalMixedCatalogService.java
@@ -165,16 +165,20 @@ public class TestInternalMixedCatalogService extends RestCatalogServiceTestBase 
       MixedFormatCatalog catalog = loadMixedIcebergCatalog();
       Assertions.assertEquals(
           InternalMixedIcebergCatalog.class.getName(), catalog.getClass().getName());
-      Assertions.assertTrue(catalog.listDatabases().isEmpty());
+      int initialDatabaseCount = catalog.listDatabases().size();
+      int initialNamespaceCount = nsCatalog.listNamespaces(Namespace.of()).size();
+      Assertions.assertFalse(catalog.listDatabases().contains(database));
 
       catalog.createDatabase(database);
-      Assertions.assertEquals(1, catalog.listDatabases().size());
+      Assertions.assertEquals(initialDatabaseCount + 1, catalog.listDatabases().size());
       Assertions.assertTrue(catalog.listDatabases().contains(database));
-      Assertions.assertEquals(1, nsCatalog.listNamespaces(Namespace.of()).size());
+      Assertions.assertEquals(
+          initialNamespaceCount + 1, nsCatalog.listNamespaces(Namespace.of()).size());
 
       catalog.dropDatabase(database);
-      Assertions.assertTrue(catalog.listDatabases().isEmpty());
-      Assertions.assertTrue(nsCatalog.listNamespaces().isEmpty());
+      Assertions.assertEquals(initialDatabaseCount, catalog.listDatabases().size());
+      Assertions.assertFalse(catalog.listDatabases().contains(database));
+      Assertions.assertEquals(initialNamespaceCount, nsCatalog.listNamespaces().size());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`amoro-ams/src/test/java/org/apache/amoro/server/RestCatalogServiceTestBase` and its subclasses (`TestInternalMixedCatalogService`, `TestInternalIcebergCatalogService`) share a single static `AmsEnvironment` and a hard-coded `database = \"test_ns\"` / `table = \"test_iceberg_tbl\"` across every `@Nested` class. Whenever cleanup leaks (the existing `@AfterEach` swallows `dropDatabase` exceptions) or background catalog scans race the tests, sibling nested classes inherit dirty catalog state and assertions that hard-code the catalog being empty start failing.

This PR makes the tests order-independent without restructuring the suite:

1. **Unique database name per test instance** — `RestCatalogServiceTestBase.database` is now `\"test_ns_\" + COUNTER.incrementAndGet()`. Each test method gets a fresh test instance (JUnit 5 default `Lifecycle.PER_METHOD`), so each test gets a fresh database name. Pollution between tests can no longer cause `AlreadyExists` on `createDatabase` or pre-populated catalog snapshots.
2. **Delta-based catalog/namespace assertions** in `TestInternalMixedCatalogService.TestDatabaseOperation.test` and `TestInternalIcebergCatalogService.NamespaceTests.testNamespaceOperations`. The previous code asserted `catalog.listDatabases().isEmpty()` which only holds in a single-test-class-per-JVM execution.

## Why are the changes needed?

These tests have been flaky on `master` for a while — for example, the `Core/hadoop3 CI` run on 2026-04-23 failed inside `TestInternalIcebergCatalogService\$CatalogPropertiesTest`'s suite, and PR #4200's CI just hit the same family of failures, all surfacing the same root cause:

```
TestInternalMixedCatalogService\$TestDatabaseOperation.test:168
    expected: <true> but was: <false>          // listDatabases().isEmpty() failed because a previous test leaked test_ns

TestInternalMixedCatalogService\$TestTableOperation.before:186
    AlreadyExists Database: test_ns already exists  // previous @AfterEach swallowed dropDatabase failure

TestInternalMixedCatalogService\$TestTableCommit.testTableCommit:295
    NoSuchTableException: ...test_iceberg_tbl not exists  // sibling test's @AfterEach.dropTable raced into our just-created table
```

The shared `test_ns` / `test_iceberg_tbl` names are the load-bearing reason these races collide. With unique per-instance database names, every test gets its own namespace, so concurrent or leaked cleanup from a sibling test no longer touches it.

This is complementary to #4185, which fixed a `Version-N-already-exists` race in `InternalMixedIcebergHandler.newTableOperations` triggered by the same shared-state pattern.

## How was this patch tested?

Ran the affected suites locally on Java 11:

```
./mvnw test -pl amoro-ams -am -Pspark-3.5,support-all-formats,openapi-sdk \\
  -Dtest='TestInternalMixedCatalogService,TestInternalIcebergCatalogService'
# Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
```

`./mvnw spotless:check checkstyle:check -pl amoro-ams -am` is clean.

## Does this PR introduce any user-facing change?

No — test-only change.