### PR TITLE
[AMORO-4373] Fix concurrency race condition in RollingFileCleaner causing silent orphan file leaks

### DIFF
--- a/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/RollingFileCleaner.java
+++ b/amoro-format-iceberg/src/main/java/org/apache/amoro/formats/iceberg/utils/RollingFileCleaner.java
@@ -30,12 +30,14 @@ import java.net.URI;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /** Rolling file cleaner for Iceberg table maintenance operations. */
 public class RollingFileCleaner {
-  private final Set<String> collectedFiles = Sets.newConcurrentHashSet();
+  private final BlockingQueue<String> collectedFiles = new LinkedBlockingQueue<>();
   private final Set<String> excludeFiles;
   private final Set<String> parentDirectories = Sets.newConcurrentHashSet();
 
@@ -90,34 +92,36 @@ public class RollingFileCleaner {
     return excludeFiles.contains(parentPath);
   }
 
-  private void doCleanFiles() {
+  private synchronized void doCleanFiles() {
     if (collectedFiles.isEmpty()) {
       return;
     }
 
-    try {
-      if (fileIO.supportBulkOperations()) {
+    Set<String> toClean = Sets.newHashSet();
+    collectedFiles.drainTo(toClean);
+    if (toClean.isEmpty()) {
+      return;
+    }
+
+    if (fileIO.supportBulkOperations()) {
+      try {
+        fileIO.asBulkFileIO().deleteFiles(toClean);
+        cleanedFileCounter.addAndGet(toClean.size());
+      } catch (BulkDeletionFailureException e) {
+        LOG.warn("Failed to delete {} expired files in bulk", e.numberFailedObjects());
+      }
+    } else {
+      for (String filePath : toClean) {
         try {
-          fileIO.asBulkFileIO().deleteFiles(collectedFiles);
-          cleanedFileCounter.addAndGet(collectedFiles.size());
-        } catch (BulkDeletionFailureException e) {
-          LOG.warn("Failed to delete {} expired files in bulk", e.numberFailedObjects());
-        }
-      } else {
-        for (String filePath : collectedFiles) {
-          try {
-            fileIO.deleteFile(filePath);
-            cleanedFileCounter.incrementAndGet();
-          } catch (Exception e) {
-            LOG.warn("Failed to delete expired file: {}", filePath, e);
-          }
+          fileIO.deleteFile(filePath);
+          cleanedFileCounter.incrementAndGet();
+        } catch (Exception e) {
+          LOG.warn("Failed to delete expired file: {}", filePath, e);
         }
       }
-
-      LOG.debug("Cleaned expired a file group, total files: {}", collectedFiles.size());
-    } finally {
-      collectedFiles.clear();
     }
+
+    LOG.debug("Cleaned expired a file group, total files: {}", toClean.size());
   }
 
   private void doCleanParentDirectory() {
@@ -149,7 +153,7 @@ public class RollingFileCleaner {
     return cleanedFileCounter.get();
   }
 
-  public void clear() {
+  public synchronized void clear() {
     if (!collectedFiles.isEmpty()) {
       doCleanFiles();
     }

--- a/amoro-format-iceberg/src/test/java/org/apache/amoro/formats/iceberg/utils/TestRollingFileCleaner.java
+++ b/amoro-format-iceberg/src/test/java/org/apache/amoro/formats/iceberg/utils/TestRollingFileCleaner.java
@@ -20,14 +20,47 @@ package org.apache.amoro.formats.iceberg.utils;
 
 import org.apache.amoro.io.AuthenticatedFileIO;
 import org.apache.amoro.io.AuthenticatedFileIOAdapter;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Lists;
 import org.apache.amoro.shade.guava32.com.google.common.collect.Sets;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.SupportsBulkOperations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 public class TestRollingFileCleaner {
+
+  static class MockBulkFileIO extends InMemoryFileIO implements SupportsBulkOperations {
+    private final Set<String> physicallyDeletedFiles = Sets.newConcurrentHashSet();
+
+    @Override
+    public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
+      List<String> toDelete = Lists.newArrayList(pathsToDelete);
+      try {
+        // Simulate network latency during remote bulk deletion
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      for (String path : toDelete) {
+        physicallyDeletedFiles.add(path);
+        try {
+          deleteFile(path);
+        } catch (NotFoundException ignored) {
+          // S3 bulk delete ignores already deleted / non-existent keys
+        }
+      }
+    }
+  }
 
   @Test
   void testCleanFiles() {
@@ -48,5 +81,60 @@ public class TestRollingFileCleaner {
     Assertions.assertEquals(5000, fileCleaner.cleanedFileCount());
     fileCleaner.clear();
     Assertions.assertEquals(5050, fileCleaner.cleanedFileCount());
+  }
+
+  @Test
+  void testConcurrentCleanFiles() throws Exception {
+    MockBulkFileIO io = new MockBulkFileIO();
+    AuthenticatedFileIO fileIO = new AuthenticatedFileIOAdapter(io);
+    RollingFileCleaner fileCleaner = new RollingFileCleaner(fileIO, Sets.newHashSet());
+
+    int threadCount = 10;
+    int filesPerThread = 300;
+    int totalFiles = threadCount * filesPerThread;
+
+    Set<String> allFiles = Sets.newConcurrentHashSet();
+    for (int t = 0; t < threadCount; t++) {
+      for (int i = 0; i < filesPerThread; i++) {
+        String filePath =
+            "file://bucket/warehouse/date=2025-01-01/thread_" + t + "_file_" + i + ".txt";
+        io.addFile(filePath, ("content_" + t + "_" + i).getBytes());
+        allFiles.add(filePath);
+      }
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    List<Future<?>> futures = new ArrayList<>();
+    for (int t = 0; t < threadCount; t++) {
+      final int threadId = t;
+      futures.add(
+          executor.submit(
+              () -> {
+                for (int i = 0; i < filesPerThread; i++) {
+                  String filePath =
+                      "file://bucket/warehouse/date=2025-01-01/thread_"
+                          + threadId
+                          + "_file_"
+                          + i
+                          + ".txt";
+                  fileCleaner.addFile(filePath);
+                }
+              }));
+    }
+
+    for (Future<?> future : futures) {
+      future.get(30, TimeUnit.SECONDS);
+    }
+    executor.shutdown();
+
+    Assertions.assertEquals(totalFiles, fileCleaner.fileCount());
+
+    fileCleaner.clear();
+
+    Assertions.assertEquals(totalFiles, fileCleaner.cleanedFileCount());
+    Assertions.assertEquals(totalFiles, io.physicallyDeletedFiles.size());
+    for (String file : allFiles) {
+      Assertions.assertFalse(io.fileExists(file), "File was leaked: " + file);
+    }
   }
 }


### PR DESCRIPTION
## Why are the changes needed?

Close #4373.

In `IcebergTableMaintainer.expireSnapshots`, table snapshots are planned and expired concurrently using `IcebergThreadPools.getMaintenanceExecutor()`. In `RollingFileCleaner`, `doCleanFiles()` was unsynchronized and directly operated on `collectedFiles`. When worker threads concurrently called `addFile()` while remote bulk deletion was in flight, newly submitted files were added to `collectedFiles` and subsequently wiped by `finally { collectedFiles.clear(); }` before being deleted, causing silent orphan storage leaks.

## Brief change log

- In `RollingFileCleaner`, replace `collectedFiles` with `BlockingQueue<String>`.
- In `doCleanFiles()`, synchronize execution and atomically drain pending files into a local batch via `collectedFiles.drainTo(toClean)` before deletion.
- Synchronize `clear()`.
- Add `testConcurrentCleanFiles` in `TestRollingFileCleaner` to verify concurrent additions during bulk deletion.

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible
- [ ] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
