### PR TITLE
Fix expireSnapshots fails with IllegalArgumentException on object-store-backed tables

### DIFF
--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/RollingFileCleaner.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/RollingFileCleaner.java
@@ -92,32 +92,43 @@ public class RollingFileCleaner {
       return;
     }
 
-    if (fileIO.supportBulkOperations()) {
-      try {
-        fileIO.asBulkFileIO().deleteFiles(collectedFiles);
-        cleanedFileCounter.addAndGet(collectedFiles.size());
-      } catch (BulkDeletionFailureException e) {
-        LOG.warn("Failed to delete {} expired files in bulk", e.numberFailedObjects());
-      }
-    } else {
-      for (String filePath : collectedFiles) {
+    try {
+      if (fileIO.supportBulkOperations()) {
         try {
-          fileIO.deleteFile(filePath);
-          cleanedFileCounter.incrementAndGet();
-        } catch (Exception e) {
-          LOG.warn("Failed to delete expired file: {}", filePath, e);
+          fileIO.asBulkFileIO().deleteFiles(collectedFiles);
+          cleanedFileCounter.addAndGet(collectedFiles.size());
+        } catch (BulkDeletionFailureException e) {
+          LOG.warn("Failed to delete {} expired files in bulk", e.numberFailedObjects());
+        }
+      } else {
+        for (String filePath : collectedFiles) {
+          try {
+            fileIO.deleteFile(filePath);
+            cleanedFileCounter.incrementAndGet();
+          } catch (Exception e) {
+            LOG.warn("Failed to delete expired file: {}", filePath, e);
+          }
         }
       }
-    }
-    // Try to delete empty parent directories
-    for (String parentDir : parentDirectories) {
-      TableFileUtil.deleteEmptyDirectory(fileIO, parentDir, excludeFiles);
-    }
-    parentDirectories.clear();
+      // Try to delete empty parent directories. Skipped automatically by
+      // TableFileUtil.deleteEmptyDirectory when the underlying FileIO is an object store.
+      if (fileIO.supportFileSystemOperations()) {
+        for (String parentDir : parentDirectories) {
+          try {
+            TableFileUtil.deleteEmptyDirectory(fileIO, parentDir, excludeFiles);
+          } catch (Exception e) {
+            LOG.warn("Failed to delete empty parent directory: {}", parentDir, e);
+          }
+        }
+      }
 
-    LOG.debug("Cleaned expired a file group, total files: {}", collectedFiles.size());
-
-    collectedFiles.clear();
+      LOG.debug("Cleaned expired a file group, total files: {}", collectedFiles.size());
+    } finally {
+      // Always drop both buffers so a failure in directory cleanup does not cause the
+      // already-deleted files to be re-submitted on the next batch.
+      parentDirectories.clear();
+      collectedFiles.clear();
+    }
   }
 
   public int fileCount() {

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/utils/TableFileUtil.java
@@ -87,6 +87,12 @@ public class TableFileUtil {
     if (directoryPath == null || directoryPath.isEmpty()) {
       return;
     }
+    // Object stores (S3FileIO / OSSFileIO / GCSFileIO ...) have no real directory concept.
+    // They are exposed via AuthenticatedFileIOAdapter whose supportFileSystemOperations() is
+    // false, so calling asFileSystemIO() would fail the precondition. Skip silently in that case.
+    if (!io.supportFileSystemOperations()) {
+      return;
+    }
     if (!io.exists(directoryPath)) {
       LOG.debug("The target directory {} does not exist or has been deleted", directoryPath);
       return;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `expireSnapshots` task failing with `IllegalArgumentException: null` when the 
underlying FileIO is an object store (S3FileIO / OSSFileIO / GCSFileIO / ResolvingFileIO).

### Root Cause

`RollingFileCleaner.doCleanFiles()` unconditionally calls `TableFileUtil.deleteEmptyDirectory()`, 
which calls `io.asFileSystemIO()`. For object-store FileIO implementations, 
`supportFileSystemOperations()` returns `false`, causing `Preconditions.checkArgument()` 
to throw `IllegalArgumentException: null`.

"Delete empty parent directory" is only meaningful for HDFS/Hadoop FS semantics — object 
stores have no real directory concept.

### Fix

1. **`TableFileUtil.deleteEmptyDirectory()`**: Add early-return when `!io.supportFileSystemOperations()`
2. **`RollingFileCleaner.doCleanFiles()`**: 
   - Guard the parent directory cleanup loop with `supportFileSystemOperations()` check
   - Catch per-directory exceptions as WARN to avoid interrupting the entire batch
   - Move `parentDirectories.clear()` and `collectedFiles.clear()` into `finally` block

No schema / config / API signature changes. HDFS tables are completely unaffected.

## How was this patch tested?

- Verified on production environment with S3FileIO (Tencent Cloud COS)
- Confirmed HDFS-backed tables still clean empty directories correctly
- No regression in existing expireSnapshots flows

fix #4237
