### PR TITLE
[hotfix] Fix S3 credentials not vended when loading Lance table

### DIFF
--- a/amoro-format-lance/src/main/java/org/apache/amoro/formats/lance/LanceDirectoryV1Catalog.java
+++ b/amoro-format-lance/src/main/java/org/apache/amoro/formats/lance/LanceDirectoryV1Catalog.java
@@ -81,6 +81,7 @@ public class LanceDirectoryV1Catalog implements FormatCatalog {
     Preconditions.checkArgument(
         root != null && !root.isEmpty(), "Warehouse must be set in catalogProperties.");
     this.namespaceProperties.put("manifest_enabled", "false");
+    this.namespaceProperties.put("vend_input_storage_options", "true");
     this.namespaceProperties.put("root", root);
     if (storageAccessKey != null) {
       this.namespaceProperties.put(STORAGE_ACCESS_KEY_ID, storageAccessKey);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
As shown in the figure below, after registering the `lance` table in Amoro, clicking the Details page for the `lance` table to view its schema information will result in the error message shown in the figure below.

<img width="1134" height="690" alt="image" src="https://github.com/user-attachments/assets/7a3edbed-ae5a-453f-8194-f13bf784b6c0" />

<img width="1550" height="659" alt="iShot_2026-07-21_11 33 13" src="https://github.com/user-attachments/assets/e65d1ce1-8eac-41cd-9875-39d16c8308db" />


<img width="2618" height="1210" alt="image" src="https://github.com/user-attachments/assets/d6f33a83-56de-4a5b-8f5f-5b31d59f5288" />

<img width="2602" height="862" alt="image" src="https://github.com/user-attachments/assets/a2ae67b2-e250-4cc8-9fb6-378c62f3c911" />

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

Dataset.open() via namespaceClient fetches storage options from describeTable(), which returns nothing by default. Enable vend_input_storage_options so AK/SK reach object_store instead of falling back to IMDS with Failed ToLoadToken.

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="2794" height="1702" alt="image" src="https://github.com/user-attachments/assets/c1df9e8a-77b0-4be7-bba0-ddcda0c0976a" />
<img width="2804" height="1484" alt="image" src="https://github.com/user-attachments/assets/9582ce09-2677-4d8e-a03f-0a48263a94fe" />

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
