### PR TITLE
[AMORO-4257][AMS] Fix duplicate process ID caused by multiple SnowflakeIdGenerator instances

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/process/TableProcessMeta.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/process/TableProcessMeta.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class TableProcessMeta {
-  private static final SnowflakeIdGenerator idGenerator = new SnowflakeIdGenerator();
+
   private long processId;
   private long tableId;
   private volatile String externalProcessIdentifier;
@@ -193,7 +193,7 @@ public class TableProcessMeta {
 
   public static TableProcessMeta createProcessMeta(TableProcess process) {
     TableProcessMeta tableProcessMeta = new TableProcessMeta();
-    tableProcessMeta.setProcessId(idGenerator.generateId());
+    tableProcessMeta.setProcessId(SnowflakeIdGenerator.INSTANCE.generateId());
     tableProcessMeta.setTableId(process.getTableIdentifier().getId());
     tableProcessMeta.setExternalProcessIdentifier("");
     tableProcessMeta.setStatus(ProcessStatus.PENDING);

--- a/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/utils/IcebergTableUtil.java
@@ -78,7 +78,6 @@ import java.util.stream.Collectors;
 public class IcebergTableUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(IcebergTableUtil.class);
-  private static final SnowflakeIdGenerator snowflakeIdGenerator = new SnowflakeIdGenerator();
 
   public static long getSnapshotId(Table table, boolean refresh) {
     Snapshot currentSnapshot = getSnapshot(table, refresh);
@@ -284,7 +283,7 @@ public class IcebergTableUtil {
                             table, entry.getKey(), entry.getValue()))
                 .reduce(Expressions::or)
                 .orElse(Expressions.alwaysTrue());
-    long processId = snowflakeIdGenerator.generateId();
+    long processId = SnowflakeIdGenerator.INSTANCE.generateId();
     ServerTableIdentifier identifier = tableRuntime.getTableIdentifier();
     OptimizingConfig config = tableRuntime.getOptimizingConfig();
     long lastMinor = tableRuntime.getLastMinorOptimizingTime();

--- a/amoro-ams/src/main/java/org/apache/amoro/server/utils/SnowflakeIdGenerator.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/utils/SnowflakeIdGenerator.java
@@ -20,6 +20,9 @@ package org.apache.amoro.server.utils;
 
 /** SnowflakeId generator */
 public class SnowflakeIdGenerator {
+  /** Global singleton instance for process ID generation. */
+  public static final SnowflakeIdGenerator INSTANCE = new SnowflakeIdGenerator();
+
   // Base timestamp (e.g., the start time of the service)
   private static final long EPOCH_SECONDS = 0L;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix duplicate process ID generation caused by multiple independent `SnowflakeIdGenerator` 
instances in the same AMS JVM.

### Root Cause

Two separate static `SnowflakeIdGenerator` instances existed:
- `IcebergTableUtil.snowflakeIdGenerator` (for optimizing process IDs)
- `TableProcessMeta.idGenerator` (for maintenance process IDs)

Both used default `machineId = 0` and maintained independent `sequence` counters. 
When both entered the same 10ms time window, they generated identical IDs, causing 
PRIMARY KEY conflicts in the `table_process` table.

### Fix

Consolidate to a single global singleton `SnowflakeIdGenerator.INSTANCE`, ensuring 
the `synchronized` lock and `sequence` counter work correctly across all callers.

## How was this patch tested?

- Verified singleton generates unique IDs under concurrent access
- Confirmed no regression in optimizing and maintenance process flows
fix #4257
