### PR TITLE
[AMORO-4242][Helm] Add Gateway API HTTPRoute support to the Amoro chart

### DIFF
--- a/charts/amoro/templates/amoro-httproute.yaml
+++ b/charts/amoro/templates/amoro-httproute.yaml
@@ -1,0 +1,54 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{ if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: httproute
+  {{- if or .Values.httpRoute.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.httpRoute.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.httpRoute.parentRefs }}
+  parentRefs: {{- include "common.tplvalues.render" ( dict "value" .Values.httpRoute.parentRefs "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.httpRoute.hostname .Values.httpRoute.extraHosts }}
+  hostnames:
+    {{- if .Values.httpRoute.hostname }}
+    - {{ .Values.httpRoute.hostname | quote }}
+    {{- end }}
+    {{- range .Values.httpRoute.extraHosts }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.httpRoute.pathType }}
+            value: {{ .Values.httpRoute.path | quote }}
+      backendRefs:
+        - name: {{ printf "%s-rest" (include "common.names.fullname" .) }}
+          port: {{ .Values.server.rest.port }}
+    {{- if .Values.httpRoute.extraRules }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.httpRoute.extraRules "context" $ ) | nindent 4 }}
+    {{- end }}
+{{ end }}

--- a/charts/amoro/tests/amoro-httproute_test.yaml
+++ b/charts/amoro/tests/amoro-httproute_test.yaml
@@ -1,0 +1,192 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#    or more contributor license agreements.  See the NOTICE file
+#    distributed with this work for additional information
+#    regarding copyright ownership.  The ASF licenses this file
+#    to you under the Apache License, Version 2.0 (the
+#    "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+suite: Test Amoro HTTPRoute
+templates:
+  - amoro-httproute.yaml
+chart:
+  appVersion: 0.1.0
+  version: 0.6.0
+tests:
+  - it: Amoro HTTPRoute should not exist if enabled is set to false
+    set:
+      httpRoute:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: Amoro HTTPRoute should exist if enabled is set to true
+    set:
+      fullnameOverride: test
+      httpRoute:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: test
+  - it: Amoro HTTPRoute should contain common labels and common annotations if set
+    set:
+      httpRoute:
+        enabled: true
+      commonLabels:
+        LABEL: LABEL_V
+      commonAnnotations:
+        ANNOTATION: ANNOTATION_V
+    asserts:
+      - exists:
+          path: metadata.labels
+      - isSubset:
+          path: metadata.labels
+          content:
+            LABEL: LABEL_V
+      - equal:
+          path: metadata.labels['app.kubernetes.io/component']
+          value: httproute
+      - exists:
+          path: metadata.annotations
+      - isSubset:
+          path: metadata.annotations
+          content:
+            ANNOTATION: ANNOTATION_V
+  - it: Amoro HTTPRoute should contain httpRoute annotations if set
+    set:
+      httpRoute:
+        enabled: true
+        annotations:
+          ANNOTATION: ANNOTATION_V2
+    asserts:
+      - exists:
+          path: metadata.annotations
+      - isSubset:
+          path: metadata.annotations
+          content:
+            ANNOTATION: ANNOTATION_V2
+  - it: Amoro HTTPRoute should not contain annotations if annotations are not set
+    set:
+      httpRoute:
+        enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: Amoro HTTPRoute should not contain parentRefs if not set
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs: [ ]
+    asserts:
+      - notExists:
+          path: spec.parentRefs
+  - it: Amoro HTTPRoute should contain parentRefs if set
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: eg
+            namespace: envoy-gateway-system
+            sectionName: http
+    asserts:
+      - contains:
+          path: spec.parentRefs
+          content:
+            name: eg
+            namespace: envoy-gateway-system
+            sectionName: http
+  - it: Amoro HTTPRoute should contain default hostname, path match and backendRef
+    set:
+      fullnameOverride: test
+      httpRoute:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.hostnames
+          content: amoro.local
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - contains:
+          path: spec.rules[0].backendRefs
+          content:
+            name: test-rest
+            port: 1630
+  - it: Amoro HTTPRoute should not contain hostnames if hostname and extraHosts are empty
+    set:
+      httpRoute:
+        enabled: true
+        hostname: ""
+        extraHosts: [ ]
+    asserts:
+      - notExists:
+          path: spec.hostnames
+  - it: Amoro HTTPRoute should contain extra Hosts if set
+    set:
+      httpRoute:
+        enabled: true
+        hostname: "amoro.local"
+        extraHosts:
+          - amoro2.local
+    asserts:
+      - contains:
+          path: spec.hostnames
+          content: amoro.local
+      - contains:
+          path: spec.hostnames
+          content: amoro2.local
+  - it: Amoro HTTPRoute should respect custom path and pathType
+    set:
+      httpRoute:
+        enabled: true
+        path: /amoro
+        pathType: Exact
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /amoro
+  - it: Amoro HTTPRoute should contain extra Rules if set
+    set:
+      httpRoute:
+        enabled: true
+        extraRules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /extra
+            backendRefs:
+              - name: extra-svc
+                port: 8080
+    asserts:
+      - contains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /extra
+            backendRefs:
+              - name: extra-svc
+                port: 8080

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -416,6 +416,54 @@ ingress:
   ##
   extraRules: [ ]
 
+httpRoute:
+  ## @param httpRoute.enabled Enable Gateway API HTTPRoute resource for Amoro Dashboard
+  ## This is an alternative to `ingress` for clusters using the Gateway API (https://gateway-api.sigs.k8s.io/).
+  ## It requires the Gateway API CRDs and a Gateway to be installed in the cluster.
+  ##
+  enabled: false
+  ## @param httpRoute.parentRefs The list of Gateways (and optional listener sections) this route attaches to
+  ## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+  ## e.g:
+  ## parentRefs:
+  ##   - name: my-gateway
+  ##     namespace: gateway-system
+  ##     sectionName: https
+  ##
+  parentRefs: [ ]
+  ## @param httpRoute.hostname Default hostname for the HTTPRoute
+  ##
+  hostname: amoro.local
+  ## @param httpRoute.path The path to match for the main hostname
+  ##
+  path: /
+  ## @param httpRoute.pathType The Gateway API path match type. One of `PathPrefix`, `Exact` or `RegularExpression`
+  ## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/#path-types
+  ##
+  pathType: PathPrefix
+  ## @param httpRoute.annotations Additional annotations for the HTTPRoute resource
+  ##
+  annotations: { }
+  ## @param httpRoute.extraHosts The list of additional hostnames to be covered with this route
+  ## e.g:
+  ## extraHosts:
+  ##   - amoro2.local
+  ##
+  extraHosts: [ ]
+  ## @param httpRoute.extraRules Additional rules to be covered with this route
+  ## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/#httproute
+  ## e.g:
+  ## extraRules:
+  ##   - matches:
+  ##       - path:
+  ##           type: PathPrefix
+  ##           value: /api
+  ##     backendRefs:
+  ##       - name: another-svc
+  ##         port: 8080
+  ##
+  extraRules: [ ]
+
 ## Liveness probe
 ##
 livenessProbe:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds optional Gateway API `HTTPRoute` support to the `charts/amoro` Helm chart, as an alternative to the existing `Ingress` for clusters that have standardized on the [Gateway API](https://gateway-api.sigs.k8s.io/).

The change is purely additive — the existing `Ingress` template and its tests are untouched, and `httpRoute.enabled` defaults to `false`, so existing installations are unaffected.

- `values.yaml`: new `httpRoute` block (`enabled`, `parentRefs`, `hostname`, `path`, `pathType`, `annotations`, `extraHosts`, `extraRules`), mirroring the shape and `## @param` documentation of the existing `ingress` block.
- `templates/amoro-httproute.yaml`: new template gated on `httpRoute.enabled`, rendering a `gateway.networking.k8s.io/v1` `HTTPRoute` that backends to the existing `<fullname>-rest` Service (port `1630`) — the same Service the `Ingress` targets. It reuses the chart's `common.names.*`, `common.labels.standard`, and `common.tplvalues.*` helpers.
- `tests/amoro-httproute_test.yaml`: 12 helm-unittest cases mirroring `amoro-ingress_test.yaml`.

### Why are the changes needed?

Gateway API is the successor to Ingress and is the recommended north-south routing API on many clusters (Istio, Envoy Gateway, Cilium, Kong, …). Users running a Gateway-API-based ingress data plane currently have to hand-write an `HTTPRoute` outside the chart to expose the Amoro dashboard. This lets them do it declaratively through the chart, the same way `ingress.enabled` works today.

### Brief change log

- Add `httpRoute` parameter block to `charts/amoro/values.yaml`
- Add `charts/amoro/templates/amoro-httproute.yaml`
- Add `charts/amoro/tests/amoro-httproute_test.yaml` (12 helm-unittest cases)

### How was this patch tested?

- `helm unittest charts/amoro` — 8 suites / 87 tests pass (12 new HTTPRoute cases + existing suites, no regression).
- `helm lint charts/amoro --set httpRoute.enabled=true` — passes.
- `helm template` rendered for three scenarios — disabled (0 documents), enabled with `parentRefs` + annotations, and enabled with `extraHosts` + custom path/pathType + `extraRules` — all render as expected and backend to `<release>-amoro-rest:1630`.

Parameters are documented inline via `## @param` comments in `values.yaml`, consistent with how the existing `ingress` parameters are documented (the chart `README.md` does not carry a per-parameter table).

fix #4242