### PR TITLE
[Hotfix][AMS] Fix optimizer registration failure under database HA mode

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/utils/AmsUtil.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/utils/AmsUtil.java
@@ -124,7 +124,11 @@ public class AmsUtil {
   }
 
   public static String getAMSThriftAddress(Configurations conf, String serviceName) {
-    if (conf.getBoolean(AmoroManagementConf.HA_ENABLE)) {
+    boolean zkHaEnabled =
+        conf.getBoolean(AmoroManagementConf.HA_ENABLE)
+            && AmoroManagementConf.HA_TYPE_ZK.equalsIgnoreCase(
+                conf.getString(AmoroManagementConf.HA_TYPE));
+    if (zkHaEnabled) {
       return String.format(
           ZOOKEEPER_ADDRESS_FORMAT,
           conf.getString(AmoroManagementConf.HA_ZOOKEEPER_ADDRESS),

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/utils/TestAmsUtil.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/utils/TestAmsUtil.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.dashboard.utils;
+
+import org.apache.amoro.Constants;
+import org.apache.amoro.config.Configurations;
+import org.apache.amoro.server.AmoroManagementConf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestAmsUtil {
+
+  @Test
+  public void testGetAMSThriftAddressWithoutHa() {
+    Configurations conf = new Configurations();
+    conf.setBoolean(AmoroManagementConf.HA_ENABLE, false);
+    conf.setString(AmoroManagementConf.SERVER_EXPOSE_HOST, "127.0.0.1");
+    conf.set(AmoroManagementConf.TABLE_SERVICE_THRIFT_BIND_PORT, 1260);
+    conf.set(AmoroManagementConf.OPTIMIZING_SERVICE_THRIFT_BIND_PORT, 1261);
+
+    Assertions.assertEquals(
+        "thrift://127.0.0.1:1260",
+        AmsUtil.getAMSThriftAddress(conf, Constants.THRIFT_TABLE_SERVICE_NAME));
+    Assertions.assertEquals(
+        "thrift://127.0.0.1:1261",
+        AmsUtil.getAMSThriftAddress(conf, Constants.THRIFT_OPTIMIZING_SERVICE_NAME));
+  }
+
+  @Test
+  public void testGetAMSThriftAddressWithZkHa() {
+    Configurations conf = new Configurations();
+    conf.setBoolean(AmoroManagementConf.HA_ENABLE, true);
+    conf.setString(AmoroManagementConf.HA_TYPE, AmoroManagementConf.HA_TYPE_ZK);
+    conf.setString(AmoroManagementConf.HA_ZOOKEEPER_ADDRESS, "127.0.0.1:2181");
+    conf.setString(AmoroManagementConf.HA_CLUSTER_NAME, "test-cluster");
+
+    Assertions.assertEquals(
+        "zookeeper://127.0.0.1:2181/test-cluster",
+        AmsUtil.getAMSThriftAddress(conf, Constants.THRIFT_TABLE_SERVICE_NAME));
+  }
+
+  @Test
+  public void testGetAMSThriftAddressWithDatabaseHa() {
+    // HA enabled but backed by database: the thrift address must fall back to the direct
+    // host:port form instead of the ZooKeeper address.
+    Configurations conf = new Configurations();
+    conf.setBoolean(AmoroManagementConf.HA_ENABLE, true);
+    conf.setString(AmoroManagementConf.HA_TYPE, AmoroManagementConf.HA_TYPE_DATABASE);
+    conf.setString(AmoroManagementConf.SERVER_EXPOSE_HOST, "127.0.0.1");
+    conf.set(AmoroManagementConf.TABLE_SERVICE_THRIFT_BIND_PORT, 1260);
+    conf.set(AmoroManagementConf.OPTIMIZING_SERVICE_THRIFT_BIND_PORT, 1261);
+
+    Assertions.assertEquals(
+        "thrift://127.0.0.1:1260",
+        AmsUtil.getAMSThriftAddress(conf, Constants.THRIFT_TABLE_SERVICE_NAME));
+    Assertions.assertEquals(
+        "thrift://127.0.0.1:1261",
+        AmsUtil.getAMSThriftAddress(conf, Constants.THRIFT_OPTIMIZING_SERVICE_NAME));
+  }
+}


### PR DESCRIPTION
## Why are the changes needed?
  When HA is enabled with ha.type=database, AmsUtil.getAMSThriftAddress still takes the ZooKeeper branch because it only checks ha.enabled. This makes it build a zookeeper://... address from ha.zookeeper-address, which is not configured in database-HA deployments. The bad URI is injected into the optimizer as ams.optimizer.uri, so the optimizer cannot reach AMS and fails to register.                                     
                                                                                                                                                                                                                    
  The fix narrows the ZooKeeper branch to ha.enabled && ha.type == zk. For database HA (and non-HA), it now returns the direct thrift://<expose-host>:<port> address, which is the same host/port the AMS node registers under its lease, so the optimizer registers correctly.

## Brief change log
  - AmsUtil.getAMSThriftAddress: only return the ZooKeeper address when ha.enabled is true and ha.type is zk; otherwise fall back to the direct thrift host:port address. This fixes optimizer registration under database-based HA. 

## How was this patch tested?
 - [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible                                                                                                     
    - Added TestAmsUtil#getAMSThriftAddress covering: HA disabled, ZK-HA (returns zookeeper://...), and database-HA (falls back to thrift://...).                                                                   
 - [ ] Add screenshots for manual tests if appropriate                                                                                                                                                             
 - [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
