### PR TITLE
[Hotfix] Rmove NOTICE/LICENSE filter from shade filters

### DIFF
--- a/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-runtime-3.3/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.3/amoro-mixed-spark-runtime-3.3/pom.xml
@@ -129,9 +129,7 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                         <exclude>**/log4j.properties</exclude>
                                         <exclude>META-INF/DEPENDENCIES</exclude>
-                                        <exclude>META-INF/*LICENSE*</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/*NOTICE*</exclude>
                                         <exclude>META-INF/**/module-info.class</exclude>
                                         <exclude>LICENSE.txt</exclude>
                                         <exclude>NOTICE.txt</exclude>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.4/amoro-mixed-spark-runtime-3.4/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.4/amoro-mixed-spark-runtime-3.4/pom.xml
@@ -128,9 +128,7 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                         <exclude>**/log4j.properties</exclude>
                                         <exclude>META-INF/DEPENDENCIES</exclude>
-                                        <exclude>META-INF/*LICENSE*</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/*NOTICE*</exclude>
                                         <exclude>META-INF/**/module-info.class</exclude>
                                         <exclude>LICENSE.txt</exclude>
                                         <exclude>NOTICE.txt</exclude>

--- a/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-runtime-3.5/pom.xml
+++ b/amoro-format-mixed/amoro-mixed-spark/v3.5/amoro-mixed-spark-runtime-3.5/pom.xml
@@ -128,9 +128,7 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                         <exclude>**/log4j.properties</exclude>
                                         <exclude>META-INF/DEPENDENCIES</exclude>
-                                        <exclude>META-INF/*LICENSE*</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/*NOTICE*</exclude>
                                         <exclude>META-INF/**/module-info.class</exclude>
                                         <exclude>LICENSE.txt</exclude>
                                         <exclude>NOTICE.txt</exclude>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.apache.org/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/apache/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

When verifying the Amoro 0.9.0 release rc8, I found that we lost the `META-INF/NOTICE`, `META-INF/LICENSE` files in the mixed-format Spark runtime jars.

This PR tried to fix it by rmoving NOTICE/LICENCE filter from shade filters.


## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- As title

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
