### PR TITLE
[AMORO-4301][ams] Fix Kubernetes executor label prefix

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/SparkOptimizerContainer.java
@@ -340,7 +340,8 @@ public class SparkOptimizerContainer extends AbstractOptimizerContainer {
     public static final String KUBERNETES_NAMESPACE = "spark.kubernetes.namespace";
     public static final String KUBERNETES_SUBMISSION_WAIT_APP_COMPLETION =
         "spark.kubernetes.submission.waitAppCompletion";
-    public static final String KUBERNETES_EXECUTOR_LABEL_PREFIX = "spark.kubernetes.driver.label.";
+    public static final String KUBERNETES_EXECUTOR_LABEL_PREFIX =
+        "spark.kubernetes.executor.label.";
     public static final String KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label.";
     public static final String KUBERNETES_DRA_ENABLED = "spark.dynamicAllocation.enabled";
     public static final String KUBERNETES_DRA_MAX_EXECUTORS =

--- a/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestSparkOptimizerContainer.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/manager/TestSparkOptimizerContainer.java
@@ -76,6 +76,17 @@ public class TestSparkOptimizerContainer {
   }
 
   @Test
+  public void testKubernetesAddsLabelsToDriverAndExecutorPods() {
+    SparkOptimizerContainer container = createContainer("k8s://https://127.0.0.1:6443");
+    Resource resource = createResource(Maps.newHashMap());
+
+    String startupArgs = container.buildOptimizerStartupArgsString(resource);
+
+    assertPodLabels(startupArgs, "spark.kubernetes.driver.label.", resource);
+    assertPodLabels(startupArgs, "spark.kubernetes.executor.label.", resource);
+  }
+
+  @Test
   public void testKubernetesWaitAppCompletionCanBeOverridden() {
     SparkOptimizerContainer container = createContainer("k8s://https://127.0.0.1:6443");
     Map<String, String> resourceProperties = Maps.newHashMap();
@@ -130,5 +141,16 @@ public class TestSparkOptimizerContainer {
         .setThreadCount(1)
         .setProperties(properties)
         .build();
+  }
+
+  private void assertPodLabels(String startupArgs, String labelPrefix, Resource resource) {
+    Assert.assertTrue(
+        startupArgs.contains(
+            "--conf " + labelPrefix + "optimizer-group=" + resource.getGroupName()));
+    Assert.assertTrue(
+        startupArgs.contains(
+            "--conf " + labelPrefix + "optimizer-implementation=spark-native-kubernetes"));
+    Assert.assertTrue(
+        startupArgs.contains("--conf " + labelPrefix + "optimizer-id=" + resource.getResourceId()));
   }
 }


### PR DESCRIPTION
## Why are the changes needed?

`KUBERNETES_EXECUTOR_LABEL_PREFIX` currently uses the driver label prefix. Because Spark options are stored by key in a map, the intended executor entries overwrite the same driver keys and no `spark.kubernetes.executor.label.*` options are emitted. Executor pods therefore miss Amoro's optimizer labels for observability and label-based operations.

Closes #4301.

## Brief change log

- Use `spark.kubernetes.executor.label.` for executor pod labels.
- Add regression coverage for all optimizer labels on both driver and executor startup arguments.

## How was this patch tested?

- [x] Added a regression test that fails before the prefix correction and passes after it.
- [x] `mvn test -pl amoro-ams -am -Dtest=TestSparkOptimizerContainer -Dsurefire.failIfNoSpecifiedTests=false -Pskip-dashboard-build` (JDK 11; 5 tests passed).
- [x] `mvn validate -pl amoro-ams` (JDK 11; Spotless and Checkstyle passed).
- [ ] Screenshots for manual tests (not applicable; no UI change).

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable