### PR TITLE
[AMORO-4235] Handling stale ack gracefully when task is reset by OptimizerKeeper

### DIFF
--- a/amoro-optimizer/amoro-optimizer-common/src/main/java/org/apache/amoro/optimizer/common/OptimizerExecutor.java
+++ b/amoro-optimizer/amoro-optimizer-common/src/main/java/org/apache/amoro/optimizer/common/OptimizerExecutor.java
@@ -234,14 +234,28 @@ public class OptimizerExecutor extends AbstractOptimizerOperator {
           amsUrl);
       return true;
     } catch (TException exception) {
-      LOG.error(
-          "Optimizer executor[{}] acknowledged task[{}] to AMS {} failed",
-          threadId,
-          task.getTaskId(),
-          amsUrl,
-          exception);
+      if (isTaskResetOrNotScheduled(exception)) {
+        LOG.warn(
+            "Optimizer executor[{}] acknowledged task[{}] to AMS {} failed because "
+                + "task has been reset by OptimizerKeeper, this is expected and will be skipped",
+            threadId,
+            task.getTaskId(),
+            amsUrl);
+      } else {
+        LOG.error(
+            "Optimizer executor[{}] acknowledged task[{}] to AMS {} failed",
+            threadId,
+            task.getTaskId(),
+            amsUrl,
+            exception);
+      }
       return false;
     }
+  }
+
+  /** Check if the exception is caused by task reset by OptimizerKeeper. */
+  private static boolean isTaskResetOrNotScheduled(TException exception) {
+    return exception.getMessage() != null && exception.getMessage().contains("Task has been reset");
   }
 
   protected OptimizingTaskResult executeTask(OptimizingTask task) {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #4235.

## Brief change log

When OptimizerKeeper detects an optimizer is expired and resets tasks by clearing
the task token, the Optimizer may still poll and attempt to ack those stale tasks.
Previously this caused ERROR logs and unexpected behavior.

This fix adds exception detection in OptimizerExecutor.ackTask() to recognize the
"Task has been reset" exception. When detected:
- Log level is reduced from ERROR to WARN
- Return false to skip task execution (as expected)
- The task will be re-polled by another optimizer and re-executed**


## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
