### PR TITLE
[Docs] Fix the broken Star History chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=apache/amoro&type=Date)](https://star-history.com/#apache/amoro&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=apache/amoro&type=Date)](https://star-history.dera.page/#apache/amoro&Date)


### PR DESCRIPTION
The Star History chart in the README is currently broken and no longer renders correctly. This change points the chart to a working mirror so the project's star history is displayed again. This is a small documentation-only fix.