### PR TITLE
[Hotfix][tools] Include Helm chart in change-version script

### DIFF
--- a/site/amoro-site/content/community/release-guide.md
+++ b/site/amoro-site/content/community/release-guide.md
@@ -266,6 +266,9 @@ fi
 
 # change version in all pom files
 find .. -name 'pom.xml' -type f -exec perl -pi -e 's#<version>'"$OLD"'</version>#<version>'"$NEW"'</version>#' {} \;
+
+# change application version in the Helm chart
+perl -pi -e 's#^appVersion: "'"$OLD"'"$#appVersion: "'"$NEW"'"#' ../charts/amoro/Chart.yaml
 ```
 
 Then run the scripts and commit the change:

--- a/tools/change-version.sh
+++ b/tools/change-version.sh
@@ -29,3 +29,6 @@ fi
 
 # change version in all pom files
 find .. -name 'pom.xml' -type f -exec perl -pi -e 's#<version>'"$OLD"'</version>#<version>'"$NEW"'</version>#' {} \;
+
+# change application version in the Helm chart
+perl -pi -e 's#^appVersion: "'"$OLD"'"$#appVersion: "'"$NEW"'"#' ../charts/amoro/Chart.yaml


### PR DESCRIPTION
## Why are the changes needed?

The `tools/change-version.sh` script currently updates only Maven POM files. As a result, the Helm chart `appVersion` can remain stale after a project version change, requiring a follow-up hotfix to align the chart with the released application version.

The root cause is that the script searches only for `pom.xml` files and does not include the Helm chart as a project-version carrier.

## Brief change log

- Update the Helm chart `appVersion` together with Maven POM versions.
- Keep the release guide's embedded script example in sync with the implementation.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

  - `bash -n tools/change-version.sh`
  - Isolated fixture verification for POM and Helm chart version replacement, including idempotency
  - `./mvnw validate`
  - `helm lint charts/amoro`

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
