### PR TITLE
[AMORO-4211] Fix legacy Flink config loading

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/FlinkOptimizerContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/FlinkOptimizerContainer.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.YamlParserUtils;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -53,7 +54,6 @@ import org.apache.flink.runtime.webmonitor.handlers.JarUploadHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.JarUploadResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -278,8 +278,8 @@ public class FlinkOptimizerContainer extends AbstractOptimizerContainer {
       Map<String, Object> configDocument;
       Path flinkConfPath = Paths.get(flinkConfDir + FLINK_CONFIG_YAML);
       if (!Files.exists(flinkConfPath, LinkOption.NOFOLLOW_LINKS)) {
-        flinkConfPath = Paths.get(flinkConfDir + LEGACY_FLINK_CONFIG_YAML);
-        configDocument = new Yaml().load(Files.newInputStream(flinkConfPath));
+        configDocument = new HashMap<>();
+        configDocument.putAll(GlobalConfiguration.loadConfiguration(flinkConfDir).toMap());
       } else {
         configDocument = YamlParserUtils.loadYamlFile(new File(flinkConfPath.toUri()));
       }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestFlinkOptimizerContainer.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestFlinkOptimizerContainer.java
@@ -28,9 +28,14 @@ import org.apache.amoro.resource.ResourceType;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
 import org.apache.amoro.utils.MemorySize;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +43,8 @@ import java.util.Objects;
 
 public class TestFlinkOptimizerContainer {
   FlinkOptimizerContainer container = new FlinkOptimizerContainer();
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   Map<String, String> containerProperties = Maps.newHashMap();
 
@@ -97,6 +104,22 @@ public class TestFlinkOptimizerContainer {
     Map<String, String> flinkConfig = container.loadFlinkConfigForYAML(newFlinkConfResourceUrl);
     Assert.assertEquals(flinkConfig.get(TASK_MANAGER_TOTAL_PROCESS_MEMORY), "1728m");
     Assert.assertEquals(flinkConfig.get(JOB_MANAGER_TOTAL_PROCESS_MEMORY), "1600m");
+  }
+
+  @Test
+  public void testReadLegacyFlinkConfigWithMetricFilterIncludes() throws Exception {
+    File flinkConf = tempFolder.newFile("flink-conf.yaml");
+    Files.write(
+        flinkConf.toPath(),
+        String.join(
+                "\n",
+                "jobmanager.rpc.address: localhost",
+                "xxx.metrics.filter.includes: *RSS:*:*;Heap:Used,Max:*")
+            .getBytes(StandardCharsets.UTF_8));
+
+    Map<String, String> flinkConfig = container.loadFlinkConfigForYAML(flinkConf.toURI().toURL());
+    Assert.assertEquals("localhost", flinkConfig.get("jobmanager.rpc.address"));
+    Assert.assertEquals("*RSS:*:*;Heap:Used,Max:*", flinkConfig.get("xxx.metrics.filter.includes"));
   }
 
   @Test


### PR DESCRIPTION
## Why are the changes needed?

Close #4211.

Legacy `flink-conf.yaml` can contain Flink metric filter values that start with `*`, for example:

```yaml
xxx.metrics.filter.includes: *RSS:*:*;Heap:Used,Max:*

Close #xxx.

## Brief change log
Updated FlinkOptimizerContainer to load legacy flink-conf.yaml using Flink GlobalConfiguration.
Kept existing config.yaml loading behavior unchanged.
Added a unit-level regression test for legacy flink-conf.yaml containing metric filter values starting with *.

## How was this patch tested?

Added regression test :

TestFlinkOptimizerContainer#testReadLegacyFlinkConfigWithMetricFilterIncludes

Add screenshots for manual tests if appropriate
<img width="970" height="691" alt="Screenshot 2026-06-11 at 10 33 50 AM" src="https://github.com/user-attachments/assets/e5c7dad3-c761-41bc-9f2f-a69ca195ff8c" />



Run test locally before making a pull request
Ran locally :

./mvnw -pl amoro-ams -am \
  -Dtest=TestFlinkOptimizerContainer#testReadLegacyFlinkConfigWithMetricFilterIncludes \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
  
 Result : 
 Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
  
  
## Documentation


Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable
