### PR TITLE
[hotfix][Process] Preserve recovery failure context

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/process/ProcessService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/process/ProcessService.java
@@ -309,11 +309,21 @@ public class ProcessService extends PersistentBase {
    */
   private void markRecoverFailed(DefaultTableProcessStore store, Throwable cause) {
     try {
+      String failMessage =
+          String.format(
+              "Failed to recover process: %s (processId=%s, tableId=%s, action=%s, engine=%s, "
+                  + "externalIdentifier=%s)",
+              cause.getMessage(),
+              store.getProcessId(),
+              store.getTableId(),
+              store.getAction(),
+              store.getExecutionEngine(),
+              store.getExternalProcessIdentifier());
       store.tryTransitState(
           ProcessStatus.FAILED,
           ProcessEvent.COMPLETE_FAILED,
           store.getExternalProcessIdentifier(),
-          "Failed to recover process: " + cause.getMessage(),
+          failMessage,
           store.getProcessParameters(),
           store.getSummary());
     } catch (Throwable t) {


### PR DESCRIPTION
## Brief change log

Preserve the recovery context in the persisted failure message when a table process cannot be recovered, so operators can diagnose the failed restoration path.

## How was this patch tested?

- [x] Add a recovery-failure test that verifies the persisted context.
- [x] Add screenshots for manual tests if appropriate (not applicable: backend-only change).
- [x] Run `TestDefaultProcessService#testRecoverTableProcess` locally with JDK 11 before creating this pull request.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- not applicable