### PR TITLE
[AMORO-4357][Docs] Document the table. prefix requirement for catalog-level table properties

### DIFF
--- a/docs/admin-guides/managing-catalogs.md
+++ b/docs/admin-guides/managing-catalogs.md
@@ -80,7 +80,7 @@ If you want to add the same table properties to all tables under a catalog, you 
 When configuring table-level properties on a catalog, you **must prefix the key with `table.`**. The prefix will be automatically stripped when the property is applied to tables. For example, to set the default `self-optimizing.group` for all tables under the catalog, you need to configure `table.self-optimizing.group` instead of `self-optimizing.group`. Properties without the `table.` prefix will not be recognized as table-level defaults and will be treated as catalog-level properties only.
 {{< /hint >}}
 
-The following table lists some examples:
+The following table lists some examples. For the full list of available table properties, see [Table configurations](../user-guides/configurations.md).
 
 | Catalog property key                        | Effective table property key              | Description                                              |
 |---------------------------------------------|-------------------------------------------|----------------------------------------------------------|

--- a/docs/admin-guides/managing-catalogs.md
+++ b/docs/admin-guides/managing-catalogs.md
@@ -76,6 +76,20 @@ Common properties include:
 ### Configure table properties
 If you want to add the same table properties to all tables under a catalog, you can add these table properties here on the catalog level. If you also configure this property on the table level, the property on the table will take effect.
 
+{{< hint info >}}
+When configuring table-level properties on a catalog, you **must prefix the key with `table.`**. The prefix will be automatically stripped when the property is applied to tables. For example, to set the default `self-optimizing.group` for all tables under the catalog, you need to configure `table.self-optimizing.group` instead of `self-optimizing.group`. Properties without the `table.` prefix will not be recognized as table-level defaults and will be treated as catalog-level properties only.
+{{< /hint >}}
+
+The following table lists some examples:
+
+| Catalog property key                        | Effective table property key              | Description                                              |
+|---------------------------------------------|-------------------------------------------|----------------------------------------------------------|
+| `table.self-optimizing.enabled`             | `self-optimizing.enabled`                 | Enable/disable self-optimizing for all tables            |
+| `table.self-optimizing.group`               | `self-optimizing.group`                   | Set the default optimizer group for all tables           |
+| `table.table-expire.enabled`                | `table-expire.enabled`                    | Enable/disable table expiration for all tables           |
+| `table.clean-orphan-file.enabled`           | `clean-orphan-file.enabled`               | Enable/disable orphan file cleaning for all tables       |
+| `table.log-store.enabled`                   | `log-store.enabled`                       | Enable/disable LogStore for all tables                   |
+
 ## REST Catalog
 When a user needs to create a Iceberg REST Catalog, they can choose **External Catalog Type**、**Custom Metastore Type**、**Iceberg Table Format**, configure properties include:
 **catalog-impl=org.apache.iceberg.rest.RESTCatalog**, **uri=$restCatalog_uri**.


### PR DESCRIPTION
## Why are the changes needed?

Close #4357.

When configuring table-level properties on a catalog, the property key must be
prefixed with `table.`. The prefix is automatically stripped when the property
is applied to tables. However, this requirement is not documented anywhere in
the user-facing documentation, which can easily lead to misconfiguration.

For example, to set the default optimizer group for all tables under a catalog,
users must configure `table.self-optimizing.group` instead of
`self-optimizing.group`. Properties without the `table.` prefix will not be
recognized as table-level defaults and will be silently ignored.

This behavior is defined in code:
- `CatalogMetaProperties.TABLE_PROPERTIES_PREFIX = "table."` (`CatalogMetaProperties.java:91`)
- `catalogUtil.mergeCatalogPropertiesToTable()` extracts only keys starting with
  `table.` and strips the prefix (`CatalogUtil.java:107-120`)

## Brief change log

- Added a hint and examples to the "Configure table properties" section in
  `docs/admin-guides/managing-catalogs.md`:
  - Added a `{{< hint info >}}` block clarifying that keys **must** be prefixed
    with `table.` and that the prefix is automatically stripped.
  - Added an example table mapping catalog property keys to their effective
    table property keys, including:
    - `table.self-optimizing.enabled` → `self-optimizing.enabled`
    - `table.self-optimizing.group` → `self-optimizing.group`
    - `table.table-expire.enabled` → `table-expire.enabled`
    - `table.clean-orphan-file.enabled` → `clean-orphan-file.enabled`
    - `table.log-store.enabled` → `log-store.enabled`
  - Linked to the [Table configurations](../configurations/) page for a complete
    list of available table properties.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
  - Rendered the doc page locally with Hugo to verify the hint block and table display correctly.

- [x] Run test locally before making a pull request
  - Only documentation files changed; no code or test impact.

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
