### PR TITLE
[ams] Fix optimizing status metrics never updated and reset on restart

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntime.java
@@ -99,6 +99,13 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
     super(store);
     this.optimizingMetrics =
         new TableOptimizingMetrics(store.getTableIdentifier(), store.getGroupName());
+    if (store instanceof DefaultTableRuntimeStore) {
+      DefaultTableRuntimeStore runtimeStore = (DefaultTableRuntimeStore) store;
+      OptimizingStatus initialStatus = OptimizingStatus.ofCode(runtimeStore.getStatusCode());
+      if (initialStatus != null) {
+        this.optimizingMetrics.statusChanged(initialStatus, runtimeStore.getStatusCodeUpdateTime());
+      }
+    }
     this.orphanFilesCleaningMetrics =
         new TableOrphanFilesCleaningMetrics(store.getTableIdentifier());
     this.tableSummaryMetrics = new TableSummaryMetrics(store.getTableIdentifier());
@@ -161,6 +168,26 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
 
   public OptimizingStatus getOptimizingStatus() {
     return OptimizingStatus.ofCode(getStatusCode());
+  }
+
+  /**
+   * Notifies the optimizing metrics after a status-code update has been committed to the store.
+   * Invoked from the store's status-change handler callback; no-op when the committed update didn't
+   * actually change the status.
+   *
+   * @param originalStatus the status before the committed update.
+   */
+  void onStatusPersisted(OptimizingStatus originalStatus) {
+    OptimizingStatus currentStatus = getOptimizingStatus();
+    if (currentStatus == null || currentStatus == originalStatus) {
+      return;
+    }
+    TableRuntimeStore store = store();
+    long updateTime =
+        store instanceof DefaultTableRuntimeStore
+            ? ((DefaultTableRuntimeStore) store).getStatusCodeUpdateTime()
+            : System.currentTimeMillis();
+    optimizingMetrics.statusChanged(currentStatus, updateTime);
   }
 
   public long getLastMajorOptimizingTime() {
@@ -319,17 +346,14 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
   }
 
   public void beginPlanning() {
-    OptimizingStatus originalStatus = getOptimizingStatus();
     store().begin().updateStatusCode(code -> OptimizingStatus.PLANNING.getCode()).commit();
   }
 
   public void planFailed() {
-    OptimizingStatus originalStatus = getOptimizingStatus();
     store().begin().updateStatusCode(code -> OptimizingStatus.PENDING.getCode()).commit();
   }
 
   public void beginProcess(OptimizingProcess optimizingProcess) {
-    OptimizingStatus originalStatus = getOptimizingStatus();
     this.optimizingProcess = optimizingProcess;
 
     store()
@@ -343,7 +367,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
   }
 
   public void completeProcess(boolean success) {
-    OptimizingStatus originalStatus = getOptimizingStatus();
     OptimizingType processType = optimizingProcess.getOptimizingType();
 
     store()
@@ -413,7 +436,6 @@ public class DefaultTableRuntime extends AbstractTableRuntime {
   }
 
   public void beginCommitting() {
-    OptimizingStatus originalStatus = getOptimizingStatus();
     store().begin().updateStatusCode(code -> OptimizingStatus.COMMITTING.getCode()).commit();
   }
 

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntimeStore.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableRuntimeStore.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
@@ -100,6 +101,11 @@ public class DefaultTableRuntimeStore extends PersistentBase implements TableRun
   @Override
   public int getStatusCode() {
     return this.meta.getStatusCode();
+  }
+
+  /** @return the persisted timestamp when the status code was last updated. */
+  public long getStatusCodeUpdateTime() {
+    return this.meta.getStatusCodeUpdateTime();
   }
 
   @Override
@@ -216,11 +222,16 @@ public class DefaultTableRuntimeStore extends PersistentBase implements TableRun
     public TableRuntimeOperation updateStatusCode(Function<Integer, Integer> updater) {
       operations.add(
           () -> {
-            Integer newStatusCode = updater.apply(oldMeta.getStatusCode());
+            Integer originalStatusCode = oldMeta.getStatusCode();
+            Integer newStatusCode = updater.apply(originalStatusCode);
+            if (Objects.equals(originalStatusCode, newStatusCode)) {
+              return;
+            }
             oldMeta.setStatusCode(newStatusCode);
+            OptimizingStatus originalStatus = OptimizingStatus.ofCode(originalStatusCode);
+            handlerCallback.add(
+                handler -> handler.handleTableChanged(tableRuntime, originalStatus));
           });
-      OptimizingStatus status = OptimizingStatus.ofCode(oldMeta.getStatusCode());
-      handlerCallback.add(handler -> handler.handleTableChanged(tableRuntime, status));
       metaOperation = true;
       return this;
     }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/table/DefaultTableService.java
@@ -192,6 +192,9 @@ public class DefaultTableService extends PersistentBase implements TableService 
 
   @Override
   public void handleTableChanged(TableRuntime tableRuntime, OptimizingStatus originalStatus) {
+    if (tableRuntime instanceof DefaultTableRuntime) {
+      ((DefaultTableRuntime) tableRuntime).onStatusPersisted(originalStatus);
+    }
     if (headHandler != null) {
       headHandler.fireStatusChanged(tableRuntime, originalStatus);
     }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/table/TestDefaultTableRuntimeHandler.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/table/TestDefaultTableRuntimeHandler.java
@@ -30,6 +30,11 @@ import org.apache.amoro.config.Configurations;
 import org.apache.amoro.config.TableConfiguration;
 import org.apache.amoro.hive.catalog.HiveCatalogTestHelper;
 import org.apache.amoro.hive.catalog.HiveTableTestHelper;
+import org.apache.amoro.metrics.Gauge;
+import org.apache.amoro.metrics.Metric;
+import org.apache.amoro.metrics.MetricDefine;
+import org.apache.amoro.metrics.MetricKey;
+import org.apache.amoro.metrics.MetricRegistry;
 import org.apache.amoro.server.manager.EventsManager;
 import org.apache.amoro.server.manager.MetricManager;
 import org.apache.amoro.server.optimizing.OptimizingStatus;
@@ -43,6 +48,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.List;
+import java.util.Map;
 
 @RunWith(Parameterized.class)
 public class TestDefaultTableRuntimeHandler extends AMSTableTestBase {
@@ -164,6 +170,85 @@ public class TestDefaultTableRuntimeHandler extends AMSTableTestBase {
     MetricManager.dispose();
     EventsManager.dispose();
     tableService = null;
+  }
+
+  @Test
+  public void testStatusChangeMetricsWiring() throws Exception {
+    tableService = new DefaultTableService(new Configurations(), CATALOG_MANAGER, runtimeFactory);
+    tableService.addHandlerChain(new TestHandler());
+    tableService.initialize();
+    if (!(catalogTestHelper().tableFormat().equals(TableFormat.MIXED_HIVE)
+        && TEST_HMS.getHiveClient().getDatabase(TableTestHelper.TEST_DB_NAME) != null)) {
+      createDatabase();
+    }
+    createTable();
+    ServerTableIdentifier tableId = tableManager().listManagedTables().get(0);
+    DefaultTableRuntime runtime = getDefaultTableRuntime(tableId.getId());
+
+    // a brand-new table reports idle in the status gauges
+    Assert.assertEquals(OptimizingStatus.IDLE, runtime.getOptimizingStatus());
+    Assert.assertEquals(1L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_IN_IDLE));
+    Assert.assertEquals(0L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_IN_PLANNING));
+
+    // IDLE -> PLANNING notifies the metrics via the status-change handler callback
+    runtime.beginPlanning();
+    Assert.assertEquals(OptimizingStatus.PLANNING, runtime.getOptimizingStatus());
+    Assert.assertEquals(1L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_IN_PLANNING));
+    Assert.assertEquals(0L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_IN_IDLE));
+    Thread.sleep(50);
+    Assert.assertTrue(
+        gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_PLANNING_DURATION) > 0);
+
+    // PLANNING -> PENDING resets the planning duration and moves the pending gauges
+    runtime.planFailed();
+    Assert.assertEquals(OptimizingStatus.PENDING, runtime.getOptimizingStatus());
+    Assert.assertEquals(1L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_IN_PENDING));
+    Assert.assertEquals(0L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_IN_PLANNING));
+    Assert.assertEquals(
+        0L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_PLANNING_DURATION));
+    Thread.sleep(50);
+    long pendingDurationBeforeRestart =
+        gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_PENDING_DURATION);
+    Assert.assertTrue(pendingDurationBeforeRestart > 0);
+
+    // A same-status write must not restart the persisted duration clock used after a restart.
+    DefaultTableRuntimeStore runtimeStore = (DefaultTableRuntimeStore) runtime.store();
+    long pendingStatusUpdateTime = runtimeStore.getStatusCodeUpdateTime();
+    runtime.store().begin().updateStatusCode(status -> status).commit();
+    Assert.assertEquals(pendingStatusUpdateTime, runtimeStore.getStatusCodeUpdateTime());
+
+    // metrics survive a restart: the restored runtime is seeded from the persisted status
+    tableService.dispose();
+    MetricManager.dispose();
+    EventsManager.dispose();
+    tableService = new DefaultTableService(new Configurations(), CATALOG_MANAGER, runtimeFactory);
+    tableService.addHandlerChain(new TestHandler());
+    tableService.initialize();
+    DefaultTableRuntime restoredRuntime = getDefaultTableRuntime(tableId.getId());
+    Assert.assertEquals(OptimizingStatus.PENDING, restoredRuntime.getOptimizingStatus());
+    Assert.assertEquals(1L, gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_IN_PENDING));
+    Assert.assertTrue(
+        gaugeValue(TableOptimizingMetrics.TABLE_OPTIMIZING_STATUS_PENDING_DURATION)
+            >= pendingDurationBeforeRestart);
+
+    dropTable();
+    dropDatabase();
+    tableService.dispose();
+    MetricManager.dispose();
+    EventsManager.dispose();
+    tableService = null;
+  }
+
+  private long gaugeValue(MetricDefine define) {
+    MetricRegistry registry = MetricManager.getInstance().getGlobalRegistry();
+    for (Map.Entry<MetricKey, Metric> entry : registry.getMetrics().entrySet()) {
+      MetricKey key = entry.getKey();
+      if (define.equals(key.getDefine())
+          && TableTestHelper.TEST_TABLE_NAME.equals(key.valueOfTag("table"))) {
+        return ((Gauge<? extends Number>) entry.getValue()).getValue().longValue();
+      }
+    }
+    throw new AssertionError("Gauge not registered for " + define.getName());
   }
 
   protected DefaultTableService tableService() {


### PR DESCRIPTION




<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

The table optimizing status metrics (table_optimizing_status_in_* and table_optimizing_status_*_duration_mills) have been broken since the TableRuntime storage refactor in AMORO-3747:

1. TableOptimizingMetrics#statusChanged is never invoked, so the status gauges stay at their initial values (idle) for the whole process lifetime and non-idle durations are always zero.
2. The runtime is not seeded with the persisted status code and update time when constructed, so durations restart from zero after an AMS restart.
3. Same-status status-code writes (e.g. setPendingInput on a non-idle table) refresh status_code_update_time, restarting the persisted duration clock used by the dashboard.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- seed TableOptimizingMetrics from the persisted status code and status_code_update_time when constructing DefaultTableRuntime
- notify the metrics from the status-change handler after the update is committed to the store
- skip status-code updates that don't change the value, so no-op writes no longer refresh status_code_update_time or fire redundant status-change notifications

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)
