### PR TITLE
[AMORO-4348] Fix infinite retry loop for failed table processes

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/process/ProcessService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/process/ProcessService.java
@@ -280,7 +280,7 @@ public class ProcessService extends PersistentBase {
               tableRuntime,
               processMeta,
               scheduler.getAction(),
-              processMeta.getRetryNumber());
+              ActionCoordinatorScheduler.PROCESS_MAX_RETRY_NUMBER);
       try {
         TableProcess process = scheduler.recover(tableRuntime, store);
         trackTableProcess(tableRuntime.getTableIdentifier(), store, process);
@@ -367,17 +367,24 @@ public class ProcessService extends PersistentBase {
             scheduler =
                 findScheduler(store.getAction().getName(), process.getTableRuntime().getFormat());
           }
+          boolean retryScheduled = false;
           if (scheduler != null
               && store.getStatus() == ProcessStatus.FAILED
               && store.getRetryNumber() < ActionCoordinatorScheduler.PROCESS_MAX_RETRY_NUMBER
               && process.getTableRuntime() != null) {
-            store.tryTransitState(
-                ProcessStatus.PENDING,
-                ProcessEvent.RETRY_REQUESTED,
-                store.getExternalProcessIdentifier(),
-                "Regular Retry.",
-                process.getProcessParameters(),
-                process.getSummary());
+            // Only resubmit when the retry transition is accepted; resubmitting a process whose
+            // transition was rejected (e.g. already terminal) would loop forever without ever
+            // increasing the retry number.
+            retryScheduled =
+                store.tryTransitState(
+                    ProcessStatus.PENDING,
+                    ProcessEvent.RETRY_REQUESTED,
+                    store.getExternalProcessIdentifier(),
+                    "Regular Retry.",
+                    process.getProcessParameters(),
+                    process.getSummary());
+          }
+          if (retryScheduled) {
             executeOrTraceProcess(store, process);
           } else {
             if (store.getStatus() == ProcessStatus.FAILED && process.getTableRuntime() != null) {
@@ -503,7 +510,7 @@ public class ProcessService extends PersistentBase {
         process.getTableRuntime(),
         processMeta,
         process.getAction(),
-        processMeta.getRetryNumber());
+        ActionCoordinatorScheduler.PROCESS_MAX_RETRY_NUMBER);
   }
 
   /**

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultProcessService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultProcessService.java
@@ -30,6 +30,7 @@ import org.apache.amoro.process.TableProcess;
 import org.apache.amoro.process.TableProcessStore;
 import org.apache.amoro.server.persistence.PersistentBase;
 import org.apache.amoro.server.persistence.mapper.TableProcessMapper;
+import org.apache.amoro.server.process.ActionCoordinatorScheduler;
 import org.apache.amoro.server.process.MockActionCoordinator;
 import org.apache.amoro.server.process.MockExecuteEngine;
 import org.apache.amoro.server.process.ProcessService;
@@ -47,6 +48,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -389,6 +392,66 @@ public class TestDefaultProcessService extends AMSTableTestBase {
       dropTable();
     } catch (Throwable t) {
       throw new RuntimeException(t);
+    }
+  }
+
+  /**
+   * Verify that a process which keeps failing is retried a bounded number of times and then
+   * dropped, instead of being resubmitted in an infinite loop. The process store must be created
+   * with the retry limit rather than the current retry count, otherwise a FAILED process is treated
+   * as terminal immediately (retryNumber >= maxRetryTime), every RETRY_REQUESTED transition is
+   * rejected, retryNumber never increases and the process is resubmitted forever.
+   */
+  @Test(timeout = 60_000)
+  public void testFailedProcessRetryIsBounded() throws InterruptedException {
+    AlwaysFailingExecuteEngine failingEngine = new AlwaysFailingExecuteEngine();
+    processServiceService().unInstallAllExecuteEngines();
+    processServiceService().installExecuteEngine(failingEngine);
+    processServiceService().unInstallAllActionCoordinators();
+    processServiceService().installActionCoordinator(new MockActionCoordinator(failingEngine));
+    try {
+      createTable();
+
+      // Wait until the failing process has been submitted at least once.
+      awaitCondition(() -> failingEngine.getSubmitAttempts() >= 1, WAIT_TIMEOUT_MS, 100L);
+
+      // The process must exhaust its bounded retries and be untracked. With the infinite
+      // retry loop, the active process map never empties and this wait times out.
+      awaitCondition(
+          () -> processServiceService().getActiveTableProcess().isEmpty(), 15_000L, 100L);
+
+      Assert.assertEquals(
+          1 + ActionCoordinatorScheduler.PROCESS_MAX_RETRY_NUMBER,
+          failingEngine.getSubmitAttempts());
+
+      dropTable();
+    } catch (Throwable t) {
+      throw new RuntimeException(t);
+    }
+  }
+
+  /** Execute engine whose processes always fail immediately after submission. */
+  private static class AlwaysFailingExecuteEngine extends MockExecuteEngine {
+    private final AtomicInteger submitAttempts = new AtomicInteger();
+    private final Set<String> failedIdentifiers = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public String submitTableProcess(org.apache.amoro.process.TableProcess tableProcess) {
+      String identifier = "failing-" + submitAttempts.incrementAndGet();
+      failedIdentifiers.add(identifier);
+      return identifier;
+    }
+
+    @Override
+    public ProcessStatus getStatus(String processIdentifier) {
+      if (failedIdentifiers.contains(processIdentifier)) {
+        return ProcessStatus.FAILED;
+      }
+      return super.getStatus(processIdentifier);
+    }
+
+    private int getSubmitAttempts() {
+      return submitAttempts.get();
     }
   }
 

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultProcessService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestDefaultProcessService.java
@@ -48,8 +48,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -430,24 +428,14 @@ public class TestDefaultProcessService extends AMSTableTestBase {
     }
   }
 
-  /** Execute engine whose processes always fail immediately after submission. */
+  /** Execute engine whose submissions always fail. */
   private static class AlwaysFailingExecuteEngine extends MockExecuteEngine {
     private final AtomicInteger submitAttempts = new AtomicInteger();
-    private final Set<String> failedIdentifiers = ConcurrentHashMap.newKeySet();
 
     @Override
     public String submitTableProcess(org.apache.amoro.process.TableProcess tableProcess) {
-      String identifier = "failing-" + submitAttempts.incrementAndGet();
-      failedIdentifiers.add(identifier);
-      return identifier;
-    }
-
-    @Override
-    public ProcessStatus getStatus(String processIdentifier) {
-      if (failedIdentifiers.contains(processIdentifier)) {
-        return ProcessStatus.FAILED;
-      }
-      return super.getStatus(processIdentifier);
+      submitAttempts.incrementAndGet();
+      throw new IllegalStateException("Submission failure");
     }
 
     private int getSubmitAttempts() {


### PR DESCRIPTION
## Why are the changes needed?

Fix #4348.

Since #4116, `ProcessService` constructs `DefaultTableProcessStore` passing the *current* retry count into the constructor's `maxRetryTime` parameter. A new process therefore gets `maxRetryTime = 0` and becomes terminal on its first failure, every subsequent transition is rejected, and `retryNumber` never increases — while the retry branch in `executeOrTraceProcess` keeps evaluating `retryNumber < PROCESS_MAX_RETRY_NUMBER` as true and resubmits the process forever, with no backoff.

## Brief change log

- Construct `DefaultTableProcessStore` with `PROCESS_MAX_RETRY_NUMBER` as `maxRetryTime`, in both the creation and the recovery path (restores the pre-#4116 semantics of #3924)
- Only resubmit a failed process when its `RETRY_REQUESTED` transition is actually accepted, so a rejected transition can never loop
- Add a regression test verifying a persistently failing process is retried exactly `PROCESS_MAX_RETRY_NUMBER` times and then dropped

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

`TestDefaultProcessService#testFailedProcessRetryIsBounded` reproduces the infinite loop before the fix (the process is never dropped and the wait times out) and passes after: the failing process is submitted `1 + PROCESS_MAX_RETRY_NUMBER` times in total and then untracked. Existing process service tests all pass.

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
