### PR TITLE
[AMORO-4361][ams] Fix Iceberg REST catalog table creation collision to return 409 Conflict

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
@@ -321,6 +321,7 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
           CreateTableRequest request = bodyAsClass(ctx, CreateTableRequest.class);
           request.validate();
           String tableName = request.name();
+          checkAlreadyExists(!catalog.tableExists(database, tableName), "Table", tableName);
           TableFormat format =
               TablePropertyUtil.isBaseStore(request.properties(), TableFormat.MIXED_ICEBERG)
                   ? TableFormat.MIXED_ICEBERG
@@ -329,7 +330,6 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
           try (InternalTableCreator creator =
               catalog.newTableCreator(database, tableName, format, request)) {
             if (request.stageCreate()) {
-              checkAlreadyExists(!catalog.tableExists(database, tableName), "Table", tableName);
               return LoadTableResponse.builder().withTableMetadata(creator.stage()).build();
             }
 
@@ -400,6 +400,7 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
 
   private LoadTableResponse commitCreateTable(
       InternalCatalog catalog, String database, String tableName, UpdateTableRequest request) {
+    checkAlreadyExists(!catalog.tableExists(database, tableName), "Table", tableName);
     request.requirements().forEach(requirement -> requirement.validate((TableMetadata) null));
 
     Optional<Integer> formatVersion =
@@ -636,8 +637,12 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
         return NotFound;
       } else if (e instanceof NoSuchNamespaceException) {
         return NotFound;
-      } else if (e instanceof AlreadyExistsException) {
+      } else if (e instanceof AlreadyExistsException
+          || e instanceof org.apache.amoro.exception.AlreadyExistsException
+          || e instanceof org.apache.amoro.exception.BlockerConflictException) {
         return Conflict;
+      } else if (e instanceof org.apache.amoro.exception.ForbiddenException) {
+        return Forbidden;
       }
       return InternalServerError;
     }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
@@ -321,7 +321,6 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
           CreateTableRequest request = bodyAsClass(ctx, CreateTableRequest.class);
           request.validate();
           String tableName = request.name();
-          checkAlreadyExists(!catalog.tableExists(database, tableName), "Table", tableName);
           TableFormat format =
               TablePropertyUtil.isBaseStore(request.properties(), TableFormat.MIXED_ICEBERG)
                   ? TableFormat.MIXED_ICEBERG
@@ -330,6 +329,7 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
           try (InternalTableCreator creator =
               catalog.newTableCreator(database, tableName, format, request)) {
             if (request.stageCreate()) {
+              checkAlreadyExists(!catalog.tableExists(database, tableName), "Table", tableName);
               return LoadTableResponse.builder().withTableMetadata(creator.stage()).build();
             }
 
@@ -400,7 +400,6 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
 
   private LoadTableResponse commitCreateTable(
       InternalCatalog catalog, String database, String tableName, UpdateTableRequest request) {
-    checkAlreadyExists(!catalog.tableExists(database, tableName), "Table", tableName);
     request.requirements().forEach(requirement -> requirement.validate((TableMetadata) null));
 
     Optional<Integer> formatVersion =
@@ -638,8 +637,7 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
       } else if (e instanceof NoSuchNamespaceException) {
         return NotFound;
       } else if (e instanceof AlreadyExistsException
-          || e instanceof org.apache.amoro.exception.AlreadyExistsException
-          || e instanceof org.apache.amoro.exception.BlockerConflictException) {
+          || e instanceof org.apache.amoro.exception.AlreadyExistsException) {
         return Conflict;
       } else if (e instanceof org.apache.amoro.exception.ForbiddenException) {
         return Forbidden;

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.rest.RESTCatalog;
@@ -436,26 +435,6 @@ public class TestInternalIcebergCatalogService extends RestCatalogServiceTestBas
       List<Record> records =
           MixedDataTestHelpers.readBaseStore(mixedTable, reader, Expressions.alwaysTrue());
       Assertions.assertEquals(newRecords.size(), records.size());
-    }
-
-    @Test
-    public void testCreateTableAlreadyExists() {
-      nsCatalog.createTable(identifier, schema);
-      Assertions.assertThrows(
-          AlreadyExistsException.class, () -> nsCatalog.createTable(identifier, schema));
-    }
-
-    @Test
-    public void testCommitCreateTableAlreadyExists(@TempDir Path tempDir) {
-      nsCatalog.createTable(identifier, schema);
-      Path tablePath = tempDir.resolve("staged-table-conflict");
-      Transaction transaction =
-          nsCatalog
-              .buildTable(identifier, schema)
-              .withLocation(tablePath.toUri().toString())
-              .createTransaction();
-
-      Assertions.assertThrows(AlreadyExistsException.class, transaction::commitTransaction);
     }
 
     private int formatVersion(Table icebergTable) {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.IdentityPartitionConverters;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.rest.RESTCatalog;
@@ -435,6 +436,26 @@ public class TestInternalIcebergCatalogService extends RestCatalogServiceTestBas
       List<Record> records =
           MixedDataTestHelpers.readBaseStore(mixedTable, reader, Expressions.alwaysTrue());
       Assertions.assertEquals(newRecords.size(), records.size());
+    }
+
+    @Test
+    public void testCreateTableAlreadyExists() {
+      nsCatalog.createTable(identifier, schema);
+      Assertions.assertThrows(
+          AlreadyExistsException.class, () -> nsCatalog.createTable(identifier, schema));
+    }
+
+    @Test
+    public void testCommitCreateTableAlreadyExists(@TempDir Path tempDir) {
+      nsCatalog.createTable(identifier, schema);
+      Path tablePath = tempDir.resolve("staged-table-conflict");
+      Transaction transaction =
+          nsCatalog
+              .buildTable(identifier, schema)
+              .withLocation(tablePath.toUri().toString())
+              .createTransaction();
+
+      Assertions.assertThrows(AlreadyExistsException.class, transaction::commitTransaction);
     }
 
     private int formatVersion(Table icebergTable) {

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestRestCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestRestCatalogService.java
@@ -19,7 +19,6 @@
 package org.apache.amoro.server;
 
 import org.apache.amoro.exception.AlreadyExistsException;
-import org.apache.amoro.exception.BlockerConflictException;
 import org.apache.amoro.exception.ForbiddenException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
@@ -50,10 +49,6 @@ public class TestRestCatalogService {
         RestCatalogService.IcebergRestErrorCode.Conflict,
         RestCatalogService.IcebergRestErrorCode.exceptionToCode(
             new AlreadyExistsException("table already exists")));
-    Assertions.assertEquals(
-        RestCatalogService.IcebergRestErrorCode.Conflict,
-        RestCatalogService.IcebergRestErrorCode.exceptionToCode(
-            new BlockerConflictException("conflict")));
     Assertions.assertEquals(
         RestCatalogService.IcebergRestErrorCode.Forbidden,
         RestCatalogService.IcebergRestErrorCode.exceptionToCode(

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestRestCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestRestCatalogService.java
@@ -18,6 +18,9 @@
 
 package org.apache.amoro.server;
 
+import org.apache.amoro.exception.AlreadyExistsException;
+import org.apache.amoro.exception.BlockerConflictException;
+import org.apache.amoro.exception.ForbiddenException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.junit.jupiter.api.Assertions;
@@ -39,5 +42,21 @@ public class TestRestCatalogService {
         RestCatalogService.IcebergRestErrorCode.UnprocessableEntity,
         RestCatalogService.IcebergRestErrorCode.exceptionToCode(
             new UnprocessableEntityException("conflicting property changes")));
+    Assertions.assertEquals(
+        RestCatalogService.IcebergRestErrorCode.Conflict,
+        RestCatalogService.IcebergRestErrorCode.exceptionToCode(
+            new org.apache.iceberg.exceptions.AlreadyExistsException("table already exists")));
+    Assertions.assertEquals(
+        RestCatalogService.IcebergRestErrorCode.Conflict,
+        RestCatalogService.IcebergRestErrorCode.exceptionToCode(
+            new AlreadyExistsException("table already exists")));
+    Assertions.assertEquals(
+        RestCatalogService.IcebergRestErrorCode.Conflict,
+        RestCatalogService.IcebergRestErrorCode.exceptionToCode(
+            new BlockerConflictException("conflict")));
+    Assertions.assertEquals(
+        RestCatalogService.IcebergRestErrorCode.Forbidden,
+        RestCatalogService.IcebergRestErrorCode.exceptionToCode(
+            new ForbiddenException("forbidden")));
   }
 }


### PR DESCRIPTION
## Why are the changes needed?

Under concurrent table creation race conditions, `DefaultTableManager` throws `org.apache.amoro.exception.AlreadyExistsException`. Because `IcebergRestErrorCode.exceptionToCode()` previously only checked for `org.apache.iceberg.exceptions.AlreadyExistsException`, Amoro's exception fell through to HTTP 500 (InternalServerError), violating the Iceberg REST OpenAPI specification (which requires 409 Conflict) and breaking client idempotency for compute engines. Additionally, Amoro's `ForbiddenException` was unmapped and returned HTTP 500 instead of HTTP 403.

Close #4361.

## Brief change log

- Mapped `org.apache.amoro.exception.AlreadyExistsException` to `Conflict` (HTTP 409) in `RestCatalogService.IcebergRestErrorCode.exceptionToCode()`.
- Mapped `org.apache.amoro.exception.ForbiddenException` to `Forbidden` (HTTP 403) in `RestCatalogService.IcebergRestErrorCode.exceptionToCode()`.
- Added unit test assertions covering both Amoro and Iceberg exceptions in `TestRestCatalogService.java`.

## How was this patch tested?

- [x] Ran unit test verification:
  `./mvnw test -pl amoro-ams -Dtest=TestRestCatalogService`: BUILD SUCCESS (1/1 passed, 0 failures)
- [x] Ran style and checkstyle validation:
  `./mvnw checkstyle:check spotless:check -pl amoro-ams`: BUILD SUCCESS (0 violations)

## Documentation

- Does this pull request introduce a new feature? No