### PR TITLE
[AMORO-4345][Iceberg] Fix catalog table listing isolation

### DIFF
--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/mixed/MixedCatalog.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/mixed/MixedCatalog.java
@@ -25,6 +25,7 @@ import org.apache.amoro.TableFormat;
 import org.apache.amoro.mixed.MixedFormatCatalog;
 import org.apache.amoro.table.MixedTable;
 import org.apache.amoro.table.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 
 import java.util.List;
@@ -81,8 +82,8 @@ public class MixedCatalog implements FormatCatalog {
       return catalog.listTables(database).stream()
           .map(TableIdentifier::getTableName)
           .collect(Collectors.toList());
-    } catch (Exception e) {
-      throw new NoSuchDatabaseException("Database: " + database + " is not exists", e);
+    } catch (NoSuchNamespaceException e) {
+      throw new NoSuchDatabaseException(e, "Database: %s does not exist", database);
     }
   }
 

--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/mixed/BasicMixedIcebergCatalog.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/mixed/BasicMixedIcebergCatalog.java
@@ -48,6 +48,9 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -56,6 +59,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class BasicMixedIcebergCatalog implements MixedFormatCatalog {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BasicMixedIcebergCatalog.class);
 
   private org.apache.iceberg.catalog.Catalog icebergCatalog;
   private TableMetaStore tableMetaStore;
@@ -138,7 +143,16 @@ public class BasicMixedIcebergCatalog implements MixedFormatCatalog {
       if (visited.contains(identifier)) {
         continue;
       }
-      Table table = tableMetaStore.doAs(() -> icebergCatalog().loadTable(identifier));
+      Table table;
+      try {
+        table = tableMetaStore.doAs(() -> icebergCatalog().loadTable(identifier));
+      } catch (NoSuchTableException | NotFoundException e) {
+        LOG.warn(
+            "Skipping table {} during mixed-format discovery because it could not be loaded: {}",
+            identifier,
+            e.toString());
+        continue;
+      }
       if (tables.isBaseStore(table)) {
         mixedTables.add(TableIdentifier.of(name(), database, identifier.name()));
         visited.add(identifier);

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/formats/mixed/TestMixedCatalog.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/formats/mixed/TestMixedCatalog.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.formats.mixed;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.amoro.NoSuchDatabaseException;
+import org.apache.amoro.TableFormat;
+import org.apache.amoro.mixed.MixedFormatCatalog;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.junit.jupiter.api.Test;
+
+public class TestMixedCatalog {
+
+  @Test
+  public void testListTablesPreservesUnexpectedFailure() {
+    MixedFormatCatalog delegate = mock(MixedFormatCatalog.class);
+    IllegalStateException failure = new IllegalStateException("failed to read table metadata");
+    when(delegate.listTables("db")).thenThrow(failure);
+
+    MixedCatalog catalog = new MixedCatalog(delegate, TableFormat.MIXED_ICEBERG);
+
+    IllegalStateException actual =
+        assertThrows(IllegalStateException.class, () -> catalog.listTables("db"));
+    assertSame(failure, actual);
+  }
+
+  @Test
+  public void testListTablesConvertsMissingNamespace() {
+    MixedFormatCatalog delegate = mock(MixedFormatCatalog.class);
+    NoSuchNamespaceException failure = new NoSuchNamespaceException("missing namespace");
+    when(delegate.listTables("missing_db")).thenThrow(failure);
+
+    MixedCatalog catalog = new MixedCatalog(delegate, TableFormat.MIXED_ICEBERG);
+
+    NoSuchDatabaseException actual =
+        assertThrows(NoSuchDatabaseException.class, () -> catalog.listTables("missing_db"));
+    assertSame(failure, actual.getCause());
+  }
+}

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/mixed/TestBasicMixedIcebergCatalog.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/mixed/TestBasicMixedIcebergCatalog.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.mixed;
+
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.amoro.table.TableIdentifier;
+import org.apache.amoro.table.TableMetaStore;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestBasicMixedIcebergCatalog {
+
+  @Test
+  public void testListTablesSkipsTableWithMissingMetadata() {
+    assertListTablesSkipsUnavailableTable(new NotFoundException("metadata file does not exist"));
+  }
+
+  @Test
+  public void testListTablesSkipsTableRemovedAfterListing() {
+    assertListTablesSkipsUnavailableTable(new NoSuchTableException("table does not exist"));
+  }
+
+  private void assertListTablesSkipsUnavailableTable(RuntimeException loadFailure) {
+    Catalog icebergCatalog = mock(Catalog.class);
+    MixedTables mixedTables = mock(MixedTables.class);
+    Table healthyTable = mock(Table.class);
+    org.apache.iceberg.catalog.TableIdentifier brokenIdentifier =
+        org.apache.iceberg.catalog.TableIdentifier.of("db", "broken_table");
+    org.apache.iceberg.catalog.TableIdentifier healthyIdentifier =
+        org.apache.iceberg.catalog.TableIdentifier.of("db", "healthy_table");
+
+    when(icebergCatalog.listTables(Namespace.of("db")))
+        .thenReturn(Arrays.asList(brokenIdentifier, healthyIdentifier));
+    when(icebergCatalog.loadTable(brokenIdentifier)).thenThrow(loadFailure);
+    when(icebergCatalog.loadTable(healthyIdentifier)).thenReturn(healthyTable);
+    when(mixedTables.isBaseStore(healthyTable)).thenReturn(true);
+    when(healthyTable.schema()).thenReturn(new Schema());
+    when(healthyTable.properties()).thenReturn(Collections.emptyMap());
+
+    BasicMixedIcebergCatalog catalog = new TestCatalog(icebergCatalog, mixedTables);
+    Map<String, String> properties = new HashMap<>();
+    properties.put(ICEBERG_CATALOG_TYPE, "hadoop");
+    properties.put(CatalogProperties.CACHE_ENABLED, "false");
+    catalog.initialize("test_catalog", properties, TableMetaStore.EMPTY);
+
+    List<TableIdentifier> tables = catalog.listTables("db");
+
+    assertEquals(
+        Collections.singletonList(TableIdentifier.of("test_catalog", "db", "healthy_table")),
+        tables);
+    verify(icebergCatalog).loadTable(brokenIdentifier);
+    verify(icebergCatalog).loadTable(healthyIdentifier);
+  }
+
+  private static class TestCatalog extends BasicMixedIcebergCatalog {
+    private final Catalog icebergCatalog;
+    private final MixedTables mixedTables;
+
+    private TestCatalog(Catalog icebergCatalog, MixedTables mixedTables) {
+      this.icebergCatalog = icebergCatalog;
+      this.mixedTables = mixedTables;
+    }
+
+    @Override
+    protected Catalog buildIcebergCatalog(
+        String name, Map<String, String> properties, Configuration hadoopConf) {
+      return icebergCatalog;
+    }
+
+    @Override
+    protected MixedTables newMixedTables(
+        TableMetaStore metaStore, Map<String, String> catalogProperties, Catalog icebergCatalog) {
+      return mixedTables;
+    }
+  }
+}


### PR DESCRIPTION
## Why are the changes needed?

Close #4345.

When mixed-format discovery encounters an Iceberg table whose metadata file is missing, table loading aborts the entire namespace listing. The failure is then incorrectly reported as a missing database, which hides healthy tables and obscures the actual cause.

## Brief change log

- Skip tables that cannot be loaded because their metadata is missing or the table was concurrently removed, while recording a warning.
- Convert only `NoSuchNamespaceException` to `NoSuchDatabaseException` and preserve other failures.
- Add regression tests for missing metadata, concurrent table removal, missing namespaces, and unexpected failures.

## How was this patch tested?

- [x] Add test cases that check the changes thoroughly including negative and positive cases if possible
- [ ] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

```shell
./mvnw -q -pl amoro-format-iceberg -am test
./mvnw -q -pl amoro-format-iceberg -am validate
```

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
