### PR TITLE
[Hotfix] Remove slf4j classes from kyuubi-hive-jdbc-shaded

### DIFF
--- a/amoro-ams/pom.xml
+++ b/amoro-ams/pom.xml
@@ -608,6 +608,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Strip shaded SLF4J 1.x classes from kyuubi-hive-jdbc-shaded to prevent
+                 it from overriding slf4j-api 2.x at runtime (StaticLoggerBinder conflict). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven-antrun-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>strip-kyuubi-shaded-slf4j</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <zip destfile="${project.build.directory}/amoro-ams-dependency/lib/kyuubi-hive-jdbc-shaded-stripped.jar">
+                                    <zipfileset src="${project.build.directory}/amoro-ams-dependency/lib/kyuubi-hive-jdbc-shaded-${kyuubi-hive-jdbc-shaded.version}.jar">
+                                        <exclude name="org/slf4j/**"></exclude>
+                                    </zipfileset>
+                                </zip>
+                                <delete file="${project.build.directory}/amoro-ams-dependency/lib/kyuubi-hive-jdbc-shaded-${kyuubi-hive-jdbc-shaded.version}.jar"></delete>
+                                <move file="${project.build.directory}/amoro-ams-dependency/lib/kyuubi-hive-jdbc-shaded-stripped.jar" tofile="${project.build.directory}/amoro-ams-dependency/lib/kyuubi-hive-jdbc-shaded-${kyuubi-hive-jdbc-shaded.version}.jar"></move>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

`kyuubi-hive-jdbc-shaded` shade the slf4j 1.x classes which are conflicts with slf4j 2.x in ams.
This PR removed them from the jar to avoid conflicts.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- As title

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
