### PR TITLE
[AMORO-4126][ams] Default waitAppCompletion=false for Spark optimizer on Kubernetes

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
@@ -202,6 +202,12 @@ public class SparkOptimizerContainer extends AbstractOptimizerContainer {
 
   private void addKubernetesProperties(
       Resource resource, SparkOptimizerContainer.SparkConf sparkConf) {
+    sparkConf.putToOptions(
+        SparkConfKeys.KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION,
+        StringUtils.defaultIfEmpty(
+            sparkConf.configValue(SparkConfKeys.KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION),
+            "false"));
+
     String driverName = kubernetesDriverName(resource);
     sparkConf.putToOptions(
         SparkOptimizerContainer.SparkConfKeys.KUBERNETES_DRIVER_NAME, driverName);
@@ -332,6 +338,8 @@ public class SparkOptimizerContainer extends AbstractOptimizerContainer {
     public static final String KUBERNETES_IMAGE_REF = "spark.kubernetes.container.image";
     public static final String KUBERNETES_DRIVER_NAME = "spark.kubernetes.driver.pod.name";
     public static final String KUBERNETES_NAMESPACE = "spark.kubernetes.namespace";
+    public static final String KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION =
+        "spark.kubernetes.submission.waitAppCompletion";
     public static final String KUBERNETES_EXECUTOR_LABEL_PREFIX = "spark.kubernetes.driver.label.";
     public static final String KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label.";
     public static final String KUBERNETES_DRA_ENABLED = "spark.dynamicAllocation.enabled";

--- a/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestSparkOptimizerContainer.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestSparkOptimizerContainer.java
@@ -19,6 +19,8 @@
 package org.apache.amoro.server.manager;
 
 import org.apache.amoro.OptimizerProperties;
+import org.apache.amoro.resource.Resource;
+import org.apache.amoro.resource.ResourceType;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,5 +59,76 @@ public class TestSparkOptimizerContainer {
     Assert.assertTrue(sparkOptions.contains("--conf key1=value1"));
     Assert.assertTrue(sparkOptions.contains("--conf key2=value4"));
     Assert.assertTrue(sparkOptions.contains("--conf key5=value5"));
+  }
+
+  @Test
+  public void testKubernetesWaitAppCompletionDefaultsToFalse() {
+    SparkOptimizerContainer container = createContainer("k8s://https://127.0.0.1:6443");
+
+    String startupArgs =
+        container.buildOptimizerStartupArgsString(createResource(Maps.newHashMap()));
+
+    Assert.assertTrue(
+        startupArgs.contains(
+            "--conf "
+                + SparkOptimizerContainer.SparkConfKeys.KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION
+                + "=false"));
+  }
+
+  @Test
+  public void testKubernetesWaitAppCompletionCanBeOverridden() {
+    SparkOptimizerContainer container = createContainer("k8s://https://127.0.0.1:6443");
+    Map<String, String> resourceProperties = Maps.newHashMap();
+    resourceProperties.put(
+        SparkOptimizerContainer.SparkConf.SPARK_PARAMETER_PREFIX
+            + SparkOptimizerContainer.SparkConfKeys.KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION,
+        "true");
+
+    String startupArgs =
+        container.buildOptimizerStartupArgsString(createResource(resourceProperties));
+
+    Assert.assertTrue(
+        startupArgs.contains(
+            "--conf "
+                + SparkOptimizerContainer.SparkConfKeys.KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION
+                + "=true"));
+    Assert.assertFalse(
+        startupArgs.contains(
+            "--conf "
+                + SparkOptimizerContainer.SparkConfKeys.KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION
+                + "=false"));
+  }
+
+  @Test
+  public void testYarnDoesNotSetKubernetesWaitAppCompletion() {
+    SparkOptimizerContainer container = createContainer("yarn");
+
+    String startupArgs =
+        container.buildOptimizerStartupArgsString(createResource(Maps.newHashMap()));
+
+    Assert.assertFalse(
+        startupArgs.contains(
+            SparkOptimizerContainer.SparkConfKeys.KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION));
+  }
+
+  private SparkOptimizerContainer createContainer(String master) {
+    Map<String, String> properties = Maps.newHashMap(containerProperties);
+    properties.put(SparkOptimizerContainer.SPARK_MASTER, master);
+    if (master.startsWith("k8s://")) {
+      properties.put(
+          SparkOptimizerContainer.SparkConf.SPARK_PARAMETER_PREFIX
+              + SparkOptimizerContainer.SparkConfKeys.KUBERNETES_IMAGE_REF,
+          "apache/amoro-spark-optimizer:test");
+    }
+    SparkOptimizerContainer container = new SparkOptimizerContainer();
+    container.init("spark", properties);
+    return container;
+  }
+
+  private Resource createResource(Map<String, String> properties) {
+    return new Resource.Builder("spark", "test-group", ResourceType.OPTIMIZER)
+        .setThreadCount(1)
+        .setProperties(properties)
+        .build();
   }
 }


### PR DESCRIPTION
## Why are the changes needed?

Spark defaults `spark.kubernetes.submission.waitAppCompletion` to `true`. For long-running Spark optimizers on Kubernetes, this keeps each local `spark-submit` launcher process alive in the AMS pod for the lifetime of the optimizer, even though AMS does not use the launcher to track or manage the application. These retained processes add unnecessary memory pressure to AMS.

AMS manages Kubernetes optimizers using a deterministic submission ID, so the launcher can exit after submitting the driver pod.

Closes #4126.

## Brief change log

- Default `spark.kubernetes.submission.waitAppCompletion` to `false` for Spark optimizers deployed on Kubernetes.
- Preserve an explicitly configured value from the optimizing container or group.
- Keep the YARN submission path unchanged.
- Add regression tests for the Kubernetes default, explicit override, and YARN isolation.

## How was this patch tested?

- [x] Add test cases that check the changes thoroughly including negative and positive cases if possible
- [ ] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

`mvn -q -pl amoro-ams -am -Dtest=TestSparkOptimizerContainer -Dsurefire.failIfNoSpecifiedTests=false -Pskip-dashboard-build test`

Result: 4 tests run, 0 failures, 0 errors, 0 skipped.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
