### PR TITLE
[Hotfix][AMS] Stabilize optimizer scale-down floor test

### DIFF
--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestOptimizerScaleKeeper.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestOptimizerScaleKeeper.java
@@ -458,15 +458,25 @@ public class TestOptimizerScaleKeeper extends AMSTableTestBase {
             .anyMatch(r -> optimizer.getResourceId().equals(r.getResourceId())));
   }
 
-  /** The min-parallelism floor keeps the last instance no matter how long it idles. */
+  /**
+   * The min-parallelism floor keeps the last instance no matter how long it idles.
+   *
+   * <p>The floor is raised only once the instance is registered: a group created with its floor
+   * already unmet would have the live keeper satisfy it in the delay-0 round that its watch queues,
+   * and that second instance races the injected rounds below. The floor path is deliberately
+   * ungated, so unlike the demand path it cannot be held back by this group's slow cadence.
+   */
   @Test
   public void testScaleDownRespectsFloor() {
     resourceAvailable.set(true);
     scaleOutCallCount.set(0);
-    ResourceGroup group = buildSlowDraResourceGroup(TEST_GROUP_NAME + "-9", 1);
+    ResourceGroup group = buildSlowDraResourceGroup(TEST_GROUP_NAME + "-9", 0);
     optimizerManager().createResourceGroup(group);
     optimizingService().createResourceGroup(group);
     registerOptimizer(group.getName(), 1);
+    ResourceGroup withFloor = buildSlowDraResourceGroup(group.getName(), 1);
+    optimizerManager().updateResourceGroup(withFloor);
+    optimizingService().updateResourceGroup(withFloor);
 
     long t0 = System.currentTimeMillis();
     optimizingService().evaluateDynamicAllocation(group.getName(), t0);
@@ -476,6 +486,10 @@ public class TestOptimizerScaleKeeper extends AMSTableTestBase {
         1,
         optimizerManager().listOptimizers(group.getName()).size(),
         "the floor must keep the last instance");
+    Assertions.assertEquals(
+        0,
+        scaleOutCallCount.get(),
+        "a floor satisfied before it is raised leaves the live keeper nothing to scale out");
   }
 
   /** Removals proceed one instance per cooldown period, never in batches. */


### PR DESCRIPTION
## Why are the changes needed?

`TestOptimizerScaleKeeper.testScaleDownRespectsFloor` intermittently failed with `expected: <1> but was: <2>`.

The test created a DRA group with an unmet `min-parallelism` floor and then manually registered an optimizer. Group creation queues an immediate scale-keeper round, and floor recovery is intentionally not delayed by the configured scaling cadence. Depending on thread scheduling, the background keeper could register one optimizer before the test registered another.

This is a test setup race rather than a failure in the production scale-down logic.

## Brief change log

- Create the test DRA group with `min-parallelism=0`.
- Raise the floor to `1` after the test optimizer is registered.
- Assert that the live scale keeper does not trigger an unexpected scale-out during setup.

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

  - Reproduced the original failure deterministically: `expected: <1> but was: <2>`.
  - `TestOptimizerScaleKeeper`: 20 tests passed.
  - `testScaleDownRespectsFloor`: passed 10 consecutive runs.

- [ ] Add screenshots for manual tests if appropriate

  Not applicable because this is a test-only change.

- [x] Run test locally before making a pull request

  - `./mvnw -o -pl amoro-ams -DskipTests validate`
  - Spotless and Checkstyle passed.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable