### PR TITLE
[hotfix][Optimizer] Remove zero-valued in-flight task counters

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -243,6 +243,9 @@ public class OptimizingQueue extends PersistentBase {
       process.close(false);
       clearProcess(process);
     }
+    // Drop the per-table in-flight counter: the table left this queue, and keeping the entry
+    // leaks one map slot per table that ever had a polled task.
+    optimizingTasksMap.remove(tableRuntime.getTableIdentifier());
     LOG.info(
         "Release queue {} with table {}",
         optimizerGroup.getName(),
@@ -511,6 +514,7 @@ public class OptimizingQueue extends PersistentBase {
 
   public void dispose() {
     this.metrics.unregister();
+    this.optimizingTasksMap.clear();
   }
 
   private TableOptimizingProcess findProcess(OptimizingTaskId taskId) {
@@ -697,13 +701,18 @@ public class OptimizingQueue extends PersistentBase {
     private void acceptResult(TaskRuntime<?> taskRuntime) {
       lock.lock();
       try {
-        optimizingTasksMap.computeIfPresent(
+        optimizingTasksMap.compute(
             tableRuntime.getTableIdentifier(),
             (k, v) -> {
+              if (v == null) {
+                return null;
+              }
               if (v.get() > 0) {
                 v.decrementAndGet();
               }
-              return v;
+              // Remove the entry at zero instead of leaving an empty counter behind:
+              // every table with a polled task would otherwise occupy a slot forever.
+              return v.get() > 0 ? v : null;
             });
         try {
           tableRuntime.addTaskQuota(taskRuntime.getCurrentQuota());

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
@@ -76,6 +76,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -954,6 +955,23 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     Assert.assertEquals(OptimizingStatus.IDLE, tableRuntime.getOptimizingStatus());
   }
 
+  @Test
+  public void testInFlightCounterEntryRemovedAfterTaskCompletes() throws Exception {
+    DefaultTableRuntime tableRuntime = initTableWithFiles();
+    OptimizingQueue queue = buildOptimizingGroupService(tableRuntime);
+    TaskRuntime<?> task = queue.pollTask(optimizerThread, MAX_POLLING_TIME);
+    Assert.assertNotNull(task);
+    Assert.assertEquals(1, readOptimizingTasksMapSize(queue));
+
+    queue.ackTask(task.getTaskId(), optimizerThread);
+    queue.completeTask(
+        optimizerThread,
+        buildOptimizingTaskResult(task.getTaskId(), optimizerThread.getThreadId()));
+
+    Assert.assertEquals(0, readOptimizingTasksMapSize(queue));
+    queue.dispose();
+  }
+
   protected DefaultTableRuntime initTableWithFiles() {
     MixedTable mixedTable =
         (MixedTable) tableService().loadTable(serverTableIdentifier()).originalTable();
@@ -1061,6 +1079,12 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     OptimizingTaskResult optimizingTaskResult = new OptimizingTaskResult(taskId, threadId);
     optimizingTaskResult.setTaskOutput(SerializationUtil.simpleSerialize(output));
     return optimizingTaskResult;
+  }
+
+  private int readOptimizingTasksMapSize(OptimizingQueue queue) throws Exception {
+    Field field = OptimizingQueue.class.getDeclaredField("optimizingTasksMap");
+    field.setAccessible(true);
+    return ((Map<?, ?>) field.get(queue)).size();
   }
 
   /**


### PR DESCRIPTION
## Brief change log

Remove the per-table in-flight task-counter entry when its count returns to zero, while preserving counters for active tasks. This prevents the counter map from retaining completed-table entries indefinitely.

## How was this patch tested?

- [x] Add queue test coverage that verifies counter removal after task completion.
- [x] Add screenshots for manual tests if appropriate (not applicable: backend-only change).
- [x] Run `TestOptimizingQueue#testInFlightCounterEntryRemovedAfterTaskCompletes` locally with JDK 11 before creating this pull request.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- not applicable