### PR TITLE
[AMORO-4297][AMS] Persist failure reasons in task quota history

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/TaskRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/TaskRuntime.java
@@ -408,6 +408,7 @@ public class TaskRuntime<T extends StagedTaskDescriptor<?, ?, ?>> extends Stated
       this.taskId = task.getTaskId().getTaskId();
       this.tableId = task.getTableId();
       this.retryNum = task.getRetry();
+      this.failReason = task.getFailReason();
     }
 
     public long getStartTime() {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestTaskRuntime.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestTaskRuntime.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.optimizing;
+
+import org.apache.amoro.api.OptimizingTaskId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TestTaskRuntime {
+
+  @Test
+  void taskQuotaCopiesFailReason() {
+    TaskRuntime<?> task = Mockito.mock(TaskRuntime.class);
+    Mockito.when(task.getTaskId()).thenReturn(new OptimizingTaskId(1L, 1));
+    Mockito.when(task.getFailReason()).thenReturn("task failed");
+
+    TaskRuntime.TaskQuota quota = new TaskRuntime.TaskQuota(task);
+
+    Assertions.assertEquals("task failed", quota.getFailReason());
+  }
+}


### PR DESCRIPTION
## Why are the changes needed?

`TaskRuntime` records the error message when an optimizing task fails, but the failure reason was not copied to `TaskQuota`. As a result, `optimizing_task_quota.fail_reason` was persisted as `NULL`.

Fixes #4297.

## Brief change log

- Propagate the failure reason from `TaskRuntime` to `TaskQuota`.
- Add a regression test for the conversion.

## How was this patch tested?

- [x] Added a focused regression test.
- [x] Ran the related optimizing queue tests locally.

```shell
./mvnw test -pl amoro-ams -Dtest=TestTaskRuntime
./mvnw test -pl amoro-ams -Dtest=TestTaskRuntime,TestOptimizingQueue
```

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable