### PR TITLE
[AMORO-4308][lance] Remove redundant getTables call

### DIFF
--- a/amoro-format-lance/src/main/java/org/apache/amoro/formats/lance/LanceDirectoryV1Catalog.java
+++ b/amoro-format-lance/src/main/java/org/apache/amoro/formats/lance/LanceDirectoryV1Catalog.java
@@ -172,8 +172,6 @@ public class LanceDirectoryV1Catalog implements FormatCatalog {
     ListTablesResponse response = namespace.listTables(request);
     if (response == null) {
       return Collections.emptyList();
-    } else {
-      response.getTables();
     }
 
     return new ArrayList<>(response.getTables());


### PR DESCRIPTION
## Why are the changes needed?

`LanceDirectoryV1Catalog.listTables()` invokes `response.getTables()` in an `else` branch without using the returned value, then invokes it again when constructing the result. The first invocation has no effect and makes the control flow unnecessarily verbose.

Close #4308.

## Brief change log

- Remove the redundant `else` branch and unused `response.getTables()` invocation from `LanceDirectoryV1Catalog.listTables()`.
- Preserve the existing null-response handling and returned table list.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

  Not applicable because this is a behavior-preserving cleanup and the Lance module currently has no test sources.

- [ ] Add screenshots for manual tests if appropriate

  Not applicable.

- [x] Run test locally before making a pull request

  `./mvnw -pl amoro-format-lance -am test`

  Result: BUILD SUCCESS; Spotless and Checkstyle passed; 97 amoro-common tests passed; the Lance module compiled successfully.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable