### PR TITLE
[Hotfix][Release] Exclude site from source package

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -64,7 +64,7 @@ cd ${CLONE_DIR}
 
 rsync -a \
   --exclude ".git" --exclude ".gitignore" \
-  --exclude ".github" --exclude "target" \
+  --exclude ".github" --exclude "/site/" --exclude "target" \
   --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" \
   --exclude "*/dependency-reduced-pom.xml" \
   . amoro-$RELEASE_VERSION


### PR DESCRIPTION
## Why are the changes needed?

The source release script clones the repository and copies the repository root into the source archive with `rsync`. Because the exclusion list does not contain the root `site/` directory, source release archives also contain the Hugo website projects, website assets, and three website-only symbolic links.

The website is deployed through its own workflow and is not required to build the Amoro software. Including it adds unrelated website content to the source distribution while duplicating documentation that is already retained under `docs/`.

## Brief change log

- Add a root-anchored `/site/` exclusion to `create_source_release.sh`.
- Keep the standalone `docs/` directory and all software source modules unchanged.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

  Not applicable because this is a one-line release packaging change.

- [ ] Add screenshots for manual tests if appropriate

  Not applicable because there is no UI change.

- [x] Run test locally before making a pull request

  - `bash -n tools/releasing/create_source_release.sh`
  - Reproduced the clean-clone, `rsync`, and tar packaging flow in a temporary directory.
  - Verified the archive has one top-level directory, zero `site/` entries, 76 retained `docs/` entries, and zero symbolic-link entries.
  - Ran `./mvnw validate -B -ntp` from the simulated source package; all 33 modules passed.
  - Ran `./mvnw apache-rat:check -DskipTests -B -ntp` from the simulated source package; all modules passed with zero unapproved files.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
