### PR TITLE
[hotfix][Optimizer] Cache group thread counts for quota sorting

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -40,6 +40,7 @@ import org.apache.amoro.server.table.blocker.TableBlocker;
 import org.apache.amoro.server.table.cleanup.TableRuntimeCleanupState;
 import org.apache.amoro.server.utils.IcebergTableUtil;
 import org.apache.amoro.server.utils.SnowflakeIdGenerator;
+import org.apache.amoro.shade.guava32.com.google.common.annotations.VisibleForTesting;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 import org.apache.amoro.table.BaseTable;
 import org.apache.amoro.table.ChangeTable;
@@ -55,13 +56,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 /** Default table runtime implementation. */
 public class DefaultTableRuntime extends AbstractTableRuntime {
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultTableRuntime.class);
+
+  @VisibleForTesting static final long THREAD_COUNT_CACHE_TTL_MS = 5_000L;
+
+  @VisibleForTesting
+  private static final ConcurrentHashMap<String, Integer> groupThreadCountCache =
+      new ConcurrentHashMap<>();
+
+  @VisibleForTesting private static final AtomicLong threadCountCacheTime = new AtomicLong(0);
 
   private static final StateKey<TableRuntimeOptimizingState> OPTIMIZING_STATE_KEY =
       StateKey.stateKey("optimizing_state")
@@ -455,7 +466,8 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
     return TableBlocker.conflict(operation, tableBlockers);
   }
 
-  private long getQuotaTime() {
+  @VisibleForTesting
+  long getQuotaTime() {
     long calculatingEndTime = System.currentTimeMillis();
     long calculatingStartTime = calculatingEndTime - AmoroServiceConstants.QUOTA_LOOK_BACK_TIME;
     taskQuotas.removeIf(task -> task.checkExpired(calculatingStartTime));
@@ -470,11 +482,21 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
   }
 
   private int getThreadCount() {
+    String groupName = getGroupName();
+    long now = System.currentTimeMillis();
+    long cachedAt = threadCountCacheTime.get();
+    if (now - cachedAt > THREAD_COUNT_CACHE_TTL_MS
+        && threadCountCacheTime.compareAndSet(cachedAt, now)) {
+      groupThreadCountCache.clear();
+    }
+    return groupThreadCountCache.computeIfAbsent(groupName, this::queryGroupThreadCount);
+  }
+
+  private int queryGroupThreadCount(String groupName) {
     List<OptimizerInstance> instances = getAs(OptimizerMapper.class, OptimizerMapper::selectAll);
     if (instances == null || instances.isEmpty()) {
       return 1;
     }
-    String groupName = getGroupName();
     return Math.max(
         instances.stream()
             .filter(instance -> Objects.equals(groupName, instance.getGroupName()))

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestDefaultTableRuntimeThreadCountCache.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestDefaultTableRuntimeThreadCountCache.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.table;
+
+import org.apache.amoro.api.OptimizerRegisterInfo;
+import org.apache.amoro.config.OptimizingConfig;
+import org.apache.amoro.server.AMSManagerTestBase;
+import org.apache.amoro.server.persistence.SqlSessionFactoryProvider;
+import org.apache.amoro.server.persistence.mapper.OptimizerMapper;
+import org.apache.amoro.server.resource.OptimizerInstance;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Maps;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TestDefaultTableRuntimeThreadCountCache extends AMSManagerTestBase {
+
+  private static final String GROUP = "thread-count-cache-test-group";
+
+  @BeforeEach
+  public void resetCache() throws Exception {
+    cacheMap().clear();
+    cacheTime().set(0);
+  }
+
+  @Test
+  public void threadCountIsCachedPerGroupUntilTtlExpiry() throws Exception {
+    insertOptimizer(GROUP, 7);
+    DefaultTableRuntime runtime = runtimeOf(GROUP);
+
+    // targetQuota = 1.0, quotaTime = LOOK_BACK_TIME => weight = 1 / threadCount
+    Assertions.assertEquals(1 / 7.0, runtime.calculateQuotaOccupy(), 1e-9);
+
+    // A new optimizer joins the group; within the TTL the cached count is still used.
+    insertOptimizer(GROUP, 3);
+    Assertions.assertEquals(1 / 7.0, runtime.calculateQuotaOccupy(), 1e-9);
+
+    // Simulate TTL expiry: the next read refreshes from the database (7 + 3 = 10).
+    cacheTime().set(System.currentTimeMillis() - 60_000);
+    Assertions.assertEquals(1 / 10.0, runtime.calculateQuotaOccupy(), 1e-9);
+    Assertions.assertEquals(1, cacheMap().size());
+  }
+
+  private DefaultTableRuntime runtimeOf(String group) {
+    DefaultTableRuntime runtime =
+        Mockito.mock(
+            DefaultTableRuntime.class,
+            Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    Mockito.doReturn(group).when(runtime).getGroupName();
+    OptimizingConfig config = new OptimizingConfig();
+    config.setEnabled(true);
+    config.setTargetQuota(1.0);
+    Mockito.doReturn(config).when(runtime).getOptimizingConfig();
+    Mockito.doReturn((long) org.apache.amoro.server.AmoroServiceConstants.QUOTA_LOOK_BACK_TIME)
+        .when(runtime)
+        .getQuotaTime();
+    return runtime;
+  }
+
+  private void insertOptimizer(String group, int threadCount) {
+    OptimizerRegisterInfo info = new OptimizerRegisterInfo();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("heartbeat", "100");
+    info.setProperties(properties);
+    info.setThreadCount(threadCount);
+    info.setMemoryMb(1024);
+    info.setGroupName(group);
+    info.setResourceId("cache-test-" + System.nanoTime());
+    info.setStartTime(System.currentTimeMillis());
+    OptimizerInstance instance = new OptimizerInstance(info, "local");
+    try (SqlSession session = SqlSessionFactoryProvider.getInstance().get().openSession(true)) {
+      session.getMapper(OptimizerMapper.class).insertOptimizer(instance);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ConcurrentHashMap<String, Integer> cacheMap() throws Exception {
+    Field field = DefaultTableRuntime.class.getDeclaredField("groupThreadCountCache");
+    field.setAccessible(true);
+    return (ConcurrentHashMap<String, Integer>) field.get(null);
+  }
+
+  private static AtomicLong cacheTime() throws Exception {
+    Field field = DefaultTableRuntime.class.getDeclaredField("threadCountCacheTime");
+    field.setAccessible(true);
+    return (AtomicLong) field.get(null);
+  }
+}


### PR DESCRIPTION
## Brief change log

Cache each optimizer group thread-count query for five seconds while calculating quota ordering. This avoids repeated external lookups without changing the refresh behavior after the cache interval.

## How was this patch tested?

- [x] Add test coverage for the thread-count cache and its refresh behavior.
- [x] Add screenshots for manual tests if appropriate (not applicable: backend-only change).
- [x] Run `TestDefaultTableRuntimeThreadCountCache` locally with JDK 11 before creating this pull request.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- not applicable