### PR TITLE
[Hotfix] Change log4j impl dependency to `log4j-slf4j2-impl`

### DIFF
--- a/amoro-ams/pom.xml
+++ b/amoro-ams/pom.xml
@@ -267,8 +267,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
 
         <dependency>
@@ -540,6 +545,10 @@
                 <exclusion>
                     <groupId>org.apache.directory.jdbm</groupId>
                     <artifactId>apacheds-jdbm1</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/amoro-ams/pom.xml
+++ b/amoro-ams/pom.xml
@@ -109,6 +109,10 @@
                     <groupId>org.rocksdb</groupId>
                     <artifactId>rocksdbjni</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -148,6 +152,10 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/amoro-format-hudi/pom.xml
+++ b/amoro-format-hudi/pom.xml
@@ -52,6 +52,10 @@
                     <groupId>asm</groupId>
                     <artifactId>asm</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/amoro-mixed-spark-3-common/pom.xml
@@ -83,6 +83,10 @@
                     <groupId>org.apache.arrow</groupId>
                     <artifactId>arrow-vector</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -133,6 +137,14 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/pom.xml
@@ -89,6 +89,10 @@
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-mapreduce</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -125,6 +129,10 @@
                 <exclusion>
                     <groupId>org.apache.arrow</groupId>
                     <artifactId>arrow-vector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-3.3/pom.xml
@@ -391,6 +391,15 @@
             <classifier>core</classifier>
             <scope>test</scope>
         </dependency>
+
+        <!-- Spark 3.3's Logging trait directly references org.slf4j.impl.StaticLoggerBinder
+             (hard bytecode dependency, fixed in Spark 3.4+ via reflection). This SLF4J 1.x
+             binding is inert for SLF4J 2.x code paths but provides the class Spark needs. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.4/amoro-mixed-spark-3.4/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.4/amoro-mixed-spark-3.4/pom.xml
@@ -89,6 +89,10 @@
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-mapreduce</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -129,6 +133,10 @@
                 <exclusion>
                     <groupId>org.apache.arrow</groupId>
                     <artifactId>arrow-vector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-3.5/pom.xml
@@ -89,6 +89,10 @@
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-mapreduce</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -129,6 +133,10 @@
                 <exclusion>
                     <groupId>org.apache.arrow</groupId>
                     <artifactId>arrow-vector</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/amoro-format-mixed/amoro-mixed-trino/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-trino/pom.xml
@@ -81,6 +81,10 @@
                     <groupId>org.eclipse.jetty.orbit</groupId>
                     <artifactId>javax.servlet</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -98,6 +102,12 @@
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
             <version>${airlift.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/amoro-format-mixed/amoro-mixed-trino/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-trino/pom.xml
@@ -107,6 +107,10 @@
                     <groupId>*</groupId>
                     <artifactId>log4j-to-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/amoro-format-paimon/pom.xml
+++ b/amoro-format-paimon/pom.xml
@@ -46,6 +46,12 @@
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-bundle</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/amoro-format-paimon/pom.xml
+++ b/amoro-format-paimon/pom.xml
@@ -80,6 +80,10 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j2-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/amoro-optimizer/amoro-optimizer-spark/pom.xml
+++ b/amoro-optimizer/amoro-optimizer-spark/pom.xml
@@ -48,6 +48,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -96,6 +100,10 @@
                 <exclusion>
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-mapreduce</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/amoro-optimizer/amoro-optimizer-standalone/pom.xml
+++ b/amoro-optimizer/amoro-optimizer-standalone/pom.xml
@@ -49,7 +49,7 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/dev/deps/dependencies-hadoop-2-spark-3.3
+++ b/dev/deps/dependencies-hadoop-2-spark-3.3
@@ -292,7 +292,6 @@ listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-999
 log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
 log4j-api/2.20.0//log4j-api-2.20.0.jar
 log4j-core/2.20.0//log4j-core-2.20.0.jar
-log4j-slf4j-impl/2.17.2//log4j-slf4j-impl-2.17.2.jar
 log4j-slf4j2-impl/2.20.0//log4j-slf4j2-impl-2.20.0.jar
 lucene-core/8.11.2//lucene-core-8.11.2.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar

--- a/dev/deps/dependencies-hadoop-2-spark-3.3
+++ b/dev/deps/dependencies-hadoop-2-spark-3.3
@@ -292,7 +292,8 @@ listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-999
 log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
 log4j-api/2.20.0//log4j-api-2.20.0.jar
 log4j-core/2.20.0//log4j-core-2.20.0.jar
-log4j-slf4j-impl/2.20.0//log4j-slf4j-impl-2.20.0.jar
+log4j-slf4j-impl/2.17.2//log4j-slf4j-impl-2.17.2.jar
+log4j-slf4j2-impl/2.20.0//log4j-slf4j2-impl-2.20.0.jar
 lucene-core/8.11.2//lucene-core-8.11.2.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.19//metrics-core-4.2.19.jar

--- a/dev/deps/dependencies-hadoop-3-spark-3.5
+++ b/dev/deps/dependencies-hadoop-3-spark-3.5
@@ -264,7 +264,7 @@ listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-999
 log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
 log4j-api/2.20.0//log4j-api-2.20.0.jar
 log4j-core/2.20.0//log4j-core-2.20.0.jar
-log4j-slf4j-impl/2.20.0//log4j-slf4j-impl-2.20.0.jar
+log4j-slf4j2-impl/2.20.0//log4j-slf4j2-impl-2.20.0.jar
 lucene-core/8.11.2//lucene-core-8.11.2.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.19//metrics-core-4.2.19.jar

--- a/pom.xml
+++ b/pom.xml
@@ -660,6 +660,13 @@
                 <version>${log4j.version}</version>
             </dependency>
 
+            <!-- SLF4J 1.x binding, only needed by modules running Spark 3.3 (test scope) -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
@@ -1816,9 +1823,11 @@
                                     <excludes>
                                         <!-- Reverses log4j-slf4j2-impl, causing a logging loop -->
                                         <exclude>org.apache.logging.log4j:log4j-to-slf4j</exclude>
-                                        <!-- SLF4J 1.x bindings — must not coexist with log4j-slf4j2-impl -->
+                                        <!-- SLF4J 1.x bindings — must not coexist with log4j-slf4j2-impl.
+                                             Note: log4j-slf4j-impl is NOT banned because Spark 3.3's
+                                             Logging trait hard-references org.slf4j.impl.StaticLoggerBinder;
+                                             modules running Spark 3.3 may opt in with test scope. -->
                                         <exclude>org.slf4j:slf4j-log4j12</exclude>
-                                        <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
                                         <exclude>org.slf4j:slf4j-simple</exclude>
                                         <exclude>org.slf4j:slf4j-nop</exclude>
                                         <exclude>org.slf4j:slf4j-jdk14</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -656,7 +656,7 @@
 
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
 
@@ -1384,7 +1384,7 @@
         <!-- tests will have log4j as the default logging framework available -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1806,6 +1806,7 @@
                 <executions>
                     <execution>
                         <id>ban-conflicting-logging-dependencies</id>
+                        <phase>verify</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -679,29 +679,6 @@
                 <version>${log4j.version}</version>
             </dependency>
 
-            <!-- log4j-to-slf4j reverses log4j-slf4j2-impl, causing a logging loop -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>${log4j.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <!-- SLF4J 1.x bindings — must not coexist with log4j-slf4j2-impl -->
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${log4j.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
             <dependency>
                 <groupId>args4j</groupId>
                 <artifactId>args4j</artifactId>
@@ -1823,6 +1800,36 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ban-conflicting-logging-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- Reverses log4j-slf4j2-impl, causing a logging loop -->
+                                        <exclude>org.apache.logging.log4j:log4j-to-slf4j</exclude>
+                                        <!-- SLF4J 1.x bindings — must not coexist with log4j-slf4j2-impl -->
+                                        <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                        <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
+                                        <exclude>org.slf4j:slf4j-simple</exclude>
+                                        <exclude>org.slf4j:slf4j-nop</exclude>
+                                        <exclude>org.slf4j:slf4j-jdk14</exclude>
+                                    </excludes>
+                                    <message>These logging dependencies conflict with log4j-slf4j2-impl. Exclude them at the source.</message>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1806,10 +1806,10 @@
                 <executions>
                     <execution>
                         <id>ban-conflicting-logging-dependencies</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
+                        <phase>verify</phase>
                         <configuration>
                             <rules>
                                 <bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -679,6 +679,29 @@
                 <version>${log4j.version}</version>
             </dependency>
 
+            <!-- log4j-to-slf4j reverses log4j-slf4j2-impl, causing a logging loop -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- SLF4J 1.x bindings — must not coexist with log4j-slf4j2-impl -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
             <dependency>
                 <groupId>args4j</groupId>
                 <artifactId>args4j</artifactId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

PR #4046 upgraded `slf4j-api` from `1.7.x` to `2.0.17`, but did not update the Log4j2 binding accordingly. `log4j-slf4j-impl` uses the StaticLoggerBinder mechanism, which is only compatible with SLF4J 1.7.x. SLF4J 2.x uses ServiceLoader to discover providers, and since `log4j-slf4j-impl` does not register as a `SLF4JServiceProvider`, SLF4J falls back to a NOP (no-operation) logger.

This PR changes the impl to `log4j-slf4j2-impl` to match the new `slf4j-api`.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- As title

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
