### PR TITLE
[AMORO-4203][optimizer-common] Migrate tests from JUnit 4 to JUnit 5

### DIFF
--- a/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/OptimizerTestBase.java
+++ b/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/OptimizerTestBase.java
@@ -19,19 +19,25 @@
 package org.apache.amoro.optimizer.common;
 
 import org.apache.amoro.TestAms;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class OptimizerTestBase {
-  @ClassRule public static TestAms TEST_AMS = new TestAms();
+  protected static final TestAms TEST_AMS = new TestAms();
 
-  @BeforeClass
-  public static void reduceCallAmsInterval() {
+  @BeforeAll
+  public static void startTestAms() throws Exception {
+    TEST_AMS.before();
     OptimizerTestHelpers.setCallAmsIntervalForTest();
   }
 
-  @Before
+  @AfterAll
+  public static void stopTestAms() {
+    TEST_AMS.after();
+  }
+
+  @BeforeEach
   public void clearTasks() {
     TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().clear();
     TEST_AMS.getOptimizerHandler().getPendingTasks().clear();

--- a/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizer.java
+++ b/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizer.java
@@ -19,19 +19,13 @@
 package org.apache.amoro.optimizer.common;
 
 import org.apache.amoro.api.OptimizingTaskResult;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class TestOptimizer extends OptimizerTestBase {
-
-  @BeforeClass
-  public static void reduceCallAmsInterval() {
-    OptimizerTestHelpers.setCallAmsIntervalForTest();
-  }
 
   @Test
   public void testStartOptimizer() throws InterruptedException {
@@ -40,7 +34,7 @@ public class TestOptimizer extends OptimizerTestBase {
     Optimizer optimizer = new Optimizer(optimizerConfig);
     new Thread(optimizer::startOptimizing).start();
     TimeUnit.SECONDS.sleep(1);
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().size());
+    Assertions.assertEquals(1, TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().size());
     TEST_AMS
         .getOptimizerHandler()
         .offerTask(TestOptimizerExecutor.TestOptimizingInput.successInput(1).toTask(0, 0));
@@ -51,7 +45,7 @@ public class TestOptimizer extends OptimizerTestBase {
     String token = optimizer.getToucher().getToken();
     List<OptimizingTaskResult> taskResults =
         TEST_AMS.getOptimizerHandler().getCompletedTasks().get(token);
-    Assert.assertEquals(2, taskResults.size());
+    Assertions.assertEquals(2, taskResults.size());
     optimizer.stopOptimizing();
   }
 }

--- a/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerConfig.java
+++ b/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerConfig.java
@@ -18,8 +18,8 @@
 
 package org.apache.amoro.optimizer.common;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.kohsuke.args4j.CmdLineException;
 
 import java.util.UUID;
@@ -31,13 +31,13 @@ public class TestOptimizerConfig {
     String cmd = "-a thrift://127.0.0.1:1260 -p 11 -g g1 -hb 2000 -eds -dsp /tmp/amoro -msz 512";
     String[] args = cmd.split(" ");
     OptimizerConfig optimizerConfig = new OptimizerConfig(args);
-    Assert.assertEquals("thrift://127.0.0.1:1260", optimizerConfig.getAmsUrl());
-    Assert.assertEquals(11, optimizerConfig.getExecutionParallel());
-    Assert.assertEquals("g1", optimizerConfig.getGroupName());
-    Assert.assertEquals(2000, optimizerConfig.getHeartBeat());
-    Assert.assertTrue(optimizerConfig.isExtendDiskStorage());
-    Assert.assertEquals("/tmp/amoro", optimizerConfig.getDiskStoragePath());
-    Assert.assertEquals(512, optimizerConfig.getMemoryStorageSize());
+    Assertions.assertEquals("thrift://127.0.0.1:1260", optimizerConfig.getAmsUrl());
+    Assertions.assertEquals(11, optimizerConfig.getExecutionParallel());
+    Assertions.assertEquals("g1", optimizerConfig.getGroupName());
+    Assertions.assertEquals(2000, optimizerConfig.getHeartBeat());
+    Assertions.assertTrue(optimizerConfig.isExtendDiskStorage());
+    Assertions.assertEquals("/tmp/amoro", optimizerConfig.getDiskStoragePath());
+    Assertions.assertEquals(512, optimizerConfig.getMemoryStorageSize());
   }
 
   @Test
@@ -60,31 +60,31 @@ public class TestOptimizerConfig {
     config.setMemoryStorageSize(memoryStorageSize);
     config.setResourceId(resourceId);
 
-    Assert.assertEquals(amsUrl, config.getAmsUrl());
-    Assert.assertEquals(executionParallel, config.getExecutionParallel());
-    Assert.assertEquals(groupName, config.getGroupName());
-    Assert.assertEquals(heartBeat, config.getHeartBeat());
-    Assert.assertTrue(config.isExtendDiskStorage());
-    Assert.assertEquals(diskStoragePath, config.getDiskStoragePath());
-    Assert.assertEquals(memoryStorageSize, config.getMemoryStorageSize());
-    Assert.assertEquals(resourceId, config.getResourceId());
+    Assertions.assertEquals(amsUrl, config.getAmsUrl());
+    Assertions.assertEquals(executionParallel, config.getExecutionParallel());
+    Assertions.assertEquals(groupName, config.getGroupName());
+    Assertions.assertEquals(heartBeat, config.getHeartBeat());
+    Assertions.assertTrue(config.isExtendDiskStorage());
+    Assertions.assertEquals(diskStoragePath, config.getDiskStoragePath());
+    Assertions.assertEquals(memoryStorageSize, config.getMemoryStorageSize());
+    Assertions.assertEquals(resourceId, config.getResourceId());
   }
 
-  @Test(expected = CmdLineException.class)
-  public void testMissingRequiredArgs() throws CmdLineException {
+  @Test
+  public void testMissingRequiredArgs() {
     String[] args = {"-a", "thrift://127.0.0.1:1260", "-p", "4"};
-    new OptimizerConfig(args);
+    Assertions.assertThrows(CmdLineException.class, () -> new OptimizerConfig(args));
   }
 
-  @Test(expected = CmdLineException.class)
-  public void testInvalidArgs() throws CmdLineException {
+  @Test
+  public void testInvalidArgs() {
     String[] args = {"-a", "thrift://127.0.0.1:1260", "-p", "invalid", "-g", "testGroup"};
-    new OptimizerConfig(args);
+    Assertions.assertThrows(CmdLineException.class, () -> new OptimizerConfig(args));
   }
 
-  @Test(expected = CmdLineException.class)
-  public void testMissingValueArgs() throws CmdLineException {
+  @Test
+  public void testMissingValueArgs() {
     String[] args = {"-a", "thrift://127.0.0.1:1260", "-p", "-g", "testGroup"};
-    new OptimizerConfig(args);
+    Assertions.assertThrows(CmdLineException.class, () -> new OptimizerConfig(args));
   }
 }

--- a/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerExecutor.java
+++ b/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerExecutor.java
@@ -30,10 +30,10 @@ import org.apache.amoro.optimizing.TaskProperties;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
 import org.apache.amoro.shade.thrift.org.apache.thrift.TException;
 import org.apache.amoro.utils.SerializationUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +44,7 @@ public class TestOptimizerExecutor extends OptimizerTestBase {
 
   private OptimizerExecutor optimizerExecutor;
 
-  @Before
+  @BeforeEach
   public void startOptimizer() {
     OptimizerConfig optimizerConfig =
         OptimizerTestHelpers.buildOptimizerConfig(TEST_AMS.getServerUrl());
@@ -52,7 +52,7 @@ public class TestOptimizerExecutor extends OptimizerTestBase {
     new Thread(optimizerExecutor::start).start();
   }
 
-  @After
+  @AfterEach
   public void stopOptimizer() {
     optimizerExecutor.stop();
   }
@@ -61,7 +61,7 @@ public class TestOptimizerExecutor extends OptimizerTestBase {
   public void testWaitForToken() throws InterruptedException {
     TEST_AMS.getOptimizerHandler().offerTask(TestOptimizingInput.successInput(1).toTask(0, 0));
     TimeUnit.MILLISECONDS.sleep(OptimizerTestHelpers.CALL_AMS_INTERVAL * 2);
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
+    Assertions.assertEquals(1, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
   }
 
   @Test
@@ -70,18 +70,19 @@ public class TestOptimizerExecutor extends OptimizerTestBase {
     String token =
         TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().keySet().iterator().next();
     TEST_AMS.getOptimizerHandler().offerTask(TestOptimizingInput.successInput(1).toTask(0, 0));
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
+    Assertions.assertEquals(1, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
     optimizerExecutor.setToken(token);
     TimeUnit.MILLISECONDS.sleep(OptimizerTestHelpers.CALL_AMS_INTERVAL * 2);
-    Assert.assertEquals(0, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
-    Assert.assertTrue(TEST_AMS.getOptimizerHandler().getCompletedTasks().containsKey(token));
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getCompletedTasks().get(token).size());
+    Assertions.assertEquals(0, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
+    Assertions.assertTrue(TEST_AMS.getOptimizerHandler().getCompletedTasks().containsKey(token));
+    Assertions.assertEquals(
+        1, TEST_AMS.getOptimizerHandler().getCompletedTasks().get(token).size());
     OptimizingTaskResult taskResult =
         TEST_AMS.getOptimizerHandler().getCompletedTasks().get(token).get(0);
-    Assert.assertEquals(new OptimizingTaskId(0, 0), taskResult.getTaskId());
-    Assert.assertNull(taskResult.getErrorMessage());
+    Assertions.assertEquals(new OptimizingTaskId(0, 0), taskResult.getTaskId());
+    Assertions.assertNull(taskResult.getErrorMessage());
     TestOptimizingOutput output = SerializationUtil.simpleDeserialize(taskResult.getTaskOutput());
-    Assert.assertEquals(1, output.inputId());
+    Assertions.assertEquals(1, output.inputId());
   }
 
   @Test
@@ -90,17 +91,18 @@ public class TestOptimizerExecutor extends OptimizerTestBase {
     String token =
         TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().keySet().iterator().next();
     TEST_AMS.getOptimizerHandler().offerTask(TestOptimizingInput.failedInput(1).toTask(0, 0));
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
+    Assertions.assertEquals(1, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
     optimizerExecutor.setToken(token);
     TimeUnit.MILLISECONDS.sleep(OptimizerTestHelpers.CALL_AMS_INTERVAL * 2);
-    Assert.assertEquals(0, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
-    Assert.assertTrue(TEST_AMS.getOptimizerHandler().getCompletedTasks().containsKey(token));
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getCompletedTasks().get(token).size());
+    Assertions.assertEquals(0, TEST_AMS.getOptimizerHandler().getPendingTasks().size());
+    Assertions.assertTrue(TEST_AMS.getOptimizerHandler().getCompletedTasks().containsKey(token));
+    Assertions.assertEquals(
+        1, TEST_AMS.getOptimizerHandler().getCompletedTasks().get(token).size());
     OptimizingTaskResult taskResult =
         TEST_AMS.getOptimizerHandler().getCompletedTasks().get(token).get(0);
-    Assert.assertEquals(new OptimizingTaskId(0, 0), taskResult.getTaskId());
-    Assert.assertNull(taskResult.getTaskOutput());
-    Assert.assertTrue(taskResult.getErrorMessage().contains(FAILED_TASK_MESSAGE));
+    Assertions.assertEquals(new OptimizingTaskId(0, 0), taskResult.getTaskId());
+    Assertions.assertNull(taskResult.getTaskOutput());
+    Assertions.assertTrue(taskResult.getErrorMessage().contains(FAILED_TASK_MESSAGE));
   }
 
   public static class TestOptimizingInput extends BaseOptimizingInput {

--- a/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerToucher.java
+++ b/amoro-optimizer/amoro-optimizer-common/src/test/java/org/apache/amoro/optimizer/common/TestOptimizerToucher.java
@@ -22,8 +22,8 @@ import org.apache.amoro.OptimizerProperties;
 import org.apache.amoro.api.OptimizerRegisterInfo;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -43,8 +43,8 @@ public class TestOptimizerToucher extends OptimizerTestBase {
     optimizerToucher.withRegisterProperty("test_k", "test_v");
     new Thread(optimizerToucher::start).start();
     tokenChangeListener.waitForTokenChange();
-    Assert.assertEquals(1, tokenChangeListener.tokenList().size());
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().size());
+    Assertions.assertEquals(1, tokenChangeListener.tokenList().size());
+    Assertions.assertEquals(1, TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().size());
     Map<String, String> optimizerProperties = Maps.newHashMap();
     optimizerProperties.put("test_k", "test_v");
     optimizerProperties.put(OptimizerProperties.OPTIMIZER_HEART_BEAT_INTERVAL, "1000");
@@ -54,8 +54,8 @@ public class TestOptimizerToucher extends OptimizerTestBase {
     // clear all optimizer, toucher will register again
     TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().clear();
     tokenChangeListener.waitForTokenChange();
-    Assert.assertEquals(2, tokenChangeListener.tokenList().size());
-    Assert.assertEquals(1, TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().size());
+    Assertions.assertEquals(2, tokenChangeListener.tokenList().size());
+    Assertions.assertEquals(1, TEST_AMS.getOptimizerHandler().getRegisteredOptimizers().size());
     validateRegisteredOptimizer(
         tokenChangeListener.tokenList().get(1), optimizerConfig, optimizerProperties);
 
@@ -66,14 +66,14 @@ public class TestOptimizerToucher extends OptimizerTestBase {
       String token, OptimizerConfig registerConfig, Map<String, String> optimizerProperties) {
     Map<String, OptimizerRegisterInfo> registeredOptimizerMap =
         TEST_AMS.getOptimizerHandler().getRegisteredOptimizers();
-    Assert.assertTrue(registeredOptimizerMap.containsKey(token));
+    Assertions.assertTrue(registeredOptimizerMap.containsKey(token));
 
     OptimizerRegisterInfo registerInfo = registeredOptimizerMap.get(token);
-    Assert.assertEquals(registerConfig.getResourceId(), registerInfo.getResourceId());
-    Assert.assertEquals(registerConfig.getGroupName(), registerInfo.getGroupName());
-    Assert.assertEquals(registerConfig.getMemorySize(), registerInfo.getMemoryMb());
-    Assert.assertEquals(registerConfig.getExecutionParallel(), registerInfo.getThreadCount());
-    Assert.assertEquals(optimizerProperties, registerInfo.getProperties());
+    Assertions.assertEquals(registerConfig.getResourceId(), registerInfo.getResourceId());
+    Assertions.assertEquals(registerConfig.getGroupName(), registerInfo.getGroupName());
+    Assertions.assertEquals(registerConfig.getMemorySize(), registerInfo.getMemoryMb());
+    Assertions.assertEquals(registerConfig.getExecutionParallel(), registerInfo.getThreadCount());
+    Assertions.assertEquals(optimizerProperties, registerInfo.getProperties());
   }
 
   static class TestTokenChangeListener implements OptimizerToucher.TokenChangeListener {


### PR DESCRIPTION
## What is this PR for?

Closes part of #4203 (Step 2 — `amoro-optimizer-common`, the smallest leaf module).

Migrates the 5 test files in `amoro-optimizer-common` to JUnit Jupiter:

- `OptimizerTestBase`
- `TestOptimizer`
- `TestOptimizerToucher`
- `TestOptimizerExecutor`
- `TestOptimizerConfig`

## How TestAms is consumed without migrating it yet

`OptimizerTestBase` previously held `@ClassRule public static TestAms TEST_AMS = new TestAms();`. `TestAms` extends `org.junit.rules.ExternalResource` and is shared across many modules, so per the staged plan in #4203 it stays on JUnit 4 until the very last (Step 9) PR.

To unblock this step, the base class now invokes `TEST_AMS.before()` from `@BeforeAll` and `TEST_AMS.after()` from `@AfterAll`. Both methods are already `public` on `TestAms`, so no reflection or wrapper is needed and the lifecycle is identical to what `@ClassRule` produced. Once #4203 reaches Step 9, `TestAms` will move to a JUnit 5 `Extension` and these direct calls can be replaced with `@RegisterExtension` for free.

## Other mechanical changes

- `org.junit.*` → `org.junit.jupiter.api.*`
- `@Before` / `@After` → `@BeforeEach` / `@AfterEach`; `@BeforeClass` → `@BeforeAll`
- `Assert.assertX(...)` → `Assertions.assertX(...)`
- `TestOptimizerConfig`: three `@Test(expected = CmdLineException.class)` rewritten as `Assertions.assertThrows(CmdLineException.class, () -> ...)`
- `TestOptimizer`: dropped its duplicate `@BeforeClass reduceCallAmsInterval()` because the parent already calls `OptimizerTestHelpers.setCallAmsIntervalForTest()` from `@BeforeAll`

## Type of change

- [x] Improvement (test infrastructure)

## How was this patch tested?

`mvn -pl amoro-optimizer/amoro-optimizer-common -am test` → 10/10 tests pass under the JUnit Platform provider, `mvn spotless:check` clean.