### PR TITLE
[Hotfix][Release] Update NOTICE copyright years for 2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Amoro (incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE-binary
+++ b/NOTICE-binary
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------------
 
 Apache Amoro (incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <maven.version>3.9.11</maven.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>2024-06-27T08:00:00Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2026-09-08T00:00:00Z</project.build.outputTimestamp>
         <root.dir>${project.basedir}</root.dir>
         <jacoco.flink.skip>false</jacoco.flink.skip>
 

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -4,4 +4,4 @@
 // ------------------------------------------------------------------
 
 Apache Amoro
-Copyright 2024 The Apache Software Foundation
+Copyright 2024-2026 The Apache Software Foundation


### PR DESCRIPTION
## Why are the changes needed?

The Apache Amoro NOTICE metadata is inconsistent with the project release history and the 2026 release cycle. The source and binary NOTICE files still use 2025, the binary NOTICE preamble uses 2024, and the Maven output timestamp causes generated JAR NOTICE files to retain the old year.

## Brief change log

- Update the Amoro copyright range in `NOTICE`, `NOTICE-binary`, and the binary NOTICE preamble to `2024-2026`.
- Update `project.build.outputTimestamp` to `2026-09-08T00:00:00Z` so Maven-generated NOTICE files use the same range.
- Keep all third-party copyright years unchanged.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

  Not applicable because this patch only updates release metadata.

- [ ] Add screenshots for manual tests if appropriate

  Not applicable because there is no UI change.

- [x] Run test locally before making a pull request

  - Built the `dist` dependency closure successfully with 20/20 Maven modules passing.
  - Verified `META-INF/NOTICE` in a regular JAR and a shaded JAR contains `Copyright 2024-2026 The Apache Software Foundation`.
  - Verified the release-layout binary tar contains exactly one top-level NOTICE with the same Amoro copyright range.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable