### PR TITLE
[AMORO-4354] Improve process identification in logs

### DIFF
--- a/amoro-common/src/main/java/org/apache/amoro/process/EngineType.java
+++ b/amoro-common/src/main/java/org/apache/amoro/process/EngineType.java
@@ -87,4 +87,9 @@ public final class EngineType {
   public int hashCode() {
     return Objects.hash(engineName);
   }
+
+  @Override
+  public String toString() {
+    return engineName;
+  }
 }

--- a/amoro-common/src/main/java/org/apache/amoro/process/TableProcess.java
+++ b/amoro-common/src/main/java/org/apache/amoro/process/TableProcess.java
@@ -20,6 +20,7 @@ package org.apache.amoro.process;
 
 import org.apache.amoro.ServerTableIdentifier;
 import org.apache.amoro.TableRuntime;
+import org.apache.amoro.shade.guava32.com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,5 +65,15 @@ public abstract class TableProcess implements AmoroProcess {
 
   public String getProcessStage() {
     return "default";
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("tableIdentifier", getTableIdentifier())
+        .add("action", getAction())
+        .add("processStage", getProcessStage())
+        .add("executionEngine", getExecutionEngine())
+        .toString();
   }
 }

--- a/amoro-common/src/test/java/org/apache/amoro/process/TestLocalExecutionEngine.java
+++ b/amoro-common/src/test/java/org/apache/amoro/process/TestLocalExecutionEngine.java
@@ -19,8 +19,11 @@
 package org.apache.amoro.process;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.apache.amoro.Action;
+import org.apache.amoro.ServerTableIdentifier;
+import org.apache.amoro.TableFormat;
 import org.apache.amoro.TableRuntime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -150,6 +153,27 @@ public class TestLocalExecutionEngine {
     Assertions.assertEquals(ProcessStatus.UNKNOWN, engine.getStatus(null));
     Assertions.assertEquals(ProcessStatus.UNKNOWN, engine.getStatus(""));
     Assertions.assertEquals(ProcessStatus.UNKNOWN, engine.getStatus("not-exist"));
+  }
+
+  @Test
+  public void testEngineTypeToString() {
+    Assertions.assertEquals("local", EngineType.of("local").toString());
+  }
+
+  @Test
+  public void testTableProcessToString() {
+    TableRuntime tableRuntime = mock(TableRuntime.class);
+    when(tableRuntime.getTableIdentifier())
+        .thenReturn(
+            ServerTableIdentifier.of(1L, "catalog", "database", "table", TableFormat.ICEBERG));
+
+    TableProcess process =
+        new LocalProcessTableProcess(tableRuntime, new LocalExecutionEngine(), "default", () -> {});
+
+    Assertions.assertEquals(
+        "LocalProcessTableProcess{tableIdentifier=catalog.database.table(tableId=1), "
+            + "action=TEST, processStage=default, executionEngine=local}",
+        process.toString());
   }
 
   private LocalExecutionEngine createEngineWithTtl(String ttl) {


### PR DESCRIPTION
## Why are the changes needed?

Close #4354.

`EngineType` and `TableProcess` currently fall back to Java's default object representation, which makes process-related logs difficult to identify.

## Brief change log

- Return the engine name from `EngineType.toString()`.
- Describe a table process with its table, action, stage, and execution engine.
- Add focused tests for both representations.

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible
- [ ] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

Commands:

- `./mvnw test -pl amoro-common -Dtest=TestLocalExecutionEngine`
- `./mvnw validate`

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
