### PR TITLE
[AMORO-4318] Add mixed Flink 1.20 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Amoro support multiple processing engines for Mixed format as below:
 
 | Processing Engine | Version                | Batch Read  | Batch Write | Batch Overwrite | Streaming Read | Streaming Write | Create Table | Alter Table |
 |-------------------|------------------------|-------------|-------------|-----------------|----------------|-----------------|--------------|-------------|
-| Flink             | 1.18.x, 1.19.x          |  &#x2714;   |   &#x2714;   |       &#x2716;   |      &#x2714;   |       &#x2714;   |    &#x2714;   |   &#x2716;   |
+| Flink             | 1.18.x, 1.19.x, 1.20.x |  &#x2714;   |   &#x2714;   |       &#x2716;   |      &#x2714;   |       &#x2714;   |    &#x2714;   |   &#x2716;   |
 | Spark             | 3.3, 3.4, 3.5          |  &#x2714;   |   &#x2714;   |       &#x2714;   |      &#x2716;   |       &#x2716;   |    &#x2714;   |   &#x2714;   |
 | Hive              | 2.x, 3.x               |  &#x2714;  |   &#x2716;  |       &#x2714;  |      &#x2716;  |       &#x2716;  |    &#x2716;  |   &#x2714;  |
 | Trino             | 406                    |  &#x2714;  |   &#x2716;  |       &#x2714;  |      &#x2716;  |       &#x2716;  |    &#x2716;  |   &#x2714;  |

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <assertj.version>3.21.0</assertj.version>
-        <flink.version>1.19.1</flink.version>
+        <flink.version>1.20.3</flink.version>
     </properties>
 
     <dependencies>
@@ -63,7 +63,7 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-flink-1.19</artifactId>
+            <artifactId>iceberg-flink-1.20</artifactId>
             <version>${iceberg.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -84,7 +84,7 @@
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-flink-1.19</artifactId>
+            <artifactId>paimon-flink-1.20</artifactId>
             <version>${paimon.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -219,7 +219,7 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-flink-1.19</artifactId>
+            <artifactId>iceberg-flink-1.20</artifactId>
             <version>${iceberg.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/java/org/apache/amoro/flink/lookup/filter/TestRowDataPredicateBase.java
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/java/org/apache/amoro/flink/lookup/filter/TestRowDataPredicateBase.java
@@ -41,7 +41,6 @@ import org.junit.Before;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.TimeZone;
 
 public abstract class TestRowDataPredicateBase {
   public static StreamExecutionEnvironment env;
@@ -67,13 +66,13 @@ public abstract class TestRowDataPredicateBase {
     RowType sourceType = (RowType) schema.toSourceRowDataType().getLogicalType();
     ClassLoader classLoader = tEnv.getClass().getClassLoader();
     FlinkTypeFactory typeFactory = new FlinkTypeFactory(classLoader, FlinkTypeSystem.INSTANCE);
+    // The session time zone parameter was removed from the converter in Flink 1.20.
     RexNodeToExpressionConverter converter =
         new RexNodeToExpressionConverter(
             new RexBuilder(typeFactory),
             sourceType.getFieldNames().toArray(new String[0]),
             funCat,
-            catMan,
-            TimeZone.getTimeZone(tEnv.getConfig().getLocalTimeZone()));
+            catMan);
 
     RexNodeExpression rexExp =
         (RexNodeExpression) tbImpl.getParser().parseSqlExpression(sqlExp, sourceType, null);

--- a/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/java/org/apache/amoro/flink/util/MixedFormatMockEnvironment.java
+++ b/amoro-format-mixed/amoro-mixed-flink/amoro-mixed-flink-common/src/test/java/org/apache/amoro/flink/util/MixedFormatMockEnvironment.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriteRequestExecutorFactory;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
@@ -58,7 +59,9 @@ public class MixedFormatMockEnvironment extends MockEnvironment {
       ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory) {
     super(
         jobID,
+        "mock-job",
         jobVertexID,
+        JobType.STREAMING,
         taskName,
         inputSplitProvider,
         bufferSize,

--- a/amoro-format-mixed/amoro-mixed-flink/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/pom.xml
@@ -40,6 +40,8 @@
         <module>v1.18/amoro-mixed-flink-runtime-1.18</module>
         <module>v1.19/amoro-mixed-flink-1.19</module>
         <module>v1.19/amoro-mixed-flink-runtime-1.19</module>
+        <module>v1.20/amoro-mixed-flink-1.20</module>
+        <module>v1.20/amoro-mixed-flink-runtime-1.20</module>
     </modules>
 
     <properties>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.20/amoro-mixed-flink-1.20/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.20/amoro-mixed-flink-1.20/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.amoro</groupId>
+        <artifactId>amoro-mixed-flink</artifactId>
+        <version>0.9-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>amoro-format-mixed-flink-1.20</artifactId>
+
+    <packaging>jar</packaging>
+    <name>Amoro Project Mixed Format Flink 1.20</name>
+    <url>https://amoro.apache.org</url>
+
+    <properties>
+        <kafka.version>3.2.3</kafka.version>
+        <assertj.version>3.21.0</assertj.version>
+        <flink.version>1.20.3</flink.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.amoro</groupId>
+            <artifactId>amoro-mixed-flink-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-flink-1.20</artifactId>
+            <version>${iceberg.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>parquet-column</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>parquet-avro</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink-1.20</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-amoro</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.amoro:amoro-format-mixed-flink-common</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/amoro-format-mixed/amoro-mixed-flink/v1.20/amoro-mixed-flink-runtime-1.20/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-flink/v1.20/amoro-mixed-flink-runtime-1.20/pom.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.amoro</groupId>
+        <artifactId>amoro-mixed-flink</artifactId>
+        <version>0.9-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>amoro-format-mixed-flink-runtime-1.20</artifactId>
+    <name>Amoro Project Mixed Format Flink 1.20 Runtime</name>
+    <url>https://amoro.apache.org</url>
+
+    <properties>
+        <flink.version>1.20.3</flink.version>
+        <flink-kafka.version>3.4.0-1.20</flink-kafka.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.amoro</groupId>
+            <artifactId>amoro-format-mixed-flink-1.20</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-kafka</artifactId>
+            <version>${flink-kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.luben</groupId>
+                    <artifactId>zstd-jni</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.luben</groupId>
+                    <artifactId>zstd-jni</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-amoro</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.core:jackson-core</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.amoro:*</include>
+                                    <include>org.apache.iceberg:*</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
+                                    <include>org.apache.parquet:*</include>
+                                    <include>org.apache.commons:*</include>
+                                    <include>commons-lang:*</include>
+                                    <include>com.github.ben-manes.caffeine:*</include>
+                                    <include>org.apache.avro:*</include>
+                                    <include>org.apache.orc:*</include>
+                                    <include>io.airlift:*</include>
+                                    <include>commons-collections:*</include>
+                                    <include>cglib:*</include>
+                                    <include>com.google.guava:*</include>
+                                    <include>asm:*</include>
+                                    <include>org.apache.httpcomponents.client5:*</include>
+                                    <include>org.apache.httpcomponents.core5:*</include>
+                                    <include>org.apache.flink:flink-connector-kafka</include>
+                                    <include>org.apache.kafka:*</include>
+                                    <include>com.github.luben:*</include>
+                                    <include>com.github.luben:*</include>
+                                </includes>
+                            </artifactSet>
+
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.iceberg</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.iceberg</shadedPattern>
+                                    <excludes>
+                                        <exclude>org.apache.iceberg.mr.hive.*</exclude>
+                                    </excludes>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.parquet</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.parquet</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.commons</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.avro</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.avro</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.orc</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.orc</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.hc</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.hc</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.jute</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.jute</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.apache.kafka</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.kafka</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>shaded.parquet</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.shaded.parquet</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.com.fasterxml</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>com.github.benmanes.caffeine</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.com.github.benmanes.caffeine</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.threeten.extra</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.threeten.extra</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>net.sf.cglib</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.net.sf.cglib</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.com.google</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>org.objectweb.asm</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.objectweb.asm</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>com.facebook.fb303</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.com.facebook.fb303</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>io.airlift</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.io.airlift</shadedPattern>
+                                </relocation>
+
+                                <!-- flink-sql-connector-kafka  -->
+                                <relocation>
+                                    <pattern>org.apache.flink.connector.kafka</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.flink.connector.kafka</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.connectors.kafka</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.flink.streaming.connectors.kafka</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.util.serialization.JSONKeyValueDeserializationSchema</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.flink.streaming.util.serialization.JSONKeyValueDeserializationSchema</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.util.serialization.KeyedSerializationSchema</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.flink.streaming.util.serialization.KeyedSerializationSchema</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.util.serialization.TypeInformationKeyValueSerializationSchema</pattern>
+                                    <shadedPattern>org.apache.amoro.shade.org.apache.flink.streaming.util.serialization.TypeInformationKeyValueSerializationSchema</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -69,7 +69,7 @@ Amoro support multiple processing engines for Mixed format as below:
 
 | Processing Engine | Version                | Batch Read  | Batch Write | Batch Overwrite | Streaming Read | Streaming Write | Create Table | Alter Table |
 |-------------------|------------------------|-------------|-------------|-----------------|----------------|-----------------|--------------|-------------|
-| Flink             | 1.18.x, 1.19.x          |  &#x2714;   |   &#x2714;   |       &#x2716;   |      &#x2714;   |       &#x2714;   |    &#x2714;   |   &#x2716;   |
+| Flink             | 1.18.x, 1.19.x, 1.20.x |  &#x2714;   |   &#x2714;   |       &#x2716;   |      &#x2714;   |       &#x2714;   |    &#x2714;   |   &#x2716;   |
 | Spark             | 3.3, 3.4, 3.5          |  &#x2714;   |   &#x2714;   |       &#x2714;   |      &#x2716;   |       &#x2716;   |    &#x2714;   |   &#x2714;   |
 | Hive              | 2.x, 3.x               |  &#x2714;  |   &#x2716;  |       &#x2714;  |      &#x2716;  |       &#x2716;  |    &#x2716;  |   &#x2714;  |
 | Trino             | 406                    |  &#x2714;  |   &#x2716;  |       &#x2714;  |      &#x2716;  |       &#x2716;  |    &#x2716;  |   &#x2714;  |

--- a/docs/engines/flink/flink-get-started.md
+++ b/docs/engines/flink/flink-get-started.md
@@ -59,7 +59,7 @@ The Amoro project can be self-compiled to obtain the runtime jar.
 The Flink Runtime Jar is located in the `amoro-format-mixed/amoro-mixed-flink/v1.18/amoro-mixed-flink-runtime-1.18/target` directory.
 
 ## Environment preparation
-Download Flink and related dependencies, and download Flink 1.18/1.19 as needed. Taking Flink 1.18 as an example:
+Download Flink and related dependencies, and download Flink 1.18/1.19/1.20 as needed. Taking Flink 1.18 as an example:
 ```shell
 # Replace version value with the latest Amoro version if needed
 AMORO_VERSION=0.9.0-incubating

--- a/docs/engines/flink/using-logstore.md
+++ b/docs/engines/flink/using-logstore.md
@@ -44,6 +44,7 @@ Users can enable LogStore by configuring the following parameters when creating 
 |------------|----------|
 | Flink 1.18 | &#x2714; |
 | Flink 1.19 | &#x2714; |
+| Flink 1.20 | &#x2714; |
 
 Kafka as LogStore Version Description:
 
@@ -51,6 +52,7 @@ Kafka as LogStore Version Description:
 |---------------|  ----------------- |
 | 1.18.x        | 0.10.2.\*<br> 0.11.\*<br> 1.\*<br> 2.\*<br> 3.\*            |
 | 1.19.x        | 0.10.2.\*<br> 0.11.\*<br> 1.\*<br> 2.\*<br> 3.\*            |
+| 1.20.x        | 0.10.2.\*<br> 0.11.\*<br> 1.\*<br> 2.\*<br> 3.\*            |
 
 
 


### PR DESCRIPTION
## Why are the changes needed?

Close #4318.

Mixed-format Flink currently supports 1.18 and 1.19. Flink 1.20 is the last minor release of the 1.x line (LTS) and is maintained in Iceberg's multi-engine support matrix, so adding it keeps the three-version support matrix (1.18/1.19/1.20) aligned with Iceberg and reduces friction for future Iceberg upgrades.

## Brief change log

- Bump `amoro-mixed-flink-common` to Flink 1.20.3 with `iceberg-flink-1.20` and `paimon-flink-1.20` (same convention as #4141). Production code compiles unchanged; two test utilities are adapted to Flink 1.20 test API changes (`MockEnvironment` constructor, `RexNodeToExpressionConverter`).
- Add `v1.20/amoro-mixed-flink-1.20` and `v1.20/amoro-mixed-flink-runtime-1.20` mirroring the v1.19 modules. The runtime overrides `flink-kafka.version` to `3.4.0-1.20`, the latest connector release targeting Flink 1.20 — the parent default `3.2.0-1.18` has no Flink 1.20 variant (the v1.19 runtime similarly overrides it to `3.3.0-1.19`).
- Update `README.md` and docs for the supported version matrix.

## How was this patch tested?

- Full `amoro-mixed-flink-common` test suite (229 tests) passes compiled against Flink 1.20.3.
- The v1.20 shaded runtime jar builds and contains the relocated Kafka connector and Iceberg classes.
