### PR TITLE
[AMORO-4343][ams] Fix runtime creation for unsupported table formats

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
@@ -854,6 +854,13 @@ public class DefaultTableService extends PersistentBase implements TableService 
     }
 
     Map<String, String> properties = table.properties();
+    if (!tableRuntimeFactory.accept(serverTableIdentifier, properties).isPresent()) {
+      LOG.debug(
+          "Skip creating table runtime for table {} because its format is not supported",
+          serverTableIdentifier);
+      return false;
+    }
+
     TableRuntimeMeta meta = new TableRuntimeMeta();
     meta.setTableId(serverTableIdentifier.getId());
     meta.setTableConfig(properties);

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestSyncUnsupportedTableFormat.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestSyncUnsupportedTableFormat.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.table;
+
+import org.apache.amoro.ServerTableIdentifier;
+import org.apache.amoro.formats.paimon.PaimonHadoopCatalogTestHelper;
+import org.apache.amoro.server.catalog.ExternalCatalog;
+import org.apache.amoro.server.catalog.TableCatalogTestBase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TestSyncUnsupportedTableFormat extends TableCatalogTestBase {
+
+  private static final String TEST_DATABASE = "test_database";
+  private static final String TEST_TABLE = "test_table";
+
+  public TestSyncUnsupportedTableFormat() {
+    super(PaimonHadoopCatalogTestHelper.defaultHelper());
+  }
+
+  @Before
+  public void createPaimonTable() throws Exception {
+    getAmoroCatalog().createDatabase(TEST_DATABASE);
+    getAmoroCatalogTestHelper().createTable(TEST_DATABASE, TEST_TABLE);
+  }
+
+  @Test
+  public void unsupportedTableFormatDoesNotCreateRuntimeDuringRepeatedSynchronization() {
+    ExternalCatalog externalCatalog =
+        (ExternalCatalog)
+            CATALOG_MANAGER.getServerCatalog(getAmoroCatalogTestHelper().catalogName());
+
+    tableService().exploreExternalCatalog(externalCatalog);
+    tableService().exploreExternalCatalog(externalCatalog);
+
+    List<ServerTableIdentifier> managedTables = tableManager().listManagedTables();
+    Assert.assertEquals(1, managedTables.size());
+    Assert.assertNull(tableManager().getTableRuntimeMata(managedTables.get(0)));
+  }
+}


### PR DESCRIPTION
## Why are the changes needed?

Close #4343.

External catalog synchronization invokes `triggerTableAdded` for every discovered table. When a table format has catalog support but no available `TableRuntimeCreator`, persisting `table_runtime` leaves a database-only runtime row. A later scan attempts to insert the same `table_id` again and logs a duplicate primary key error.

## Brief change log

- Check `TableRuntimeFactory` support before persisting table runtime metadata.
- Add a Paimon integration test that verifies metadata synchronization succeeds, no runtime is created, and repeated scans remain safe.

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible
- [ ] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

Commands:
- `./mvnw -q -pl amoro-ams -am -Pskip-dashboard-build -Dtest=TestSyncUnsupportedTableFormat -DfailIfNoTests=false test`
- `./mvnw -q -pl amoro-ams -am -Pskip-dashboard-build -Dtest=TestSyncTableOfExternalCatalog,TestSyncUnsupportedTableFormat -DfailIfNoTests=false test`
- `./mvnw -q -pl amoro-ams -am -Pskip-dashboard-build -DskipTests spotless:check`

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable