### PR TITLE
[AMORO-4363][ams] Support HEAD route for namespaces in Iceberg REST catalog

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/RestCatalogService.java
@@ -136,6 +136,7 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
             get("/v1/catalogs/{catalog}/namespaces", this::listNamespaces);
             post("/v1/catalogs/{catalog}/namespaces", this::createNamespace);
             get("/v1/catalogs/{catalog}/namespaces/{namespace}", this::getNamespace);
+            head("/v1/catalogs/{catalog}/namespaces/{namespace}", this::namespaceExists);
             delete("/v1/catalogs/{catalog}/namespaces/{namespace}", this::dropNamespace);
             post(
                 "/v1/catalogs/{catalog}/namespaces/{namespace}/properties",
@@ -259,6 +260,11 @@ public class RestCatalogService extends PersistentBase implements RestExtension 
                 .withNamespace(Namespace.of(database))
                 .setProperties(catalog.getDatabaseProperties(database))
                 .build());
+  }
+
+  /** HEAD PREFIX/v1/catalogs/{catalog}/namespaces/{namespace} */
+  public void namespaceExists(Context ctx) {
+    handleNamespace(ctx, (catalog, database) -> null);
   }
 
   /** DELETE PREFIX/v1/catalogs/{catalog}/namespaces/{namespace} */

--- a/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/TestInternalIcebergCatalogService.java
@@ -66,6 +66,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -135,6 +136,56 @@ public class TestInternalIcebergCatalogService extends RestCatalogServiceTestBas
       Assertions.assertTrue(nsCatalog.loadNamespaceMetadata(ns).isEmpty());
       nsCatalog.dropNamespace(Namespace.of(database));
       Assertions.assertTrue(nsCatalog.listNamespaces().isEmpty());
+    }
+
+    @Test
+    public void testNamespaceExists() throws IOException, InterruptedException {
+      HttpClient client = HttpClient.newHttpClient();
+      String existsUrl =
+          ams.getHttpUrl()
+              + restCatalogUri
+              + "/v1/catalogs/"
+              + catalogName()
+              + "/namespaces/"
+              + database;
+      String notExistsUrl =
+          ams.getHttpUrl()
+              + restCatalogUri
+              + "/v1/catalogs/"
+              + catalogName()
+              + "/namespaces/non_existent_db";
+
+      // 1. Verify non-existent namespace returns 404
+      HttpRequest notFoundReq =
+          HttpRequest.newBuilder(URI.create(notExistsUrl))
+              .timeout(Duration.ofSeconds(5))
+              .method("HEAD", HttpRequest.BodyPublishers.noBody())
+              .build();
+      HttpResponse<Void> notFoundResp =
+          client.send(notFoundReq, HttpResponse.BodyHandlers.discarding());
+      Assertions.assertEquals(404, notFoundResp.statusCode());
+      // Note: Iceberg RESTSessionCatalog uses GET fallback unless Endpoint.V1_NAMESPACE_EXISTS is
+      // advertised in /v1/config
+      Assertions.assertFalse(nsCatalog.namespaceExists(Namespace.of("non_existent_db")));
+
+      // 2. Create namespace and verify HEAD returns 204 No Content
+      nsCatalog.createNamespace(ns);
+      HttpRequest existsReq =
+          HttpRequest.newBuilder(URI.create(existsUrl))
+              .timeout(Duration.ofSeconds(5))
+              .method("HEAD", HttpRequest.BodyPublishers.noBody())
+              .build();
+      HttpResponse<Void> existsResp =
+          client.send(existsReq, HttpResponse.BodyHandlers.discarding());
+      Assertions.assertEquals(204, existsResp.statusCode());
+      Assertions.assertTrue(nsCatalog.namespaceExists(ns));
+
+      // 3. Drop namespace and verify HEAD returns 404 again (full lifecycle verification)
+      nsCatalog.dropNamespace(ns);
+      HttpResponse<Void> postDropResp =
+          client.send(existsReq, HttpResponse.BodyHandlers.discarding());
+      Assertions.assertEquals(404, postDropResp.statusCode());
+      Assertions.assertFalse(nsCatalog.namespaceExists(ns));
     }
 
     @Test


### PR DESCRIPTION
## Why are the changes needed?

Close #4363.

In `RestCatalogService.java`, the `head(...)` route is registered for tables (`tableExists`), but was omitted for namespaces. Consequently, unrouted `HEAD` requests to `/v1/catalogs/{catalog}/namespaces/{namespace}` fell through to Jetty's static file handler, returning `HTTP 200 OK` (0 bytes).

Modern, spec-compliant Iceberg REST clients (such as Apache's official `github.com/apache/iceberg-go` client via `cat.CheckNamespaceExists`) strictly issue `HEAD /v1/{prefix}/namespaces/{namespace}` for namespace existence checks without fallback to `GET`. As a result, `iceberg-go` incorrectly reported that any non-existent database existed (`Exists: true`).

Per the Iceberg REST Catalog OpenAPI specification (`operationId: namespaceExists`):
- `HEAD /v1/{prefix}/namespaces/{namespace}` should return `204 No Content` if the namespace exists.
- It should return `404 Not Found` if the namespace does not exist.

## Brief change log

- **`RestCatalogService.java`**:
  - Registered `head("/v1/catalogs/{catalog}/namespaces/{namespace}", this::namespaceExists)` in `endpoints()`.
  - Added `namespaceExists` handler delegating to `handleNamespace(ctx, (catalog, database) -> null)`. When the namespace exists, `null` is translated by `handleCatalog` to `204 No Content`. When it does not exist, `NoSuchNamespaceException` is thrown and mapped to `404 Not Found`.
- **`TestInternalIcebergCatalogService.java`**:
  - Added `testNamespaceExists()` validating the full HTTP `HEAD` lifecycle: `404` (before creation) -> `204` (after creation) -> `404` (after drop).

## How was this patch tested?

- [x] Added unit test `TestInternalIcebergCatalogService.NamespaceTests#testNamespaceExists` covering negative, positive, and drop lifecycles.
- [x] Verified against live `iceberg-go` client (`github.com/apache/iceberg-go v0.6.0`) in Docker:
  - `CheckNamespaceExists('test_db')` -> `204 No Content` (`Exists: true`)
  - `CheckNamespaceExists('non_existent_db')` -> `404 Not Found` (`Exists: false`)
- [x] Executed `./mvnw spotless:check checkstyle:check -pl amoro-ams` (0 violations).

## Documentation

- Does this pull request introduce a new feature? no
