### PR TITLE
[AMORO-1523][AMS] Auto-install discovered plugins when no plugin configs exist

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/manager/AbstractPluginManager.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/manager/AbstractPluginManager.java
@@ -85,6 +85,19 @@ public abstract class AbstractPluginManager<T extends ActivePlugin> implements P
     foundAvailablePlugins();
 
     List<PluginConfiguration> pluginConfigs = loadPluginConfigurations();
+    // If no plugin configs were loaded from file but plugins were found via ServiceLoader,
+    // create default configurations so they can be installed. This handles the case where
+    // AMS is started from an IDE without the full plugins directory structure.
+    if (pluginConfigs.isEmpty() && !foundedPlugins.isEmpty()) {
+      pluginConfigs =
+          foundedPlugins.keySet().stream()
+              .map(PluginConfiguration::emptyConfig)
+              .collect(Collectors.toList());
+      LOG.info(
+          "No {} plugin configurations found, auto-installing discovered plugins: {}",
+          pluginCategory(),
+          foundedPlugins.keySet());
+    }
     pluginConfigs.stream()
         .sorted(Comparator.comparing(PluginConfiguration::getPriority))
         .forEach(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #1523: When starting AMS in IntelliJ IDEA, the Local Optimizer cannot be started because the `execute-engines.yaml` plugin configuration file is missing from the default IDE setup.

### Root Cause

`AbstractPluginManager.initialize()` discovers plugins via ServiceLoader but then only installs those with matching YAML configurations. When started from an IDE without the `plugins/` config directory, no configurations are loaded, so discovered plugins like `LocalExecutionEngine` are never installed.

### Fix

When `loadPluginConfigurations()` returns an empty list but `foundAvailablePlugins()` has discovered plugins, auto-create default configurations for all discovered plugins. This ensures the Local Optimizer works out-of-the-box in IDE development environments.

## How was this patch tested?

- Verified the fix compiles
- The `emptyConfig()` method already exists in `PluginConfiguration` for this purpose