### PR TITLE
[AMORO-2099][amoro-web] Remove default Glue lock configuration

### DIFF
--- a/amoro-web/src/views/catalogs/Detail.vue
+++ b/amoro-web/src/views/catalogs/Detail.vue
@@ -184,7 +184,7 @@ const defaultPropertiesMap = {
   hadoop: ['warehouse'],
   filesystem: ['warehouse'],
   custom: ['catalog-impl'],
-  glue: ['warehouse', 'lock-impl', 'lock.table'],
+  glue: ['warehouse'],
   rest: ['uri'],
   PAIMON: ['warehouse'],
 }


### PR DESCRIPTION
## Why are the changes needed?

The Glue Catalog form currently adds `lock-impl` and `lock.table` as default properties. Because the properties form requires non-empty values, users must configure an external lock manager even though the current Iceberg and AWS SDK versions support Glue optimistic locking through the table `versionId`.

This makes Glue Catalog creation require unnecessary DynamoDB lock configuration. Iceberg 1.7.2 automatically uses Glue optimistic locking when `lock-impl` is absent, and Amoro uses AWS SDK 2.24.12, which provides the required `versionId` API.

This is a follow-up to #2099, where the lock properties were originally added to the dashboard.

## Brief change log

- Stop adding `lock-impl` and `lock.table` as default properties for new Glue Catalogs.
- Keep `warehouse` as the only default Glue Catalog property.
- Preserve the generic Properties editor so existing or explicitly configured external lock settings remain supported.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

Validation performed:

- `pnpm build` passed.
- `git diff --check` passed.
- `pnpm lint` was run and reported 137 existing repository lint problems unrelated to this one-line change.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
