### PR TITLE
[AMORO-4368][Dashboard] Fix Tables menu navigation after viewing Hive tables

### DIFF
--- a/amoro-web/src/components/Sidebar.vue
+++ b/amoro-web/src/components/Sidebar.vue
@@ -143,38 +143,7 @@ export default defineComponent({
 
     const navClick = (item: MenuItem) => {
       if (item.key === 'tables') {
-        let catalog: string | undefined
-        let db: string | undefined
-        let tableName: string | undefined
-
-        try {
-          const stored = localStorage.getItem('easylake-menu-catalog-db-table')
-          if (stored) {
-            const parsed = JSON.parse(stored) as { catalog?: string; database?: string; tableName?: string }
-            catalog = parsed.catalog
-            db = parsed.database
-            tableName = parsed.tableName
-          }
-        }
-        catch (e) {
-          // ignore localStorage read/parse errors
-        }
-
-        if (catalog && db && tableName) {
-          router.replace({
-            path: '/tables',
-            query: {
-              catalog,
-              db,
-              table: tableName,
-            },
-          })
-        }
-        else {
-          router.replace({
-            path: '/tables',
-          })
-        }
+        router.replace({ path: '/tables', query: {} })
 
         nextTick(() => {
           setCurMenu()


### PR DESCRIPTION
## Why are the changes needed?

Clicking Tables after viewing a plain Hive table restores its cached identifier under `/tables`. This calls the generic details endpoint and reports that the table does not exist, although `/hive/details` loads it successfully.

Closes #4368.

## Brief change log

Make the Tables sidebar entry return to `/tables` without table query parameters. Selecting a table still opens the appropriate details page, and the table tree continues to restore its expanded nodes from session storage.

## How was this patch tested?

- Manually opened a Hive table, returned through Tables, and selected the table again. Its schema loaded successfully.
- Verified that the catalog and database nodes expand again after returning to the table browser.
- `pnpm exec eslint src/components/Sidebar.vue`
- `pnpm build`
- `git diff --check`

## Documentation

- Does this pull request introduce a new feature? No.
- Documentation: not applicable.