### PR TITLE
[hotfix][Process] Fail and untrack processes with a missing engine

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/process/ProcessService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/process/ProcessService.java
@@ -346,6 +346,25 @@ public class ProcessService extends PersistentBase {
           store.getExecutionEngine(),
           store.getAction(),
           process.getTableIdentifier());
+      // Leaving the PENDING process tracked blocks this action forever (hasAliveTableProcess
+      // gates every later tick, and a restart repeats the same failure). Mark it FAILED so the
+      // record is visible, then untrack so the table can be scheduled again.
+      try {
+        store.tryTransitState(
+            ProcessStatus.FAILED,
+            ProcessEvent.COMPLETE_FAILED,
+            store.getExternalProcessIdentifier(),
+            String.format(
+                "Execution engine not found: %s (action=%s)",
+                store.getExecutionEngine(), store.getAction()),
+            store.getProcessParameters(),
+            store.getSummary());
+      } catch (Throwable t) {
+        LOG.error(
+            "Failed to mark process {} as FAILED for missing engine", store.getProcessId(), t);
+      }
+      untrackTableProcessInstance(
+          process.getTableRuntime().getTableIdentifier(), store.getProcessId());
       return;
     }
 


### PR DESCRIPTION
## Brief change log

When the configured execution engine is absent, persist the process as failed and untrack it from the table runtime. This prevents a pending process from blocking later scheduling attempts indefinitely.

## How was this patch tested?

- [x] Validate the table-process execution path after the missing-engine handling change.
- [x] Add screenshots for manual tests if appropriate (not applicable: backend-only change).
- [x] Run `TestDefaultProcessService#testRunTableProcess` locally with JDK 11 before creating this pull request.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- not applicable