### PR TITLE
[hotfix][Optimizer] Recognize CLOSED optimizing processes

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/optimizing/OptimizingQueue.java
@@ -775,7 +775,10 @@ public class OptimizingQueue extends PersistentBase {
 
     @Override
     public boolean isClosed() {
-      return status == ProcessStatus.KILLED;
+      // close() sets CLOSED (KILLED is reserved for kill flows); checking only KILLED made
+      // this predicate permanently false, so the acceptResult guard against late results on a
+      // closed process could never fire.
+      return status == ProcessStatus.CLOSED || status == ProcessStatus.KILLED;
     }
 
     @Override

--- a/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/optimizing/TestOptimizingQueue.java
@@ -858,6 +858,8 @@ public class TestOptimizingQueue extends AMSTableTestBase {
     // Close process without success (simulates group change / forced termination)
     process.close(false);
 
+    Assert.assertTrue(process.isClosed());
+
     // lastOptimizedSnapshotId and lastOptimizedChangeSnapshotId should NOT be updated
     Assert.assertEquals(snapshotIdBeforePlanning, tableRuntime.getLastOptimizedSnapshotId());
     Assert.assertEquals(


### PR DESCRIPTION
## Brief change log

Make `OptimizingProcess.isClosed()` recognize the `CLOSED` status set by `close()`, in addition to `KILLED`. This restores the guard against accepting late results for a closed optimizing process.

## How was this patch tested?

- [x] Extend process-close queue coverage to assert the closed predicate.
- [x] Add screenshots for manual tests if appropriate (not applicable: backend-only change).
- [x] Run `TestOptimizingQueue#testProcessCloseKeepsLastOptimizedSnapshotId` locally with JDK 11 before creating this pull request.

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
- not applicable